### PR TITLE
Add codecov integration to Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,6 @@ install:
 script:
   - travis_retry mvn -B $MAVEN_OVERRIDE install -U
   - travis_retry travis/test_wordcount.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This configures upload of our Jacoco coverage results to https://codecov.io. The coverage report from this branch is at https://codecov.io/github/kennknowles/incubator-beam?ref=codecov.

I chose codecov because it provides browser extensions to overlay the coverage information onto pull requests, where it can supplement our review process.

As with Travis-CI, this requires activation for any fork that it is going to run against. Any contributor can activate their own fork. Activating this or another code coverage tool for Apache's fork will require some trivial work from infra. It can also be used with Jenkins, if desired.

(To forestall any concerns about downloading and executing an arbitrary script: Travis-CI already does this in the form of running the script specified by pull requests, which are much more likely to be malicious or erroneous.)