### PR TITLE
[BEAM-151] Move maven archetypes build order to be after runners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
   <modules>
     <module>sdks</module>
     <module>runners</module>
+    <!-- sdks/java/maven-archtypes has several dependencies on the
+         DataflowPipelineRunner. Until these are refactored out or
+         a released artifact exists, we need to modify the build order. -->
+    <module>sdks/java/maven-archetypes</module>
     <module>examples</module>
   </modules>
 

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -36,6 +36,10 @@
 
   <modules>
     <module>core</module>
+    <!-- sdks/java/maven-archtypes has several dependencies on the
+         DataflowPipelineRunner. Until these are refactored out or
+         a released artifact exists, we need to modify the build order.
+    <module>maven-archetypes</module> -->
   </modules>
 
   <profiles>

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -36,7 +36,6 @@
 
   <modules>
     <module>core</module>
-    <module>maven-archetypes</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace "<Jira issue #>" in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
sdks/java/maven-archtypes has several dependencies on the DataflowPipelineRunner. Until these are refactored out or a released artifact exists, we need to modify the build order.