### PR TITLE
[BEAM-222] Don't advance beyond last valid value

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSource.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSource.java
@@ -173,7 +173,7 @@ public class TestCountingSource
 
     @Override
     public boolean advance() {
-      if (current >= numMessagesPerShard) {
+      if (current >= numMessagesPerShard - 1) {
         return false;
       }
       // If testing dedup, occasionally insert a duplicate value;
@@ -181,7 +181,7 @@ public class TestCountingSource
         return true;
       }
       current++;
-      return current < numMessagesPerShard;
+      return true;
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSourceTest.java
@@ -53,4 +53,22 @@ public class TestCountingSourceTest {
     assertEquals(2L, (long) reader.getCurrent().getValue());
     assertFalse(reader.advance());
   }
+
+  @Test
+  public void testCanResumeWithExpandedCount() throws IOException {
+    TestCountingSource source = new TestCountingSource(1);
+    PipelineOptions options = PipelineOptionsFactory.create();
+    TestCountingSource.CountingSourceReader reader =
+        source.createReader(options, null /* no checkpoint */);
+    assertTrue(reader.start());
+    assertEquals(0L, (long) reader.getCurrent().getValue());
+    assertFalse(reader.advance());
+    TestCountingSource.CounterMark checkpoint = reader.getCheckpointMark();
+    checkpoint.finalizeCheckpoint();
+    source = new TestCountingSource(2);
+    reader = source.createReader(options, checkpoint);
+    assertTrue(reader.start());
+    assertEquals(1L, (long) reader.getCurrent().getValue());
+    assertFalse(reader.advance());
+  }
 }


### PR DESCRIPTION
Turns out there was a bug with allowing 'advanced beyond last element' to be a valid counter state.
Only an internal reload test caught it.
Included unit test for that case.