### PR TITLE
Fix misleading Javadoc on Trigger.onElement()

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/Trigger.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/transforms/windowing/Trigger.java
@@ -281,7 +281,7 @@ public abstract class Trigger<W extends BoundedWindow> implements Serializable, 
 
 
   /**
-   * Called immediately after an element is first incorporated into a window.
+   * Called every time an element is incorporated into a window.
    */
   public abstract void onElement(OnElementContext c) throws Exception;
 


### PR DESCRIPTION
This has been bothering me for a while and I always have to go back to the code to check whether my assumption is right. The comment should now reflect the actual behavior.

I didn't file a Jira for this since it's a very small change. I hope this is alright.
