### PR TITLE
[BEAM-22] Schedule roots less aggressively

### DIFF
--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InMemoryWatermarkManager.java
@@ -862,22 +862,6 @@ public class InMemoryWatermarkManager {
   }
 
   /**
-   * Returns true if, for any {@link TransformWatermarks} returned by
-   * {@link #getWatermarks(AppliedPTransform)}, the output watermark will be equal to
-   * {@link BoundedWindow#TIMESTAMP_MAX_VALUE}.
-   */
-  public boolean allWatermarksAtPositiveInfinity() {
-    for (Map.Entry<AppliedPTransform<?, ?, ?>, TransformWatermarks> watermarksEntry :
-        transformToWatermarks.entrySet()) {
-      Instant endOfTime = THE_END_OF_TIME.get();
-      if (watermarksEntry.getValue().getOutputWatermark().isBefore(endOfTime)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
    * A (key, Instant) pair that holds the watermark. Holds are per-key, but the watermark is global,
    * and as such the watermark manager must track holds and the release of holds on a per-key basis.
    *

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -356,6 +356,17 @@ class InProcessEvaluationContext {
     return watermarkManager.extractFiredTimers();
   }
 
+  /**
+   * Returns true if the step will not produce additional output.
+   *
+   * <p>If the provided transform produces only {@link IsBounded#BOUNDED}
+   * {@link PCollection PCollections}, returns true if the watermark is at
+   * {@link BoundedWindow#TIMESTAMP_MAX_VALUE positive infinity}.
+   *
+   * <p>If the provided transform produces any {@link IsBounded#UNBOUNDED}
+   * {@link PCollection PCollections}, returns the value of
+   * {@link InProcessPipelineOptions#isShutdownUnboundedProducersWithMaxWatermark()}.
+   */
   public boolean isDone(AppliedPTransform<?, ?, ?> transform) {
     boolean done = true;
     for (PValue output : transform.getOutput().expand()) {
@@ -375,6 +386,7 @@ class InProcessEvaluationContext {
     }
     return done;
   }
+
   /**
    * Returns true if all steps are done.
    */

--- a/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdk/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -401,7 +401,7 @@ class InProcessEvaluationContext {
 
   private boolean containsUnboundedPCollection() {
     for (AppliedPTransform<?, ?, ?> transform : stepNames.keySet()) {
-      for (PValue value : transform.getInput().expand()) {
+      for (PValue value : transform.getOutput().expand()) {
         if (value instanceof PCollection
             && ((PCollection<?>) value).isBounded().equals(IsBounded.UNBOUNDED)) {
           return true;


### PR DESCRIPTION
The excess scheduling of known-empty bundles can consume excessive
resources, especially with the default CachedThreadPool executor service.

Removes an unnecessary synchronized block (the map is already
thread-safe)