### PR TITLE
Fix versions and artifact names in runner poms

### DIFF
--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -24,7 +24,7 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>runners-parent</artifactId>
+    <artifactId>runners</artifactId>
     <version>1.6.0-SNAPSHOT</version>
   </parent>
 

--- a/runners/pom.xml
+++ b/runners/pom.xml
@@ -29,7 +29,7 @@
   </parent>
 
   <groupId>org.apache.beam</groupId>
-  <artifactId>runners-parent</artifactId>
+  <artifactId>runners</artifactId>
   <version>1.6.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>

--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -17,7 +17,7 @@ License.
     <parent>
         <groupId>org.apache.beam</groupId>
         <artifactId>runners</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spark-runner</artifactId>
@@ -41,7 +41,7 @@ License.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.7</java.version>
         <spark.version>1.5.2</spark.version>
-        <beam.version>1.5.0-SNAPSHOT</beam.version>
+        <beam.version>1.6.0-SNAPSHOT</beam.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
The name and version of the parent pom referenced by the Spark runner has diverged. I also just chose the simpler name.