### PR TITLE
[BEAM-220] fix flaky KafkaIO test

### DIFF
--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -58,6 +58,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -337,6 +338,18 @@ public class KafkaIOTest {
     }
   }
 
+  // Kafka records are read in a separate thread inside the reader. As a result advance() might not
+  // read any records even from the mock consumer, especially for the first record.
+  // This is a helper method to loop until we read a record.
+  private static void advanceOnce(UnboundedReader<?> reader) throws IOException {
+    int attempts = 0;
+    while (!reader.advance()) {
+      attempts++;
+      // very rarely will there be more than one attempts.
+      assertTrue("could not advance() even after 1000 attempts.", attempts < 1000);
+    }
+  }
+
   @Test
   public void testUnboundedSourceCheckpointMark() throws Exception {
     int numElements = 85; // 85 to make sure some partitions have more records than other.
@@ -350,16 +363,15 @@ public class KafkaIOTest {
 
     UnboundedReader<KafkaRecord<byte[], Long>> reader = source.createReader(null, null);
     final int numToSkip = 3;
-    // advance once:
-    assertTrue(reader.start());
 
-    // Advance the source numToSkip-1 elements and manually save state.
-    for (long l = 0; l < numToSkip - 1; ++l) {
-      assertTrue(reader.advance());
+    // advance numToSkip elements
+    for (long l = 0; l < numToSkip; ++l) {
+      if (l > 0 || !reader.start()) {
+        advanceOnce(reader);
+      }
     }
 
     // Confirm that we get the expected element in sequence before checkpointing.
-
     assertEquals(numToSkip - 1, (long) reader.getCurrent().getKV().getValue());
     assertEquals(numToSkip - 1, reader.getCurrentTimestamp().getMillis());
 
@@ -367,14 +379,15 @@ public class KafkaIOTest {
     KafkaCheckpointMark mark = CoderUtils.clone(
         source.getCheckpointMarkCoder(), (KafkaCheckpointMark) reader.getCheckpointMark());
     reader = source.createReader(null, mark);
-    assertTrue(reader.start());
 
     // Confirm that we get the next elements in sequence.
     // This also confirms that Reader interleaves records from each partitions by the reader.
     for (int i = numToSkip; i < numElements; i++) {
+      if (i > numToSkip || !reader.start()) {
+        advanceOnce(reader);
+      }
       assertEquals(i, (long) reader.getCurrent().getKV().getValue());
       assertEquals(i, reader.getCurrentTimestamp().getMillis());
-      reader.advance();
     }
   }
 }


### PR DESCRIPTION
Fix a flaky KafkaIO test.

KafkaIO reader reads from Kafka in a separate thread. As a result, `start()` or `advance()` might not read a record with in 10 millis timeout even from the mock kafka consumer. Updated one test that manually reads from KafkaIO reader to invoke `advance()` in a loop.

This should fix the flaky test. I am running these tests in a loop on my desktop to verify. One thing I can not explain is the following log from the failed jenkins build linked in BEAM-220 (the log was same when I reproduced it locally):

    Apr 22, 2016 7:04:10 AM org.apache.beam.sdk.io.kafka.KafkaIO$UnboundedKafkaReader advance
    INFO: Reader-0: first record offset 0

It is entirely clear if this is from the failed test, but `first record offset 0` implies the `start()` must have returned true.