### PR TITLE
[BEAM-175][BEAM-32] Don't leak state in Global window.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.util.WindowingStrategy;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -245,10 +246,12 @@ public final class PaneInfo {
   /**
    * The zero-based index of this trigger firing that produced this pane.
    *
-   * <p>This will return 0 for the first time the timer fires, 1 for the next time, etc.
+   * <p>If the {@link WindowingStrategy#getPaneIndexBehavior} is
+   * {@link Window.PaneIndexBehavior#SEQUENTIAL} then this will return 0 for the first time the
+   * timer fires, 1 for the next time, etc. A given (key, window, pane-index) is thus guaranteed
+   * to be unique in the output of a group-by-key operation.
    *
-   * <p>A given (key, window, pane-index) is guaranteed to be unique in the
-   * output of a group-by-key operation.
+   * <p>Otherwise this value is always zero.
    */
   public long getIndex() {
     return index;
@@ -257,10 +260,12 @@ public final class PaneInfo {
   /**
    * The zero-based index of this trigger firing among non-speculative panes.
    *
-   * <p> This will return 0 for the first non-{@link Timing#EARLY} timer firing, 1 for the next one,
-   * etc.
+   * <p>If the {@link WindowingStrategy#getPaneIndexBehavior} is
+   * {@link Window.PaneIndexBehavior#SEQUENTIAL} then this will return -1 for all
+   * {@link Timing#EARLY} panes,  0 for the first non-{@link Timing#EARLY} pane, 1 for the next
+   * pane, etc.
    *
-   * <p>Always -1 for speculative data.
+   * <p>Otherwise this value is always zero.
    */
   public long getNonSpeculativeIndex() {
     return nonSpeculativeIndex;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ActiveWindowSet.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ActiveWindowSet.java
@@ -172,4 +172,9 @@ public interface ActiveWindowSet<W extends BoundedWindow> {
    * ACTIVE windows {@code toBeMerged} have been merged into {@code mergeResult}.
    */
   W mergedWriteStateAddress(Collection<W> toBeMerged, W mergeResult);
+
+  /**
+   * Return {@literal true} if active window set has any non-empty state.
+   */
+  boolean hasState();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExecutableTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExecutableTrigger.java
@@ -21,6 +21,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.Trigger;
 import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 
+
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
@@ -140,7 +141,7 @@ public class ExecutableTrigger implements Serializable {
   }
 
   /**
-   * Invoke clear for the current this trigger.
+   * Invoke {@link Trigger#clear} for the current trigger.
    */
   public void invokeClear(Trigger.TriggerContext c) throws Exception {
     trigger.clear(c.forTrigger(this));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FinishedTriggersBitSet.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FinishedTriggersBitSet.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.util;
 
+import com.google.common.base.MoreObjects;
+
 import java.util.BitSet;
 
 /**
@@ -63,5 +65,10 @@ public class FinishedTriggersBitSet implements FinishedTriggers {
   @Override
   public FinishedTriggersBitSet copy() {
     return new FinishedTriggersBitSet((BitSet) bitSet.clone());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).addValue(bitSet).toString();
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MergingActiveWindowSet.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MergingActiveWindowSet.java
@@ -340,6 +340,11 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
     return mergeResult;
   }
 
+  @Override
+  public boolean hasState() {
+    return !activeWindowToStateAddressWindows.isEmpty();
+  }
+
   @VisibleForTesting
   public void checkInvariants() {
     Set<W> knownStateAddressWindows = new HashSet<>();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NonMergingActiveWindowSet.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NonMergingActiveWindowSet.java
@@ -90,4 +90,9 @@ public class NonMergingActiveWindowSet<W extends BoundedWindow> implements Activ
   public W mergedWriteStateAddress(Collection<W> toBeMerged, W mergeResult) {
     return mergeResult;
   }
+
+  @Override
+  public boolean hasState() {
+    return false;
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TriggerRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TriggerRunner.java
@@ -226,9 +226,17 @@ public class TriggerRunner<W extends BoundedWindow> {
     rootTrigger.invokeClear(contextFactory.base(window, timers, rootTrigger, finishedSet));
   }
 
+  /**
+   * Return {@literal true} if trigger has any finished bits state.
+   */
+  public boolean hasFinishedBits(StateAccessor<?> state) {
+    return isFinishedSetNeeded() && state.access(FINISHED_BITS_TAG).read() != null;
+  }
+
   private boolean isFinishedSetNeeded() {
     // TODO: If we know that no trigger in the tree will ever finish, we don't need to do the
     // lookup. Right now, we special case this for the DefaultTrigger.
     return !(rootTrigger.getSpec() instanceof DefaultTrigger);
   }
+
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -55,7 +55,7 @@ import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
 import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
-import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior;
+import org.apache.beam.sdk.transforms.windowing.Window.EmptyPaneBehavior;
 import org.apache.beam.sdk.util.PerKeyCombineFnRunners;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
@@ -595,7 +595,7 @@ public class CombineTest implements Serializable {
         .apply(Window.<Integer>into(new GlobalWindows())
             .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
             .accumulatingFiredPanes()
-            .withAllowedLateness(new Duration(0), ClosingBehavior.FIRE_ALWAYS))
+            .withAllowedLateness(new Duration(0), EmptyPaneBehavior.FIRE_ALWAYS))
         .apply(Sum.integersGlobally().withoutDefaults().withFanout(2))
         .apply(ParDo.of(new GetLast()));
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
@@ -246,7 +246,7 @@ public class WindowTest implements Serializable {
     FixedWindows windowFn = FixedWindows.of(Duration.standardHours(5));
     AfterWatermark.FromEndOfWindow triggerBuilder = AfterWatermark.pastEndOfWindow();
     Duration allowedLateness = Duration.standardMinutes(10);
-    Window.ClosingBehavior closingBehavior = Window.ClosingBehavior.FIRE_IF_NON_EMPTY;
+    Window.EmptyPaneBehavior closingBehavior = Window.EmptyPaneBehavior.FIRE_IF_NON_EMPTY;
     OutputTimeFn<BoundedWindow> outputTimeFn = OutputTimeFns.outputAtEndOfWindow();
 
     Window.Bound<?> window = Window

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnRunnerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnRunnerTest.java
@@ -58,7 +58,8 @@ import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
 import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.Trigger;
-import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior;
+import org.apache.beam.sdk.transforms.windowing.Window.EmptyPaneBehavior;
+import org.apache.beam.sdk.transforms.windowing.Window.PaneIndexBehavior;
 import org.apache.beam.sdk.util.WindowingStrategy.AccumulationMode;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TimestampedValue;
@@ -142,8 +143,9 @@ public class ReduceFnRunnerTest {
     // Test basic execution of a trigger using a non-combining window set and discarding mode.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // Pane of {1, 2}
     injectElement(tester, 1);
@@ -172,8 +174,9 @@ public class ReduceFnRunnerTest {
     // Test basic execution of a trigger using a non-combining window set and accumulating mode.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.ACCUMULATING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.ACCUMULATING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     injectElement(tester, 1);
 
@@ -308,8 +311,9 @@ public class ReduceFnRunnerTest {
     // Test handling of late data. Specifically, ensure the watermark hold is correct.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.ACCUMULATING_FIRED_PANES, Duration.millis(10),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.ACCUMULATING_FIRED_PANES,
+            Duration.millis(10),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // Input watermark -> null
     assertEquals(null, tester.getWatermarkHold());
@@ -427,8 +431,9 @@ public class ReduceFnRunnerTest {
     // Make sure holds are only set if they are accompanied by an end-of-window timer.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.ACCUMULATING_FIRED_PANES, Duration.millis(10),
-            ClosingBehavior.FIRE_ALWAYS);
+            AccumulationMode.ACCUMULATING_FIRED_PANES,
+            Duration.millis(10),
+            EmptyPaneBehavior.FIRE_ALWAYS);
     tester.setAutoAdvanceOutputWatermark(false);
 
     // Case: Unobservably late
@@ -465,8 +470,9 @@ public class ReduceFnRunnerTest {
   public void testPaneInfoAllStates() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     tester.advanceInputWatermark(new Instant(0));
     when(mockTrigger.shouldFire(anyTriggerContext())).thenReturn(true);
@@ -510,7 +516,7 @@ public class ReduceFnRunnerTest {
             .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
             .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
-            .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
+            .withClosingBehavior(EmptyPaneBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));
     tester.injectElements(
@@ -561,9 +567,10 @@ public class ReduceFnRunnerTest {
                 AfterPane.elementCountAtLeast(2),
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
+            .withOnTimeBehavior(EmptyPaneBehavior.FIRE_ALWAYS)
             .withAllowedLateness(Duration.millis(100))
             .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
-            .withClosingBehavior(ClosingBehavior.FIRE_IF_NON_EMPTY));
+            .withClosingBehavior(EmptyPaneBehavior.FIRE_IF_NON_EMPTY));
 
     tester.advanceInputWatermark(new Instant(0));
     tester.injectElements(
@@ -590,7 +597,7 @@ public class ReduceFnRunnerTest {
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
             .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
-            .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
+            .withClosingBehavior(EmptyPaneBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));
     tester.injectElements(
@@ -619,7 +626,7 @@ public class ReduceFnRunnerTest {
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
             .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
-            .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
+            .withClosingBehavior(EmptyPaneBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));
     tester.injectElements(
@@ -671,7 +678,7 @@ public class ReduceFnRunnerTest {
                     .orFinally(AfterWatermark.pastEndOfWindow()))
             .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
-            .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
+            .withClosingBehavior(EmptyPaneBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));
 
@@ -693,8 +700,9 @@ public class ReduceFnRunnerTest {
   public void testPaneInfoSkipToFinish() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     tester.advanceInputWatermark(new Instant(0));
     when(mockTrigger.shouldFire(anyTriggerContext())).thenReturn(true);
@@ -708,8 +716,9 @@ public class ReduceFnRunnerTest {
   public void testPaneInfoSkipToNonSpeculativeAndFinish() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     tester.advanceInputWatermark(new Instant(15));
     when(mockTrigger.shouldFire(anyTriggerContext())).thenReturn(true);
@@ -725,8 +734,9 @@ public class ReduceFnRunnerTest {
     // unmerged windows.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(Sessions.withGapDuration(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(0),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(0),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // All on time data, verify watermark hold.
     // These two windows should pre-merge immediately to [1, 20)
@@ -758,8 +768,9 @@ public class ReduceFnRunnerTest {
   public void testMergingWithCloseBeforeGC() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(Sessions.withGapDuration(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(50),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(50),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // Two elements in two overlapping session windows.
     tester.injectElements(
@@ -793,8 +804,9 @@ public class ReduceFnRunnerTest {
   public void testMergingWithCloseTrigger() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(Sessions.withGapDuration(Duration.millis(10)), mockTrigger,
-                                    AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(50),
-                                    ClosingBehavior.FIRE_IF_NON_EMPTY);
+                                    AccumulationMode.DISCARDING_FIRED_PANES,
+                                    Duration.millis(50),
+                                    EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // Create a new merged session window.
     tester.injectElements(TimestampedValue.of(1, new Instant(1)),
@@ -826,8 +838,9 @@ public class ReduceFnRunnerTest {
   public void testMergingWithReusedWindow() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(Sessions.withGapDuration(Duration.millis(10)), mockTrigger,
-                                    AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(50),
-                                    ClosingBehavior.FIRE_IF_NON_EMPTY);
+                                    AccumulationMode.DISCARDING_FIRED_PANES,
+                                    Duration.millis(50),
+                                    EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // One elements in one session window.
     tester.injectElements(TimestampedValue.of(1, new Instant(1))); // in [1, 11), gc at 21.
@@ -867,8 +880,9 @@ public class ReduceFnRunnerTest {
   public void testMergingWithClosedRepresentative() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(Sessions.withGapDuration(Duration.millis(10)), mockTrigger,
-                                    AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(50),
-                                    ClosingBehavior.FIRE_IF_NON_EMPTY);
+                                    AccumulationMode.DISCARDING_FIRED_PANES,
+                                    Duration.millis(50),
+                                    EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // 2 elements into merged session window.
     // Close the trigger, but the garbage collection timer is still pending.
@@ -908,8 +922,9 @@ public class ReduceFnRunnerTest {
   public void testMergingWithClosedDoesNotPoison() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(Sessions.withGapDuration(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(50),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(50),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // 1 element, force its trigger to close.
     when(mockTrigger.shouldFire(anyTriggerContext())).thenReturn(true);
@@ -987,8 +1002,9 @@ public class ReduceFnRunnerTest {
     // modify PaneInfo.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.DISCARDING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.DISCARDING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // Inject a couple of on-time elements and fire at the window end.
     injectElement(tester, 1);
@@ -1032,8 +1048,9 @@ public class ReduceFnRunnerTest {
     // modify PaneInfo.
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(FixedWindows.of(Duration.millis(10)), mockTrigger,
-            AccumulationMode.ACCUMULATING_FIRED_PANES, Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            AccumulationMode.ACCUMULATING_FIRED_PANES,
+            Duration.millis(100),
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     // Inject a couple of on-time elements and fire at the window end.
     injectElement(tester, 1);
@@ -1215,6 +1232,7 @@ public class ReduceFnRunnerTest {
             WindowingStrategy.of(new GlobalWindows())
                              .withTrigger(Repeatedly.<GlobalWindow>forever(
                                  AfterPane.elementCountAtLeast(3)))
+                             .withOnTimeBehavior(EmptyPaneBehavior.FIRE_IF_NON_EMPTY)
                              .withMode(AccumulationMode.DISCARDING_FIRED_PANES));
 
     tester.advanceInputWatermark(new Instant(0));
@@ -1239,11 +1257,14 @@ public class ReduceFnRunnerTest {
     assertEquals(Timing.ON_TIME, output.get(0).getPane().getTiming());
     assertEquals(n / 3, output.get(0).getPane().getIndex());
     assertEquals(n - ((n / 3) * 3), Iterables.size(output.get(0).getValue()));
+
+    tester.assertEmptyState();
+    tester.assertNoTimers();
   }
 
   /**
    * We should fire an empty ON_TIME pane in the GlobalWindow when the watermark moves to
-   * end-of-time.
+   * end-of-time if we asked for it.
    */
   @Test
   public void fireEmptyOnDrainInGlobalWindowIfRequested() throws Exception {
@@ -1253,6 +1274,7 @@ public class ReduceFnRunnerTest {
                              .withTrigger(Repeatedly.<GlobalWindow>forever(
                                  AfterProcessingTime.pastFirstElementInPane().plusDelayOf(
                                      new Duration(3))))
+                             .withOnTimeBehavior(EmptyPaneBehavior.FIRE_ALWAYS)
                              .withMode(AccumulationMode.DISCARDING_FIRED_PANES));
 
     final int n = 20;
@@ -1276,6 +1298,109 @@ public class ReduceFnRunnerTest {
     assertEquals(Timing.ON_TIME, output.get(0).getPane().getTiming());
     assertEquals((n + 3) / 4, output.get(0).getPane().getIndex());
     assertEquals(0, Iterables.size(output.get(0).getValue()));
+
+    tester.assertEmptyState();
+    tester.assertNoTimers();
+  }
+
+  /**
+   * We should not fire an empty ON_TIME pane in the GlobalWindow when the watermark moves to
+   * end-of-time if we did not ask for it.
+   */
+  @Test
+  public void dontFireEmptyOnDrainInGlobalWindowIfNotRequested() throws Exception {
+    ReduceFnTester<Integer, Iterable<Integer>, GlobalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(new GlobalWindows())
+                             .withTrigger(
+                                 Repeatedly.<GlobalWindow>forever(
+                                     AfterProcessingTime.pastFirstElementInPane()
+                                                        .plusDelayOf(new Duration(3))))
+                             .withOnTimeBehavior(EmptyPaneBehavior.FIRE_IF_NON_EMPTY)
+                             .withMode(AccumulationMode.DISCARDING_FIRED_PANES));
+
+    final int n = 20;
+    for (int i = 0; i < n; i++) {
+      tester.advanceProcessingTime(new Instant(i));
+      tester.injectElements(TimestampedValue.of(i, new Instant(i)));
+    }
+    tester.advanceProcessingTime(new Instant(n + 4));
+    List<WindowedValue<Iterable<Integer>>> output = tester.extractOutput();
+    assertEquals((n + 3) / 4, output.size());
+    for (int i = 0; i < output.size(); i++) {
+      assertEquals(Timing.EARLY, output.get(i).getPane().getTiming());
+      assertEquals(i, output.get(i).getPane().getIndex());
+      assertEquals(4, Iterables.size(output.get(i).getValue()));
+    }
+
+    tester.advanceInputWatermark(BoundedWindow.TIMESTAMP_MAX_VALUE);
+
+    output = tester.extractOutput();
+    assertEquals(0, output.size());
+
+    tester.assertEmptyState();
+    tester.assertNoTimers();
+  }
+
+  /**
+   * Pane index should be a constant zero if we requested it.
+   */
+  @Test
+  public void zeroIndexIfRequested() throws Exception {
+    ReduceFnTester<Integer, Iterable<Integer>, GlobalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(new GlobalWindows())
+                             .withTrigger(Repeatedly.<GlobalWindow>forever(
+                                 AfterPane.elementCountAtLeast(3)))
+                             .withOnTimeBehavior(EmptyPaneBehavior.FIRE_IF_NON_EMPTY)
+                             .withPaneIndexBehavior(PaneIndexBehavior.ZERO)
+                             .withMode(AccumulationMode.DISCARDING_FIRED_PANES));
+
+    final int n = 20;
+    for (int i = 0; i < n; i++) {
+      tester.injectElements(TimestampedValue.of(i, new Instant(i)));
+    }
+
+    List<WindowedValue<Iterable<Integer>>> output = tester.extractOutput();
+    assertEquals(n / 3, output.size());
+    for (int i = 0; i < output.size(); i++) {
+      assertEquals(Timing.EARLY, output.get(i).getPane().getTiming());
+      assertEquals(0, output.get(i).getPane().getIndex());
+    }
+  }
+
+  /**
+   * We should not accumulate state in the Global window if there's no pending data.
+   */
+  @Test
+  public void dontLeakStateInGlobalWindow() throws Exception {
+    ReduceFnTester<Integer, Iterable<Integer>, GlobalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(new GlobalWindows())
+                             .withTrigger(
+                                 Repeatedly.<GlobalWindow>forever(
+                                     AfterProcessingTime
+                                         .<GlobalWindow>pastFirstElementInPane()
+                                         .plusDelayOf(new Duration(5))))
+                             .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
+                             .withPaneIndexBehavior(PaneIndexBehavior.ZERO)
+                             .withOnTimeBehavior(EmptyPaneBehavior.FIRE_IF_NON_EMPTY));
+
+    tester.advanceInputWatermark(new Instant(0));
+
+    final int n = 20;
+    for (int i = 0; i < n; i++) {
+      tester.advanceProcessingTime(new Instant(i));
+      tester.injectElements(TimestampedValue.of(i, new Instant(i)));
+    }
+
+    tester.advanceProcessingTime(new Instant(n + 6));
+
+    List<WindowedValue<Iterable<Integer>>> output = tester.extractOutput();
+    assertEquals(n / 5, output.size());
+
+    tester.assertEmptyState();
+    tester.assertNoTimers();
   }
 
   /**
@@ -1290,7 +1415,7 @@ public class ReduceFnRunnerTest {
             AfterWatermark.pastEndOfWindow().withLateFirings(AfterPane.elementCountAtLeast(2)),
             AccumulationMode.DISCARDING_FIRED_PANES,
             Duration.millis(100),
-            ClosingBehavior.FIRE_IF_NON_EMPTY);
+            EmptyPaneBehavior.FIRE_IF_NON_EMPTY);
 
     tester.advanceInputWatermark(new Instant(0));
     tester.advanceOutputWatermark(new Instant(0));
@@ -1312,6 +1437,9 @@ public class ReduceFnRunnerTest {
 
     List<WindowedValue<Iterable<Integer>>> output = tester.extractOutput();
     assertEquals(2, output.size());
+
+    tester.assertEmptyState();
+    tester.assertNoTimers();
   }
 
   private static class SumAndVerifyContextFn extends CombineFnWithContext<Integer, int[], Integer> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnTester.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnTester.java
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.transforms.windowing.OutputTimeFns;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.Trigger;
 import org.apache.beam.sdk.transforms.windowing.TriggerBuilder;
-import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior;
+import org.apache.beam.sdk.transforms.windowing.Window.EmptyPaneBehavior;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.util.TimerInternals.TimerData;
 import org.apache.beam.sdk.util.WindowingStrategy.AccumulationMode;
@@ -132,7 +132,8 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
 
   public static <W extends BoundedWindow> ReduceFnTester<Integer, Iterable<Integer>, W>
       nonCombining(WindowFn<?, W> windowFn, TriggerBuilder trigger, AccumulationMode mode,
-          Duration allowedDataLateness, ClosingBehavior closingBehavior) throws Exception {
+          Duration allowedDataLateness,
+          EmptyPaneBehavior closingBehavior) throws Exception {
     WindowingStrategy<?, W> strategy =
         WindowingStrategy.of(windowFn)
             .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
@@ -245,6 +246,25 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
     return createRunner().hasNoActiveWindows();
   }
 
+  public final void assertEmptyState() {
+    for (StateNamespace namespace : stateInternals.getNamespacesInUse()) {
+      if (namespace instanceof StateNamespaces.GlobalNamespace) {
+        continue;
+      } else if (namespace instanceof StateNamespaces.WindowNamespace) {
+        Set<StateTag<? super String, ?>> tagsInUse = stateInternals.getTagsInUse(namespace);
+        assertTrue(namespace + " contains " + tagsInUse, tagsInUse.isEmpty());
+      } else if (namespace instanceof StateNamespaces.WindowAndTriggerNamespace) {
+        Set<StateTag<? super String, ?>> tagsInUse = stateInternals.getTagsInUse(namespace);
+        assertTrue(namespace + " contains " + tagsInUse, tagsInUse.isEmpty());
+      } else {
+        fail("Unrecognized namespace " + namespace);
+      }
+    }
+  }
+
+  public final void assertNoTimers() {
+    timerInternals.assertNoTimers();
+  }
   @SafeVarargs
   public final void assertHasOnlyGlobalAndFinishedSetsFor(W... expectedWindows) {
     assertHasOnlyGlobalAndAllowedTags(
@@ -621,6 +641,12 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
     /** Current synchronized processing time. */
     @Nullable
     private Instant synchronizedProcessingTime = null;
+    public void assertNoTimers() {
+      assertTrue("Still have " + watermarkTimers.size() + " event timers",
+          watermarkTimers.isEmpty         ());
+      assertTrue("Still have " + processingTimers.size() + " processing timers",
+          processingTimers.isEmpty());
+    }
 
     @Nullable
     public Instant getNextTimer(TimeDomain domain) {


### PR DESCRIPTION
* Delete end-of-window timer after triggering if there's no
  state left to garbage collect.
* Avoid holds and end-of-time unless requested.
* Avoid requiring previous pane info in global window.