### PR TITLE
[BEAM-215] Fix CreateSource#getBytesPerOffset

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -400,9 +400,9 @@ public class Create<T> {
       @Override
       public long getBytesPerOffset() {
         if (allElementsBytes.size() == 0) {
-          return 0L;
+          return 1L;
         }
-        return totalSize / allElementsBytes.size();
+        return Math.max(1, totalSize / allElementsBytes.size());
       }
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -51,6 +51,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
@@ -342,6 +343,25 @@ public class CreateTest {
     PipelineOptions options = PipelineOptionsFactory.create();
     List<? extends BoundedSource<Integer>> splitSources = source.splitIntoBundles(12, options);
     assertThat(splitSources, hasSize(3));
+    SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
+  }
+
+  @Test
+  public void testSourceSplitIntoBundlesVoid() throws Exception {
+    CreateSource<Void> source =
+        CreateSource.fromIterable(
+            Lists.<Void>newArrayList(null, null, null, null, null), VoidCoder.of());
+    PipelineOptions options = PipelineOptionsFactory.create();
+    List<? extends BoundedSource<Void>> splitSources = source.splitIntoBundles(3, options);
+    SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
+  }
+
+  @Test
+  public void testSourceSplitIntoBundlesEmpty() throws Exception {
+    CreateSource<Integer> source =
+        CreateSource.fromIterable(ImmutableList.<Integer>of(), BigEndianIntegerCoder.of());
+    PipelineOptions options = PipelineOptionsFactory.create();
+    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoBundles(12, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Return 1L when there are no elements, as the default value. Return 1L
when the total encoded size of all the elements is 0, for example when
using VoidCoder.
