### PR TITLE
Update sdk pregenerated protos to 0.5.160304

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -455,7 +455,7 @@
     <dependency>
       <groupId>com.google.cloud.dataflow</groupId>
       <artifactId>google-cloud-dataflow-java-proto-library-all</artifactId>
-      <version>0.5.160222</version>
+      <version>0.5.160304</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Newest version only contains generated protobuf code for Beam