### PR TITLE
[BEAM-115] Add control of PipelineVisitor recursion into composite transforms

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ConsumerTrackingPipelineVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ConsumerTrackingPipelineVisitor.java
@@ -41,7 +41,7 @@ import java.util.Set;
  * {@link Pipeline}. This is used to schedule consuming {@link PTransform PTransforms} to consume
  * input after the upstream transform has produced and committed output.
  */
-public class ConsumerTrackingPipelineVisitor implements PipelineVisitor {
+public class ConsumerTrackingPipelineVisitor extends PipelineVisitor.Defaults {
   private Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers = new HashMap<>();
   private Collection<AppliedPTransform<?, ?, ?>> rootTransforms = new ArrayList<>();
   private Collection<PCollectionView<?>> views = new ArrayList<>();
@@ -51,13 +51,14 @@ public class ConsumerTrackingPipelineVisitor implements PipelineVisitor {
   private boolean finalized = false;
 
   @Override
-  public void enterCompositeTransform(TransformTreeNode node) {
+  public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
     checkState(
         !finalized,
         "Attempting to traverse a pipeline (node %s) with a %s "
             + "which has already visited a Pipeline and is finalized",
         node.getFullName(),
         ConsumerTrackingPipelineVisitor.class.getSimpleName());
+    return CompositeBehavior.ENTER_TRANSFORM;
   }
 
   @Override
@@ -73,7 +74,7 @@ public class ConsumerTrackingPipelineVisitor implements PipelineVisitor {
   }
 
   @Override
-  public void visitTransform(TransformTreeNode node) {
+  public void visitPrimitiveTransform(TransformTreeNode node) {
     toFinalize.removeAll(node.getInput().expand());
     AppliedPTransform<?, ?, ?> appliedTransform = getAppliedTransform(node);
     stepNames.put(appliedTransform, genStepName());

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
@@ -56,12 +56,13 @@ class KeyedPValueTrackingVisitor implements PipelineVisitor {
   }
 
   @Override
-  public void enterCompositeTransform(TransformTreeNode node) {
+  public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
     checkState(
         !finalized,
         "Attempted to use a %s that has already been finalized on a pipeline (visiting node %s)",
         KeyedPValueTrackingVisitor.class.getSimpleName(),
         node);
+    return CompositeBehavior.ENTER_TRANSFORM;
   }
 
   @Override
@@ -79,7 +80,7 @@ class KeyedPValueTrackingVisitor implements PipelineVisitor {
   }
 
   @Override
-  public void visitTransform(TransformTreeNode node) {}
+  public void visitPrimitiveTransform(TransformTreeNode node) {}
 
   @Override
   public void visitValue(PValue value, TransformTreeNode producer) {

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkPipelineTranslator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkPipelineTranslator.java
@@ -28,7 +28,7 @@ import org.apache.beam.sdk.Pipeline;
  * a {@link org.apache.flink.streaming.api.datastream.DataStream} (for streaming) or a
  * {@link org.apache.flink.api.java.DataSet} (for batch) one.
  */
-public abstract class FlinkPipelineTranslator implements Pipeline.PipelineVisitor {
+public abstract class FlinkPipelineTranslator extends Pipeline.PipelineVisitor.Defaults {
 
   public void translate(Pipeline pipeline) {
     pipeline.traverseTopologically(this);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineRunner.java
@@ -680,17 +680,18 @@ public class DataflowPipelineRunner extends PipelineRunner<DataflowPipelineJob> 
         }
 
         @Override
-        public void visitTransform(TransformTreeNode node) {
+        public void visitPrimitiveTransform(TransformTreeNode node) {
           if (ptransformViewsWithNonDeterministicKeyCoders.contains(node.getTransform())) {
             ptransformViewNamesWithNonDeterministicKeyCoders.add(node.getFullName());
           }
         }
 
         @Override
-        public void enterCompositeTransform(TransformTreeNode node) {
+        public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
           if (ptransformViewsWithNonDeterministicKeyCoders.contains(node.getTransform())) {
             ptransformViewNamesWithNonDeterministicKeyCoders.add(node.getFullName());
           }
+          return CompositeBehavior.ENTER_TRANSFORM;
         }
 
         @Override

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -348,7 +348,7 @@ public class DataflowPipelineTranslator {
   /**
    * Translates a Pipeline into the Dataflow representation.
    */
-  class Translator implements PipelineVisitor, TranslationContext {
+  class Translator extends PipelineVisitor.Defaults implements TranslationContext {
     /** The Pipeline to translate. */
     private final Pipeline pipeline;
 
@@ -493,16 +493,13 @@ public class DataflowPipelineTranslator {
       return currentTransform;
     }
 
-    @Override
-    public void enterCompositeTransform(TransformTreeNode node) {
-    }
 
     @Override
     public void leaveCompositeTransform(TransformTreeNode node) {
     }
 
     @Override
-    public void visitTransform(TransformTreeNode node) {
+    public void visitPrimitiveTransform(TransformTreeNode node) {
       PTransform<?, ?> transform = node.getTransform();
       TransformTranslator translator =
           getTransformTranslator(transform.getClass());

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineRunnerTest.java
@@ -84,7 +84,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.PInput;
-import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
@@ -820,26 +819,15 @@ public class DataflowPipelineRunnerTest {
   }
 
   /** Records all the composite transforms visited within the Pipeline. */
-  private static class CompositeTransformRecorder implements PipelineVisitor {
+  private static class CompositeTransformRecorder extends PipelineVisitor.Defaults {
     private List<PTransform<?, ?>> transforms = new ArrayList<>();
 
     @Override
-    public void enterCompositeTransform(TransformTreeNode node) {
+    public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
       if (node.getTransform() != null) {
         transforms.add(node.getTransform());
       }
-    }
-
-    @Override
-    public void leaveCompositeTransform(TransformTreeNode node) {
-    }
-
-    @Override
-    public void visitTransform(TransformTreeNode node) {
-    }
-
-    @Override
-    public void visitValue(PValue value, TransformTreeNode producer) {
+      return CompositeBehavior.ENTER_TRANSFORM;
     }
 
     public List<PTransform<?, ?>> getCompositeTransforms() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -220,8 +220,10 @@ public class Pipeline {
     /**
      * Called for each composite transform after all topological predecessors have been visited
      * but before any of its component transforms.
+     *
+     * <p>The return value controls whether or not child transforms are visited.
      */
-    public void enterCompositeTransform(TransformTreeNode node);
+    public CompositeBehavior enterCompositeTransform(TransformTreeNode node);
 
     /**
      * Called for each composite transform after all of its component transforms and their outputs
@@ -233,13 +235,42 @@ public class Pipeline {
      * Called for each primitive transform after all of its topological predecessors
      * and inputs have been visited.
      */
-    public void visitTransform(TransformTreeNode node);
+    public void visitPrimitiveTransform(TransformTreeNode node);
 
     /**
      * Called for each value after the transform that produced the value has been
      * visited.
      */
     public void visitValue(PValue value, TransformTreeNode producer);
+
+    /**
+     * Control enum for indicating whether or not a traversal should process the contents of
+     * a composite transform or not.
+     */
+    public enum CompositeBehavior {
+      ENTER_TRANSFORM,
+      DO_NOT_ENTER_TRANSFORM;
+    }
+
+    /**
+     * Default no-op {@link PipelineVisitor} that enters all composite transforms.
+     * User implementations can override just those methods they are interested in.
+     */
+    public class Defaults implements PipelineVisitor {
+      @Override
+      public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
+        return CompositeBehavior.ENTER_TRANSFORM;
+      }
+
+      @Override
+      public void leaveCompositeTransform(TransformTreeNode node) { }
+
+      @Override
+      public void visitPrimitiveTransform(TransformTreeNode node) { }
+
+      @Override
+      public void visitValue(PValue value, TransformTreeNode producer) { }
+    }
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/AggregatorPipelineExtractor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/AggregatorPipelineExtractor.java
@@ -56,7 +56,7 @@ public class AggregatorPipelineExtractor {
     return aggregatorSteps.asMap();
   }
 
-  private static class AggregatorVisitor implements PipelineVisitor {
+  private static class AggregatorVisitor extends PipelineVisitor.Defaults {
     private final SetMultimap<Aggregator<?, ?>, PTransform<?, ?>> aggregatorSteps;
 
     public AggregatorVisitor(SetMultimap<Aggregator<?, ?>, PTransform<?, ?>> aggregatorSteps) {
@@ -64,13 +64,7 @@ public class AggregatorPipelineExtractor {
     }
 
     @Override
-    public void enterCompositeTransform(TransformTreeNode node) {}
-
-    @Override
-    public void leaveCompositeTransform(TransformTreeNode node) {}
-
-    @Override
-    public void visitTransform(TransformTreeNode node) {
+    public void visitPrimitiveTransform(TransformTreeNode node) {
       PTransform<?, ?> transform = node.getTransform();
       addStepToAggregators(transform, getAggregators(transform));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/DirectPipelineRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/DirectPipelineRunner.java
@@ -828,7 +828,7 @@ public class DirectPipelineRunner
 
   /////////////////////////////////////////////////////////////////////////////
 
-  class Evaluator implements PipelineVisitor, EvaluationContext {
+  class Evaluator extends PipelineVisitor.Defaults implements EvaluationContext {
     /**
      * A map from PTransform to the step name of that transform. This is the internal name for the
      * transform (e.g. "s2").
@@ -881,15 +881,7 @@ public class DirectPipelineRunner
     }
 
     @Override
-    public void enterCompositeTransform(TransformTreeNode node) {
-    }
-
-    @Override
-    public void leaveCompositeTransform(TransformTreeNode node) {
-    }
-
-    @Override
-    public void visitTransform(TransformTreeNode node) {
+    public void visitPrimitiveTransform(TransformTreeNode node) {
       PTransform<?, ?> transform = node.getTransform();
       fullNames.put(transform, node.getFullName());
       TransformEvaluator evaluator =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/RecordingPipelineVisitor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/RecordingPipelineVisitor.java
@@ -30,21 +30,13 @@ import java.util.List;
  *
  * <p>Provided for internal unit tests.
  */
-public class RecordingPipelineVisitor implements Pipeline.PipelineVisitor {
+public class RecordingPipelineVisitor extends Pipeline.PipelineVisitor.Defaults {
 
   public final List<PTransform<?, ?>> transforms = new ArrayList<>();
   public final List<PValue> values = new ArrayList<>();
 
   @Override
-  public void enterCompositeTransform(TransformTreeNode node) {
-  }
-
-  @Override
-  public void leaveCompositeTransform(TransformTreeNode node) {
-  }
-
-  @Override
-  public void visitTransform(TransformTreeNode node) {
+  public void visitPrimitiveTransform(TransformTreeNode node) {
     transforms.add(node.getTransform());
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformTreeNode.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformTreeNode.java
@@ -17,7 +17,8 @@
  */
 package org.apache.beam.sdk.runners;
 
-import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.Pipeline.PipelineVisitor;
+import org.apache.beam.sdk.Pipeline.PipelineVisitor.CompositeBehavior;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
@@ -198,7 +199,7 @@ public class TransformTreeNode {
    * transform (or child nodes for composite transforms), then the
    * output values.
    */
-  public void visit(Pipeline.PipelineVisitor visitor,
+  public void visit(PipelineVisitor visitor,
                     Set<PValue> visitedValues) {
     if (!finishedSpecifying) {
       finishSpecifying();
@@ -212,13 +213,16 @@ public class TransformTreeNode {
     }
 
     if (isCompositeNode()) {
-      visitor.enterCompositeTransform(this);
-      for (TransformTreeNode child : parts) {
-        child.visit(visitor, visitedValues);
+      PipelineVisitor.CompositeBehavior recurse = visitor.enterCompositeTransform(this);
+
+      if (recurse.equals(CompositeBehavior.ENTER_TRANSFORM)) {
+        for (TransformTreeNode child : parts) {
+          child.visit(visitor, visitedValues);
+        }
       }
       visitor.leaveCompositeTransform(this);
     } else {
-      visitor.visitTransform(this);
+      visitor.visitPrimitiveTransform(this);
     }
 
     // Visit outputs.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/AggregatorPipelineExtractorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/AggregatorPipelineExtractorTest.java
@@ -205,7 +205,7 @@ public class AggregatorPipelineExtractorTest {
     public Object answer(InvocationOnMock invocation) throws Throwable {
       PipelineVisitor visitor = (PipelineVisitor) invocation.getArguments()[0];
       for (TransformTreeNode node : nodes) {
-        visitor.visitTransform(node);
+        visitor.visitPrimitiveTransform(node);
       }
       return null;
     }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
This is to easily support wholesale replacement of composite transforms. The Flink and Spark runner already achieve this by tracking whether they are in a region of the Pipeline that should be ignored. I ported over the Spark runner to simplify it, but not the Flink runner, to get this PR out for feedback.