### PR TITLE
[BEAM-208] Remove use of System.currentTimeMillis in Flink Test

### DIFF
--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/GroupByNullKeyTest.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/GroupByNullKeyTest.java
@@ -67,12 +67,11 @@ public class GroupByNullKeyTest extends StreamingProgramTestBase implements Seri
     @Override
     public void processElement(ProcessContext c) {
       KV<Integer, String> record = c.element();
-      long now = System.currentTimeMillis();
       int timestamp = record.getKey();
       String userName = record.getValue();
       if (userName != null) {
         // Sets the implicit timestamp field to be used in windowing.
-        c.outputWithTimestamp(userName, new Instant(timestamp + now));
+        c.outputWithTimestamp(userName, new Instant(timestamp));
       }
     }
   }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This will stop tests failing if the DoFn executes within ~25 seconds of
an hour boundary.