### PR TITLE
[BEAM-22] Remove isKeyed property of InProcess Bundles

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessBundleFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessBundleFactory.java
@@ -48,9 +48,7 @@ class InProcessBundleFactory implements BundleFactory {
 
   @Override
   public <T> UncommittedBundle<T> createBundle(CommittedBundle<?> input, PCollection<T> output) {
-    return input.isKeyed()
-        ? InProcessBundle.keyed(output, input.getKey())
-        : InProcessBundle.unkeyed(output);
+    return InProcessBundle.keyed(output, input.getKey());
   }
 
   @Override
@@ -64,7 +62,6 @@ class InProcessBundleFactory implements BundleFactory {
    */
   private static final class InProcessBundle<T> implements UncommittedBundle<T> {
     private final PCollection<T> pcollection;
-    private final boolean keyed;
     private final Object key;
     private boolean committed = false;
     private ImmutableList.Builder<WindowedValue<T>> elements;
@@ -73,23 +70,19 @@ class InProcessBundleFactory implements BundleFactory {
      * Create a new {@link InProcessBundle} for the specified {@link PCollection} without a key.
      */
     public static <T> InProcessBundle<T> unkeyed(PCollection<T> pcollection) {
-      return new InProcessBundle<T>(pcollection, false, null);
+      return new InProcessBundle<T>(pcollection, null);
     }
 
     /**
      * Create a new {@link InProcessBundle} for the specified {@link PCollection} with the specified
      * key.
-     *
-     * <p>See {@link CommittedBundle#getKey()} and {@link CommittedBundle#isKeyed()} for more
-     * information.
      */
     public static <T> InProcessBundle<T> keyed(PCollection<T> pcollection, Object key) {
-      return new InProcessBundle<T>(pcollection, true, key);
+      return new InProcessBundle<T>(pcollection, key);
     }
 
-    private InProcessBundle(PCollection<T> pcollection, boolean keyed, Object key) {
+    private InProcessBundle(PCollection<T> pcollection, Object key) {
       this.pcollection = pcollection;
-      this.keyed = keyed;
       this.key = key;
       this.elements = ImmutableList.builder();
     }
@@ -120,11 +113,6 @@ class InProcessBundleFactory implements BundleFactory {
         @Nullable
         public Object getKey() {
           return key;
-        }
-
-        @Override
-        public boolean isKeyed() {
-          return keyed;
         }
 
         @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessBundleFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessBundleFactory.java
@@ -43,18 +43,18 @@ class InProcessBundleFactory implements BundleFactory {
 
   @Override
   public <T> UncommittedBundle<T> createRootBundle(PCollection<T> output) {
-    return InProcessBundle.unkeyed(output);
+    return InProcessBundle.create(output, null);
   }
 
   @Override
   public <T> UncommittedBundle<T> createBundle(CommittedBundle<?> input, PCollection<T> output) {
-    return InProcessBundle.keyed(output, input.getKey());
+    return InProcessBundle.create(output, input.getKey());
   }
 
   @Override
   public <T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, Object key, PCollection<T> output) {
-    return InProcessBundle.keyed(output, key);
+      CommittedBundle<?> input, @Nullable Object key, PCollection<T> output) {
+    return InProcessBundle.create(output, key);
   }
 
   /**
@@ -62,22 +62,14 @@ class InProcessBundleFactory implements BundleFactory {
    */
   private static final class InProcessBundle<T> implements UncommittedBundle<T> {
     private final PCollection<T> pcollection;
-    private final Object key;
+    @Nullable private final Object key;
     private boolean committed = false;
     private ImmutableList.Builder<WindowedValue<T>> elements;
 
     /**
-     * Create a new {@link InProcessBundle} for the specified {@link PCollection} without a key.
+     * Create a new {@link InProcessBundle} for the specified {@link PCollection}.
      */
-    public static <T> InProcessBundle<T> unkeyed(PCollection<T> pcollection) {
-      return new InProcessBundle<T>(pcollection, null);
-    }
-
-    /**
-     * Create a new {@link InProcessBundle} for the specified {@link PCollection} with the specified
-     * key.
-     */
-    public static <T> InProcessBundle<T> keyed(PCollection<T> pcollection, Object key) {
+    public static <T> InProcessBundle<T> create(PCollection<T> pcollection, @Nullable Object key) {
       return new InProcessBundle<T>(pcollection, key);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -135,12 +135,6 @@ public class InProcessPipelineRunner
     PCollection<T> getPCollection();
 
     /**
-     * Returns whether this bundle is keyed. A bundle that is part of a {@link PCollection} that
-     * occurs after a {@link GroupByKey} is keyed by the result of the last {@link GroupByKey}.
-     */
-    boolean isKeyed();
-
-    /**
      * Returns the (possibly null) key that was output in the most recent {@link GroupByKey} in the
      * execution of this bundle.
      */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/inprocess/InProcessBundleFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/inprocess/InProcessBundleFactoryTest.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.runners.inprocess;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -75,7 +74,6 @@ public class InProcessBundleFactoryTest {
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
 
-    assertThat(bundle.isKeyed(), is(false));
     assertThat(bundle.getKey(), nullValue());
   }
 
@@ -86,7 +84,6 @@ public class InProcessBundleFactoryTest {
         bundleFactory.createKeyedBundle(null, key, pcollection);
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
-    assertThat(bundle.isKeyed(), is(true));
     assertThat(bundle.getKey(), equalTo(key));
   }
 
@@ -165,7 +162,6 @@ public class InProcessBundleFactoryTest {
         bundleFactory
             .createBundle(bundleFactory.createRootBundle(created).commit(Instant.now()), downstream)
             .commit(Instant.now());
-    assertThat(newBundle.isKeyed(), is(false));
   }
 
   @Test
@@ -176,13 +172,7 @@ public class InProcessBundleFactoryTest {
                 bundleFactory.createKeyedBundle(null, "foo", created).commit(Instant.now()),
                 downstream)
             .commit(Instant.now());
-    assertThat(newBundle.isKeyed(), is(true));
     assertThat(newBundle.getKey(), Matchers.<Object>equalTo("foo"));
-  }
-
-  @Test
-  public void createRootBundleUnkeyed() {
-    assertThat(bundleFactory.createRootBundle(created).commit(Instant.now()).isKeyed(), is(false));
   }
 
   @Test
@@ -192,7 +182,6 @@ public class InProcessBundleFactoryTest {
             .createKeyedBundle(
                 bundleFactory.createRootBundle(created).commit(Instant.now()), "foo", downstream)
             .commit(Instant.now());
-    assertThat(keyedBundle.isKeyed(), is(true));
     assertThat(keyedBundle.getKey(), Matchers.<Object>equalTo("foo"));
   }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The property of keyedness belongs to a PCollection. A BundleFactory
propogates the key as far as possible, but does not track if a bundle is
keyed.