### PR TITLE
[BEAM-22] Execute ModelEnforcements in TransformExecutor

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CompletionCallback.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/CompletionCallback.java
@@ -22,9 +22,10 @@ import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.C
  */
 interface CompletionCallback {
   /**
-   * Handle a successful result.
+   * Handle a successful result, returning the committed outputs of the result.
    */
-  void handleResult(CommittedBundle<?> inputBundle, InProcessTransformResult result);
+  Iterable<? extends CommittedBundle<?>> handleResult(
+      CommittedBundle<?> inputBundle, InProcessTransformResult result);
 
   /**
    * Handle a result that terminated abnormally due to the provided {@link Throwable}.

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/ExecutorServiceParallelExecutor.java
@@ -19,6 +19,7 @@ import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InMemoryWatermarkManager.FiredTimers;
 import com.google.cloud.dataflow.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
 import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
 import com.google.cloud.dataflow.sdk.util.KeyedWorkItem;
 import com.google.cloud.dataflow.sdk.util.KeyedWorkItems;
 import com.google.cloud.dataflow.sdk.util.TimeDomain;
@@ -60,6 +61,10 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
   private final Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers;
   private final Set<PValue> keyedPValues;
   private final TransformEvaluatorRegistry registry;
+  @SuppressWarnings("rawtypes")
+  private final Map<Class<? extends PTransform>, Collection<ModelEnforcementFactory>>
+      transformEnforcements;
+
   private final InProcessEvaluationContext evaluationContext;
 
   private final ConcurrentMap<StepAndKey, TransformExecutorService> currentEvaluations;
@@ -78,9 +83,11 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
       Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers,
       Set<PValue> keyedPValues,
       TransformEvaluatorRegistry registry,
+      @SuppressWarnings("rawtypes")
+      Map<Class<? extends PTransform>, Collection<ModelEnforcementFactory>> transformEnforcements,
       InProcessEvaluationContext context) {
     return new ExecutorServiceParallelExecutor(
-        executorService, valueToConsumers, keyedPValues, registry, context);
+        executorService, valueToConsumers, keyedPValues, registry, transformEnforcements, context);
   }
 
   private ExecutorServiceParallelExecutor(
@@ -88,11 +95,14 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
       Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers,
       Set<PValue> keyedPValues,
       TransformEvaluatorRegistry registry,
+      @SuppressWarnings("rawtypes")
+      Map<Class<? extends PTransform>, Collection<ModelEnforcementFactory>> transformEnforcements,
       InProcessEvaluationContext context) {
     this.executorService = executorService;
     this.valueToConsumers = valueToConsumers;
     this.keyedPValues = keyedPValues;
     this.registry = registry;
+    this.transformEnforcements = transformEnforcements;
     this.evaluationContext = context;
 
     currentEvaluations = new ConcurrentHashMap<>();
@@ -126,6 +136,7 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
       @Nullable final CommittedBundle<T> bundle,
       final CompletionCallback onComplete) {
     TransformExecutorService transformExecutor;
+
     if (bundle != null && isKeyed(bundle.getPCollection())) {
       final StepAndKey stepAndKey =
           StepAndKey.of(transform, bundle == null ? null : bundle.getKey());
@@ -133,9 +144,21 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
     } else {
       transformExecutor = parallelExecutorService;
     }
+
+    Collection<ModelEnforcementFactory> enforcements =
+        MoreObjects.firstNonNull(
+            transformEnforcements.get(transform.getTransform().getClass()),
+            Collections.<ModelEnforcementFactory>emptyList());
+
     TransformExecutor<T> callable =
         TransformExecutor.create(
-            registry, evaluationContext, bundle, transform, onComplete, transformExecutor);
+            registry,
+            enforcements,
+            evaluationContext,
+            bundle,
+            transform,
+            onComplete,
+            transformExecutor);
     transformExecutor.schedule(callable);
   }
 
@@ -176,12 +199,14 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
    */
   private class DefaultCompletionCallback implements CompletionCallback {
     @Override
-    public void handleResult(CommittedBundle<?> inputBundle, InProcessTransformResult result) {
+    public Iterable<? extends CommittedBundle<?>> handleResult(
+        CommittedBundle<?> inputBundle, InProcessTransformResult result) {
       Iterable<? extends CommittedBundle<?>> resultBundles =
           evaluationContext.handleResult(inputBundle, Collections.<TimerData>emptyList(), result);
       for (CommittedBundle<?> outputBundle : resultBundles) {
         allUpdates.offer(ExecutorUpdate.fromBundle(outputBundle));
       }
+      return resultBundles;
     }
 
     @Override
@@ -204,12 +229,14 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
     }
 
     @Override
-    public void handleResult(CommittedBundle<?> inputBundle, InProcessTransformResult result) {
+    public Iterable<? extends CommittedBundle<?>> handleResult(
+        CommittedBundle<?> inputBundle, InProcessTransformResult result) {
       Iterable<? extends CommittedBundle<?>> resultBundles =
           evaluationContext.handleResult(inputBundle, timers, result);
       for (CommittedBundle<?> outputBundle : resultBundles) {
         allUpdates.offer(ExecutorUpdate.fromBundle(outputBundle));
       }
+      return resultBundles;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -52,6 +52,7 @@ import com.google.common.collect.ImmutableSet;
 import org.joda.time.Instant;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -243,6 +244,7 @@ public class InProcessPipelineRunner
             consumerTrackingVisitor.getValueToConsumers(),
             keyedPValueVisitor.getKeyedPValues(),
             TransformEvaluatorRegistry.defaultRegistry(),
+            defaultModelEnforcements(options),
             context);
     executor.start(consumerTrackingVisitor.getRootTransforms());
 
@@ -260,6 +262,11 @@ public class InProcessPipelineRunner
       }
     }
     return result;
+  }
+
+  private Map<Class<? extends PTransform>, Collection<ModelEnforcementFactory>>
+      defaultModelEnforcements(InProcessPipelineOptions options) {
+    return Collections.emptyMap();
   }
 
   /**

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutor.java
@@ -20,6 +20,8 @@ import com.google.cloud.dataflow.sdk.transforms.AppliedPTransform;
 import com.google.cloud.dataflow.sdk.util.WindowedValue;
 import com.google.common.base.Throwables;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 
 import javax.annotation.Nullable;
@@ -35,6 +37,7 @@ import javax.annotation.Nullable;
 class TransformExecutor<T> implements Callable<InProcessTransformResult> {
   public static <T> TransformExecutor<T> create(
       TransformEvaluatorFactory factory,
+      Iterable<? extends ModelEnforcementFactory> modelEnforcements,
       InProcessEvaluationContext evaluationContext,
       CommittedBundle<T> inputBundle,
       AppliedPTransform<?, ?, ?> transform,
@@ -42,6 +45,7 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
       TransformExecutorService transformEvaluationState) {
     return new TransformExecutor<>(
         factory,
+        modelEnforcements,
         evaluationContext,
         inputBundle,
         transform,
@@ -50,6 +54,8 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
   }
 
   private final TransformEvaluatorFactory evaluatorFactory;
+  private final Iterable<? extends ModelEnforcementFactory> modelEnforcements;
+
   private final InProcessEvaluationContext evaluationContext;
 
   /** The transform that will be evaluated. */
