### PR TITLE
Fix AutoValue coverage exclusion for coveralls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
           </executions>
         <configuration>
           <excludes>
-            <exclude>**/AutoValue_*.java</exclude>
+            <exclude>**/AutoValue_*.class</exclude>
           </excludes>
         </configuration>
         </plugin>


### PR DESCRIPTION
#109 introduces AutoValue but breaks our coverage tooling. This should fix it, but let's wait for a green jenkins build before merge. 