### PR TITLE
Fix tests marked RunnableOnService that aren't

### DIFF
--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.cloud.dataflow.sdk.Pipeline.PipelineExecutionException;
-import com.google.cloud.dataflow.sdk.testing.RunnableOnService;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Combine.CombineFn;
 import com.google.cloud.dataflow.sdk.transforms.Max.MaxIntegerFn;
@@ -32,7 +31,6 @@ import com.google.cloud.dataflow.sdk.transforms.display.DisplayData;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -129,7 +127,6 @@ public class DoFnTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInStartBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFn<String, String>() {
       @Override
@@ -148,7 +145,6 @@ public class DoFnTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInProcessElementThrows() {
     TestPipeline p = createTestPipeline(new DoFn<String, String>() {
       @Override
@@ -164,7 +160,6 @@ public class DoFnTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInFinishBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFn<String, String>() {
       @Override

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnWithContextTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/transforms/DoFnWithContextTest.java
@@ -26,14 +26,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.dataflow.sdk.Pipeline.PipelineExecutionException;
-import com.google.cloud.dataflow.sdk.testing.RunnableOnService;
 import com.google.cloud.dataflow.sdk.testing.TestPipeline;
 import com.google.cloud.dataflow.sdk.transforms.Combine.CombineFn;
 import com.google.cloud.dataflow.sdk.transforms.Max.MaxIntegerFn;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -160,7 +158,6 @@ public class DoFnWithContextTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInStartBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFnWithContext<String, String>() {
       @StartBundle
@@ -179,7 +176,6 @@ public class DoFnWithContextTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInProcessElementThrows() {
     TestPipeline p = createTestPipeline(new DoFnWithContext<String, String>() {
       @ProcessElement
@@ -195,7 +191,6 @@ public class DoFnWithContextTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void testCreateAggregatorInFinishBundleThrows() {
     TestPipeline p = createTestPipeline(new DoFnWithContext<String, String>() {
       @FinishBundle

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/transforms/WithTimestampsTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/transforms/WithTimestampsTest.java
@@ -85,7 +85,6 @@ public class WithTimestampsTest implements Serializable {
   }
 
   @Test
-  @Category(RunnableOnService.class)
   public void withTimestampsBackwardsInTimeShouldThrow() {
     TestPipeline p = TestPipeline.create();
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace "<Jira issue #>" in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Tests must make exclusively assertions about the contents of
PCollections to be marked RunnableOnService. Tests making assertions
about the client result cannot be ported between runners and do not meet
this requirement.

RunnableOnService tests that expect a specific exception as a result of
the pipeline failing are not portable. Remove the RunnableOnService
category from DoFnTest, DoFnWithContextTest, and WithTimestampTest tests
which expect exceptions.