### PR TITLE
Exclude more IDE files from Spark runner RAT check

### DIFF
--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -260,11 +260,14 @@
                     <configuration>
                         <excludes>
                             <exclude>.travis.yml</exclude>
-                            <exclude>**/*.checkstyle</exclude>
                             <exclude>**/*.conf</exclude>
                             <exclude>**/*.iml</exclude>
                             <exclude>**/*.md</exclude>
                             <exclude>**/*.txt</exclude>
+                            <exclude>**/.project</exclude>
+                            <exclude>**/.checkstyle</exclude>
+                            <exclude>**/.classpath</exclude>
+                            <exclude>**/.settings/</exclude>
                             <exclude>**/gen/**</exclude>
                             <exclude>**/resources/**</exclude>
                             <exclude>**/target/**</exclude>


### PR DESCRIPTION
It also seems that some of the prior rules were overly broad, excluding `*.filename` when they only should be excluding dotfiles.