### PR TITLE
[BEAM-44] Stop nesting Nullable coders

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/NullableCoder.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/coders/NullableCoder.java
@@ -43,6 +43,9 @@ import javax.annotation.Nullable;
  */
 public class NullableCoder<T> extends StandardCoder<T> {
   public static <T> NullableCoder<T> of(Coder<T> valueCoder) {
+    if (valueCoder instanceof NullableCoder) {
+      return (NullableCoder<T>) valueCoder;
+    }
     return new NullableCoder<>(valueCoder);
   }
 

--- a/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/coders/NullableCoderTest.java
+++ b/sdks/java/core/src/test/java/com/google/cloud/dataflow/sdk/coders/NullableCoderTest.java
@@ -18,8 +18,10 @@
 package com.google.cloud.dataflow.sdk.coders;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.theInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.dataflow.sdk.testing.CoderProperties;
@@ -130,4 +132,9 @@ public class NullableCoderTest {
     TEST_CODER.decode(input, Coder.Context.OUTER);
   }
 
+  @Test
+  public void testNestedNullableCoder() {
+    NullableCoder<Double> coder = NullableCoder.of(DoubleCoder.of());
+    assertThat(NullableCoder.of(coder), theInstance(coder));
+  }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace "<Jira issue #>" in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

A single layer of nullable coders is sufficient to safely encode
possibly-null values. This allows use of NullableCoder#of to wrap any
coder, without duplicating null-safety logic applied by NullableCoder.

Fixes BEAM-44