### PR TITLE
Import blacklist

### DIFF
--- a/sdks/java/checkstyle.xml
+++ b/sdks/java/checkstyle.xml
@@ -122,6 +122,10 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="severity" value="error"/>
     </module>
 
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="com.google.api.client.repackaged"/>
+    </module>
+
     <module name="UnusedImports">
       <property name="severity" value="error"/>
       <property name="processJavadoc" value="true"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubClient.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubClient.java
@@ -18,7 +18,7 @@
 
 package org.apache.beam.sdk.io;
 
-import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -88,7 +88,7 @@ public interface PubsubClient extends AutoCloseable {
 
     public String getV1Beta1Path() {
       String[] splits = path.split("/");
-      Preconditions.checkState(splits.length == 4);
+      checkState(splits.length == 4);
       return String.format("/subscriptions/%s/%s", splits[1], splits[3]);
     }
 
@@ -136,7 +136,7 @@ public interface PubsubClient extends AutoCloseable {
 
     public String getV1Beta1Path() {
       String[] splits = path.split("/");
-      Preconditions.checkState(splits.length == 4);
+      checkState(splits.length == 4);
       return String.format("/topics/%s/%s", splits[1], splits[3]);
     }
 


### PR DESCRIPTION
Use checkstyle to catch the illegal import of repackaged Guava.

Caught one invalid use case.