@@ -64,12 +70,14 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
 
   private TransformExecutor(
       TransformEvaluatorFactory factory,
+      Iterable<? extends ModelEnforcementFactory> modelEnforcements,
       InProcessEvaluationContext evaluationContext,
       CommittedBundle<T> inputBundle,
       AppliedPTransform<?, ?, ?> transform,
       CompletionCallback completionCallback,
       TransformExecutorService transformEvaluationState) {
     this.evaluatorFactory = factory;
+    this.modelEnforcements = modelEnforcements;
     this.evaluationContext = evaluationContext;
 
     this.inputBundle = inputBundle;
@@ -84,15 +92,17 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
   public InProcessTransformResult call() {
     this.thread = Thread.currentThread();
     try {
+      Collection<ModelEnforcement<T>> enforcements = new ArrayList<>();
+      for (ModelEnforcementFactory enforcementFactory : modelEnforcements) {
+        ModelEnforcement<T> enforcement = enforcementFactory.forBundle(inputBundle, transform);
+        enforcements.add(enforcement);
+      }
       TransformEvaluator<T> evaluator =
           evaluatorFactory.forApplication(transform, inputBundle, evaluationContext);
-      if (inputBundle != null) {
-        for (WindowedValue<T> value : inputBundle.getElements()) {
-          evaluator.processElement(value);
-        }
-      }
-      InProcessTransformResult result = evaluator.finishBundle();
-      onComplete.handleResult(inputBundle, result);
+
+      processElements(evaluator, enforcements);
+
+      InProcessTransformResult result = finishBundle(evaluator, enforcements);
       return result;
     } catch (Throwable t) {
       onComplete.handleThrowable(inputBundle, t);
@@ -101,6 +111,46 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
       this.thread = null;
       transformEvaluationState.complete(this);
     }
+  }
+
+  /**
+   * Processes all the elements in the input bundle using the transform evaluator, applying any
+   * necessary {@link ModelEnforcement ModelEnforcements}.
+   */
+  private void processElements(
+      TransformEvaluator<T> evaluator, Collection<ModelEnforcement<T>> enforcements)
+      throws Exception {
+    if (inputBundle != null) {
+      for (WindowedValue<T> value : inputBundle.getElements()) {
+        for (ModelEnforcement<T> enforcement : enforcements) {
+          enforcement.beforeElement(value);
+        }
+
+        evaluator.processElement(value);
+
+        for (ModelEnforcement<T> enforcement : enforcements) {
+          enforcement.afterElement(value);
+        }
+      }
+    }
+  }
+
+  /**
+   * Finishes processing the input bundle and commit the result using the
+   * {@link CompletionCallback}, applying any {@link ModelEnforcement} if necessary.
+   *
+   * @return the {@link InProcessTransformResult} produced by
+   *         {@link TransformEvaluator#finishBundle()}
+   */
+  private InProcessTransformResult finishBundle(
+      TransformEvaluator<T> evaluator, Collection<ModelEnforcement<T>> enforcements)
+      throws Exception {
+    InProcessTransformResult result = evaluator.finishBundle();
+    Iterable<? extends CommittedBundle<?>> outputs = onComplete.handleResult(inputBundle, result);
+    for (ModelEnforcement<T> enforcement : enforcements) {
+      enforcement.afterFinish(inputBundle, result, outputs);
+    }
+    return result;
   }
 
   /**

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/runners/inprocess/TransformExecutorTest.java
@@ -343,12 +343,14 @@ public class TransformExecutorTest {
             transformEvaluationState);
 
     executor.call();
-    TestEnforcement<?> counter = enforcement.instance;
+    TestEnforcement<?> testEnforcement = enforcement.instance;
     assertThat(
-        counter.beforeElements, Matchers.<WindowedValue<?>>containsInAnyOrder(barElem, fooElem));
+        testEnforcement.beforeElements,
+        Matchers.<WindowedValue<?>>containsInAnyOrder(barElem, fooElem));
     assertThat(
-        counter.afterElements, Matchers.<WindowedValue<?>>containsInAnyOrder(barElem, fooElem));
-    assertThat(counter.finishedBundles, contains(result));
+        testEnforcement.afterElements,
+        Matchers.<WindowedValue<?>>containsInAnyOrder(barElem, fooElem));
+    assertThat(testEnforcement.finishedBundles, contains(result));
   }
 
   @Test
@@ -497,9 +499,9 @@ public class TransformExecutorTest {
     @Override
     public <T> TestEnforcement<T> forBundle(
         CommittedBundle<T> input, AppliedPTransform<?, ?, ?> consumer) {
-      TestEnforcement<T> newCounter = new TestEnforcement<>();
-      instance = newCounter;
-      return newCounter;
+      TestEnforcement<T> newEnforcement = new TestEnforcement<>();
+      instance = newEnforcement;
+      return newEnforcement;
     }
   }
 


### PR DESCRIPTION
This allows a configurable application of Model Enforcement based on the
class of transform being executed, both before and after an element is
processed and after the transform completes.