### PR TITLE
[BEAM-171] Fix JAXBCoder in the nested context

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
@@ -85,13 +85,7 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
         }
       }
 
-      jaxbMarshaller.marshal(
-          value,
-          new FilterOutputStream(outStream) {
-            // JAXB closes the underlying stream so we must filter out those calls.
-            @Override
-            public void close() throws IOException {}
-          });
+      jaxbMarshaller.marshal(value, new CloseIgnoringOutputStream(outStream));
     } catch (JAXBException e) {
       throw new CoderException(e);
     }
@@ -132,6 +126,19 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
     @Override
     public void close() {
       // Do nothing. JAXB closes the underlying stream so we must filter out those calls.
+    }
+  }
+
+  private static class CloseIgnoringOutputStream extends FilterOutputStream {
+
+    protected CloseIgnoringOutputStream(OutputStream out) {
+      super(out);
+    }
+
+    @Override
+    public void close() throws IOException {
+      // JAXB closes the underlying stream so we must filter out those calls.
+      flush();
     }
   }
 

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
@@ -138,7 +138,6 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
     @Override
     public void close() throws IOException {
       // JAXB closes the underlying stream so we must filter out those calls.
-      flush();
     }
   }
 

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
@@ -103,19 +103,14 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
         jaxbUnmarshaller = jaxbContext.createUnmarshaller();
       }
 
-      if (context.isWholeStream) {
-        @SuppressWarnings("unchecked")
-        T obj = (T) jaxbUnmarshaller.unmarshal(new CloseIgnoringInputStream(inStream));
-        return obj;
-      } else {
+      InputStream stream = inStream;
+      if (!context.isWholeStream) {
         long limit = VarInt.decodeLong(inStream);
-        @SuppressWarnings("unchecked")
-        T obj =
-            (T)
-                jaxbUnmarshaller.unmarshal(
-                    new CloseIgnoringInputStream(ByteStreams.limit(inStream, limit)));
-        return obj;
+        stream = ByteStreams.limit(inStream, limit);
       }
+      @SuppressWarnings("unchecked")
+      T obj = (T) jaxbUnmarshaller.unmarshal(new CloseIgnoringInputStream(stream));
+      return obj;
     } catch (JAXBException e) {
       throw new CoderException(e);
     }

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
@@ -80,16 +80,18 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
           // value
           VarInt.encode(size, outStream);
         } catch (Exception e) {
-          throw new CoderException(e);
+          throw new CoderException(
+              "An Exception occured while trying to get the size of an encoded representation", e);
         }
       }
 
-      jaxbMarshaller.marshal(value, new FilterOutputStream(outStream) {
-        // JAXB closes the underyling stream so we must filter out those calls.
-        @Override
-        public void close() throws IOException {
-        }
-      });
+      jaxbMarshaller.marshal(
+          value,
+          new FilterOutputStream(outStream) {
+            // JAXB closes the underlying stream so we must filter out those calls.
+            @Override
+            public void close() throws IOException {}
+          });
     } catch (JAXBException e) {
       throw new CoderException(e);
     }
@@ -129,7 +131,7 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
 
     @Override
     public void close() {
-      // Do nothing. JAXB closes the underyling stream so we must filter out those calls.
+      // Do nothing. JAXB closes the underlying stream so we must filter out those calls.
     }
   }
 

--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/JAXBCoder.java
@@ -127,6 +127,7 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
   }
 
   private static class CloseIgnoringInputStream extends FilterInputStream {
+
     protected CloseIgnoringInputStream(InputStream in) {
       super(in);
     }
@@ -134,9 +135,9 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
     @Override
     public void close() {
       // Do nothing. JAXB closes the underyling stream so we must filter out those calls.
-
     }
   }
+
   ////////////////////////////////////////////////////////////////////////////////////
   // JSON Serialization details below
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace "<Jira issue #>" in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
JAXBCoder in the nested context is broken with any coder that writes
content after the output of the XML stream, as decode will read the
entire remaining stream and fail.

In the nested context, prepend a long representing the size of the XML
while encoding, and limit the size of the returned stream while
decoding.

Replaces #112 

This should not be ported to the DataflowJavaSDK