### PR TITLE
[BEAM-215] Override Create in the SparkPipelineRunner

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineRunner.java
@@ -27,12 +27,14 @@ import org.apache.beam.runners.spark.translation.TransformTranslator;
 import org.apache.beam.runners.spark.translation.streaming.StreamingEvaluationContext;
 import org.apache.beam.runners.spark.translation.streaming.StreamingTransformTranslator;
 import org.apache.beam.runners.spark.translation.streaming.StreamingWindowPipelineDetector;
+import org.apache.beam.runners.spark.util.SinglePrimitiveOutputPTransform;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.runners.TransformTreeNode;
+import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.util.GroupByKeyViaGroupByKeyOnly;
@@ -124,6 +126,9 @@ public final class SparkPipelineRunner extends PipelineRunner<EvaluationResult> 
     if (transform instanceof GroupByKey) {
       return (OT) ((PCollection) input).apply(
           new GroupByKeyViaGroupByKeyOnly((GroupByKey) transform));
+    } else if (transform instanceof Create.Values) {
+      return (OT) super.apply(
+        new SinglePrimitiveOutputPTransform((Create.Values) transform), input);
     } else {
       return super.apply(transform, input);
     }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SinglePrimitiveOutputPTransform.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SinglePrimitiveOutputPTransform.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.util;
+
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.util.WindowingStrategy;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollection.IsBounded;
+import org.apache.beam.sdk.values.PInput;
+
+public class SinglePrimitiveOutputPTransform<T> extends PTransform<PInput, PCollection<T>> {
+  private PTransform<PInput, PCollection<T>> transform;
+
+  public SinglePrimitiveOutputPTransform(PTransform<PInput, PCollection<T>> transform) {
+    this.transform = transform;
+  }
+
+  @Override
+  public PCollection<T> apply(PInput input) {
+    try {
+      PCollection<T> collection = PCollection.<T>createPrimitiveOutputInternal(
+              input.getPipeline(), WindowingStrategy.globalDefault(), IsBounded.BOUNDED);
+      collection.setCoder(transform.getDefaultOutputCoder(input, collection));
+      return collection;
+    } catch (CannotProvideCoderException e) {
+      throw new IllegalArgumentException(
+          "Unable to infer a coder and no Coder was specified. "
+              + "Please set a coder by invoking Create.withCoder() explicitly.",
+          e);
+    }
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This allows existing pipelines to continue to function by keeping the
graph structure identical while replacing Create with a Read.

After [BEAM-17](https://issues.apache.org/jira/browse/BEAM-17?jql=project%20%3D%20BEAM%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22create%22%20ORDER%20BY%20priority%20DESC) this override can be removed.

See #183 for more information.