### PR TITLE
[BEAM-80] Change ReduceFnRunner to process elements before timers

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/GroupAlsoByWindowViaWindowSetDoFn.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/util/GroupAlsoByWindowViaWindowSetDoFn.java
@@ -80,10 +80,10 @@ public class GroupAlsoByWindowViaWindowSetDoFn<
             reduceFn,
             c.getPipelineOptions());
 
+    reduceFnRunner.processElements(element.elementsIterable());
     for (TimerData timer : element.timersIterable()) {
       reduceFnRunner.onTimer(timer);
     }
-    reduceFnRunner.processElements(element.elementsIterable());
     reduceFnRunner.persist();
   }
 


### PR DESCRIPTION
This change will allow ReduceFnRunner to add more elements to firing panes.
For example, when elements and its end of window timer come in the same bundle, ReduceFnRunner now can include these elements in the ON_TIME pane.