### PR TITLE
Replace unambiguous of `throw Throwables.propagate` with definition

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/options/PipelineOptionsFactory.java
@@ -602,7 +602,7 @@ public class PipelineOptionsFactory {
         COMBINED_CACHE.put(combinedPipelineOptionsInterfaces,
             new Registration<T>(allProxyClass, propertyDescriptors));
       } catch (IntrospectionException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 
@@ -617,7 +617,7 @@ public class PipelineOptionsFactory {
         INTERFACE_CACHE.put(iface,
             new Registration<T>(proxyClass, propertyDescriptors));
       } catch (IntrospectionException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
     @SuppressWarnings("unchecked")

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessCreate.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessCreate.java
@@ -29,7 +29,6 @@ import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.dataflow.sdk.values.PInput;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
@@ -75,7 +74,7 @@ class InProcessCreate<T> extends ForwardingPTransform<PInput, PCollection<T>> {
     try {
       source = new InMemorySource<>(original.getElements(), elementCoder);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     PCollection<T> result = input.getPipeline().apply(Read.from(source));
     result.setCoder(elementCoder);

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/util/MutationDetectors.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/util/MutationDetectors.java
@@ -18,7 +18,6 @@ package com.google.cloud.dataflow.sdk.util;
 
 import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.coders.CoderException;
-import com.google.common.base.Throwables;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -113,7 +112,7 @@ public class MutationDetectors {
       try {
         verifyUnmodifiedThrowingCheckedExceptions();
       } catch (CoderException exn) {
-        Throwables.propagate(exn);
+        throw new RuntimeException(exn);
       }
     }
 

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/testing/RestoreSystemProperties.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/testing/RestoreSystemProperties.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.dataflow.sdk.testing;
 
-import com.google.common.base.Throwables;
-
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
 
@@ -45,7 +43,7 @@ public class RestoreSystemProperties extends ExternalResource implements TestRul
       System.getProperties().clear();
       System.getProperties().load(bais);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/util/GcsUtilTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/util/GcsUtilTest.java
@@ -151,6 +151,7 @@ public class GcsUtilTest {
                   countDownLatches[currentLatch - 1].countDown();
                 }
               } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
               }
             }

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/util/GcsUtilTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/util/GcsUtilTest.java
@@ -52,7 +52,6 @@ import com.google.cloud.dataflow.sdk.testing.FastNanoClockAndSleeper;
 import com.google.cloud.dataflow.sdk.util.gcsfs.GcsPath;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 import org.junit.Rule;
@@ -141,20 +140,21 @@ public class GcsUtilTest {
     for (int i = 0; i < numThreads; i++) {
       final int currentLatch = i;
       countDownLatches[i] = new CountDownLatch(1);
-      executorService.execute(new Runnable() {
-        @Override
-        public void run() {
-          // Wait for latch N and then release latch N - 1
-          try {
-            countDownLatches[currentLatch].await();
-            if (currentLatch > 0) {
-              countDownLatches[currentLatch - 1].countDown();
+      executorService.execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              // Wait for latch N and then release latch N - 1
+              try {
+                countDownLatches[currentLatch].await();
+                if (currentLatch > 0) {
+                  countDownLatches[currentLatch - 1].countDown();
+                }
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
             }
-          } catch (InterruptedException e) {
-            throw Throwables.propagate(e);
-          }
-        }
-      });
+          });
     }
 
     // Release the last latch starting the chain reaction.


### PR DESCRIPTION
In the SDK the path taken by `Throwables.propagate` is always statically known, and the inlined logic is more explicit and readable:

 - If an exception e is already a checked exception, `Throwables.propagate(e)`
   is the same as `throw new RuntimeException(e)`.
 - If an exception e is already a `RuntimeException` or `Error`,
   `Throwables.propagate(e)` is the same as `throw e`.