### PR TITLE
[BEAM-151] Enable integration tests underneath google-cloud-dataflow-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,8 @@
     <protobuf.version>3.0.0-beta-1</protobuf.version>
     <pubsub.version>v1-rev7-1.21.0</pubsub.version>
     <slf4j.version>1.7.14</slf4j.version>
+    <surefire.dependencyToScan>${project.groupId}:${project.versionId}</surefire.dependencyToScan>
+    <surefire.testPipelineOptions>[]</surefire.testPipelineOptions>
     <stax2.version>3.1.4</stax2.version>
     <storage.version>v1-rev53-1.21.0</storage.version>
     <woodstox.version>4.4.1</woodstox.version>
@@ -293,9 +295,13 @@
             <threadCount>4</threadCount>
             <groups>${testGroups}</groups>
             <systemPropertyVariables>
+              <dataflowOptions>${surefire.testPipelineOptions}</dataflowOptions>
               <runIntegrationTestOnService>${runIntegrationTestOnService}</runIntegrationTestOnService>
               <projectName>${dataflowProjectName}</projectName>
             </systemPropertyVariables>
+            <dependenciesToScan>
+                <dependency>${surefire.dependencyToScan}</dependency>
+            </dependenciesToScan>
             <useManifestOnlyJar>false</useManifestOnlyJar>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -55,6 +55,8 @@
         <runIntegrationTestOnService>true</runIntegrationTestOnService>
         <testGroups>com.google.cloud.dataflow.sdk.testing.RunnableOnService</testGroups>
         <testParallelValue>both</testParallelValue>
+        <surefire.dependency>org.apache.beam:java-sdk-all</surefire.dependency>
+        <surefire.testPipelineOptions>${dataflow.testPipelineOptions}</surefire.testPipelineOptions>
       </properties>
     </profile>
   </profiles>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -46,17 +46,6 @@
     <dataflowProjectName></dataflowProjectName>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>DataflowPipelineTests</id>
-      <properties>
-        <runIntegrationTestOnService>true</runIntegrationTestOnService>
-        <testGroups>com.google.cloud.dataflow.sdk.testing.RunnableOnService</testGroups>
-        <testParallelValue>both</testParallelValue>
-      </properties>
-    </profile>
-  </profiles>
-
   <build>
     <resources>
       <resource>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace "<Jira issue #>" in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Added surefire.dependencyToScan and surefire.testPipelineOptions configuration options

surefire.dependencyToScan adds an additional dependency used to find tests.
This allows for java-sdk-all to be added to all runners for running
the @Category(RunnableOnService.class) tests.

surefire.testPipelineOptions configures the pipeline options used while
constructing instances of a TestPipeline. A json list of arguments
is expected, for example:
[ "--runner=MyRunner", "--myRunnerOption=myRunnerValue" ]