### PR TITLE
[BEAM-162] Merging with closed windows less sensitive to bundle partioning

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/util/MergingActiveWindowSet.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/util/MergingActiveWindowSet.java
@@ -44,16 +44,15 @@ import javax.annotation.Nullable;
 
 /**
  * An {@link ActiveWindowSet} for merging {@link WindowFn} implementations.
- * <p>
+ *
  * <p>The underlying notion of {@link MergingActiveWindowSet} is that of representing equivalence
  * classes of merged windows as a mapping from the merged "super-window" to a set of
  * <i>state address</i> windows in which some state has been persisted. The mapping need not
  * contain EPHEMERAL windows, because they are created and merged without any persistent state.
  * Each window must be a state address window for at most one window, so the mapping is
  * invertible.
- * <p>
+ *
  * <p>The states of a non-expired window are treated as follows:
- * <p>
  * <ul>
  * <li><b>NEW</b>: a NEW has an empty set of associated state address windows.</li>
  * <li><b>ACTIVE</b>: an ACTIVE window will be associated with some nonempty set of state
@@ -67,7 +66,7 @@ import javax.annotation.Nullable;
  * an EPHEMERAL window must be registered with this {@link ActiveWindowSet} by a call
  * to {@link #recordMerge} prior to any request for a {@link #mergeResultWindow}.</li>
  * </ul>
- * <p>
+ *
  * <p>To illustrate why an ACTIVE window need not be amongst its own state address windows,
  * consider two active windows W1 and W2 that are merged to form W12. Further writes may be
  * applied to either of W1 or W2, since a read of W12 implies reading both of W12 and merging

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/util/ReduceFnRunnerTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/util/ReduceFnRunnerTest.java
@@ -839,8 +839,7 @@ public class ReduceFnRunnerTest {
   }
 
   /**
-   * If an element for a closed session window ends up being merged into other still-open
-   * session windows, the resulting session window is not 'poisoned'.
+   * An element for a closed window does not contribute to merging of still open windows.
    */
   @Test
   public void testMergingWithClosedDoesNotPoison() throws Exception {
@@ -873,7 +872,7 @@ public class ReduceFnRunnerTest {
         output.get(0).getPane(),
         equalTo(PaneInfo.createPane(true, true, Timing.EARLY, 0, 0)));
     assertThat(output.get(1),
-        isSingleWindowedValue(containsInAnyOrder(1, 2, 3),
+        isSingleWindowedValue(containsInAnyOrder(1, 3),
             1, // timestamp
             1, // window start
             13)); // window end


### PR DESCRIPTION
This change also rejects elements for windows which are closed before merging. 
(Rejecting elements which end up in a closed window post-merging is still there.)

Idea is rejecting post-merge is necessary so that we never emit elements for a closed window, and rejecting pre-merge is necessary so that the result is invariant on bundle repartioning. 

However:
 - We want to abandon closable triggers.
 - The notion of invariance on bundle repartioning is already unsupportable for most of our triggers.
So I'd be fine if we give up on this one.