### PR TITLE
Filter Synthetic Methods in PipelineOptionsFactory

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/PipelineOptions.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/options/PipelineOptions.java
@@ -137,7 +137,8 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>{@link Default @Default} represents a set of annotations that can be used to annotate getter
  * properties on {@link PipelineOptions} with information representing the default value to be
- * returned if no value is specified.
+ * returned if no value is specified. Any default implementation (using the {@code default} keyword)
+ * is ignored.
  *
  * <p>{@link Hidden @Hidden} hides an option from being listed when {@code --help}
  * is invoked via {@link PipelineOptionsFactory#fromArgs(String[])}.

--- a/sdk/src/test/java8/com/google/cloud/dataflow/sdk/options/PipelineOptionsFactoryJava8Test.java
+++ b/sdk/src/test/java8/com/google/cloud/dataflow/sdk/options/PipelineOptionsFactoryJava8Test.java
@@ -32,7 +32,7 @@ import org.junit.runners.JUnit4;
 public class PipelineOptionsFactoryJava8Test {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  private static interface OptsWithDefault extends PipelineOptions {
+  private static interface OptionsWithDefaultMethod extends PipelineOptions {
     default Number getValue() {
       return 1024;
     }
@@ -42,32 +42,33 @@ public class PipelineOptionsFactoryJava8Test {
 
   @Test
   public void testDefaultMethodIgnoresDefaultImplementation() {
-    OptsWithDefault optsWithDefault = PipelineOptionsFactory.as(OptsWithDefault.class);
+    OptionsWithDefaultMethod optsWithDefault =
+        PipelineOptionsFactory.as(OptionsWithDefaultMethod.class);
     assertThat(optsWithDefault.getValue(), nullValue());
 
     optsWithDefault.setValue(12.25);
     assertThat(optsWithDefault.getValue(), equalTo(Double.valueOf(12.25)));
   }
 
-  private static interface ExtendedOptsWithDefault extends OptsWithDefault {}
+  private static interface ExtendedOptionsWithDefault extends OptionsWithDefaultMethod {}
 
   @Test
   public void testDefaultMethodInExtendedClassIgnoresDefaultImplementation() {
-    OptsWithDefault extendedOptsWithDefault =
-        PipelineOptionsFactory.as(ExtendedOptsWithDefault.class);
+    OptionsWithDefaultMethod extendedOptsWithDefault =
+        PipelineOptionsFactory.as(ExtendedOptionsWithDefault.class);
     assertThat(extendedOptsWithDefault.getValue(), nullValue());
 
     extendedOptsWithDefault.setValue(Double.NEGATIVE_INFINITY);
     assertThat(extendedOptsWithDefault.getValue(), equalTo(Double.NEGATIVE_INFINITY));
   }
 
-  private static interface Opts extends PipelineOptions {
+  private static interface Options extends PipelineOptions {
     Number getValue();
 
     void setValue(Number value);
   }
 
-  private static interface SubtypeReturingOpts extends Opts {
+  private static interface SubtypeReturingOptions extends Options {
     @Override
     Integer getValue();
     void setValue(Integer value);
@@ -78,12 +79,12 @@ public class PipelineOptionsFactoryJava8Test {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(
         "Method [getValue] has multiple definitions [public abstract java.lang.Integer "
-        + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$"
-        + "SubtypeReturingOpts.getValue(), public abstract java.lang.Number "
-        + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$Opts"
-        + ".getValue()] with different return types for ["
-        + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$"
-        + "SubtypeReturingOpts].");
-    PipelineOptionsFactory.as(SubtypeReturingOpts.class);
+            + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$"
+            + "SubtypeReturingOptions.getValue(), public abstract java.lang.Number "
+            + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$Options"
+            + ".getValue()] with different return types for ["
+            + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$"
+            + "SubtypeReturingOptions].");
+    PipelineOptionsFactory.as(SubtypeReturingOptions.class);
   }
 }

--- a/sdk/src/test/java8/com/google/cloud/dataflow/sdk/options/PipelineOptionsFactoryJava8Test.java
+++ b/sdk/src/test/java8/com/google/cloud/dataflow/sdk/options/PipelineOptionsFactoryJava8Test.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataflow.sdk.options;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Java 8 tests for {@link PipelineOptionsFactory}.
+ */
+@RunWith(JUnit4.class)
+public class PipelineOptionsFactoryJava8Test {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static interface OptsWithDefault extends PipelineOptions {
+    default Number getValue() {
+      return 1024;
+    }
+
+    void setValue(Number value);
+  }
+
+  @Test
+  public void testDefaultMethodIgnoresDefaultImplementation() {
+    OptsWithDefault optsWithDefault = PipelineOptionsFactory.as(OptsWithDefault.class);
+    assertThat(optsWithDefault.getValue(), nullValue());
+
+    optsWithDefault.setValue(12.25);
+    assertThat(optsWithDefault.getValue(), equalTo(Double.valueOf(12.25)));
+  }
+
+  private static interface ExtendedOptsWithDefault extends OptsWithDefault {}
+
+  @Test
+  public void testDefaultMethodInExtendedClassIgnoresDefaultImplementation() {
+    OptsWithDefault extendedOptsWithDefault =
+        PipelineOptionsFactory.as(ExtendedOptsWithDefault.class);
+    assertThat(extendedOptsWithDefault.getValue(), nullValue());
+
+    extendedOptsWithDefault.setValue(Double.NEGATIVE_INFINITY);
+    assertThat(extendedOptsWithDefault.getValue(), equalTo(Double.NEGATIVE_INFINITY));
+  }
+
+  private static interface Opts extends PipelineOptions {
+    Number getValue();
+
+    void setValue(Number value);
+  }
+
+  private static interface SubtypeReturingOpts extends Opts {
+    @Override
+    Integer getValue();
+    void setValue(Integer value);
+  }
+
+  @Test
+  public void testReturnTypeConflictThrows() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "Method [getValue] has multiple definitions [public abstract java.lang.Integer "
+        + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$"
+        + "SubtypeReturingOpts.getValue(), public abstract java.lang.Number "
+        + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$Opts"
+        + ".getValue()] with different return types for ["
+        + "com.google.cloud.dataflow.sdk.options.PipelineOptionsFactoryJava8Test$"
+        + "SubtypeReturingOpts].");
+    PipelineOptionsFactory.as(SubtypeReturingOpts.class);
+  }
+}


### PR DESCRIPTION
Fixes the testReturnTypeConflcitThrows when compiled with java 8, which inserts a bridge method which is reported as a a conflicting type (even though it is an effect of a conflicting type rather than a cause, and the user cannot change anything about it)