### PR TITLE
[BEAM-22] Add splitOffElements to InProcess Bundles

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -163,11 +163,35 @@ public class InProcessPipelineRunner
      * timers that fired to produce this bundle.
      */
     Instant getSynchronizedProcessingOutputWatermark();
+
+    /**
+     * Splits this bundle into two {@link CommittedBundle CommittedBundles}, a primary and residual.
+     * The residual bundle will contain all of the elements contained within the elements iterable
+     * argument, while the primary bundle will contain all other elements. The returned bundles will
+     * be otherwise identical to this bundle.
+     */
+    BundleSplit<T> splitOffElements(Iterable<WindowedValue<T>> elements);
+  }
+
+  static interface BundleSplit<T> {
+    /**
+     * Gets the {@link CommittedBundle} containing the primary elements. These elements are
+     * generally those that were successfully processed.
+     */
+    CommittedBundle<T> getPrimary();
+
+    /**
+     * Gets the {@link CommittedBundle} containing the elements that were split off. These elements
+     * are generally those that could not be processed due to side inputs that are not currently
+     * ready.
+     */
+    CommittedBundle<T> getResidual();
   }
 
   /**
    * A {@link PCollectionViewWriter} is responsible for writing contents of a {@link PCollection} to
    * a storage mechanism that can be read from while constructing a {@link PCollectionView}.
+   *
    * @param <ElemT> the type of elements the input {@link PCollection} contains.
    * @param <ViewT> the type of the PCollectionView this writer writes to.
    */


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This allows elements that could not be processed to be "reclaimed" from
a bundle and placed into a residual bundle.

Required to stop blocking on SideInputs.