### PR TITLE
[BEAM-188] Write: apply GlobalWindows first

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
@@ -35,8 +35,6 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PDone;
 
-import org.joda.time.Instant;
-
 import java.util.UUID;
 
 /**


### PR DESCRIPTION
And do not supply a timestamp when outputting.

Note that this is safe because the functions in the Writer cannot access the window
or timestamp. When we add per-Window or similar functions to the sinks, we will
likely do so at a higher level.

Also testing and improving the existing tests. Note that the session test did fail without the accompanying changes to Write.