### PR TITLE
FileBasedSource: throw IOException instead of Exception where possible

### DIFF
--- a/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/com/google/cloud/dataflow/sdk/io/FileBasedSource.java
@@ -236,7 +236,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       Thread.currentThread().interrupt();
       throw new IOException(e);
     } catch (ExecutionException e) {
-      throw new IOException(e);
+      throw new IOException(e.getCause());
     }  finally {
       service.shutdown();
     }


### PR DESCRIPTION
- Replace "throws Exception" with "throws IOException" from APIs
  that already only throw IOException. **Only private or final methods,
  so that we don't affect overriding classes.**
- Refactor one function to catch, handle, and rethrow
  (Interrupted|Execution)Exception.

This makes it easier to write a new FileBasedSource, because the
FilebasedReader functions are only registered to throw IOException.