### PR TITLE
[BEAM-22] Return a map of CommittedBundle to Consumers from handleResult

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/CompletionCallback.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/CompletionCallback.java
@@ -18,15 +18,20 @@
 package org.apache.beam.sdk.runners.inprocess;
 
 import org.apache.beam.sdk.runners.inprocess.InProcessPipelineRunner.CommittedBundle;
+import org.apache.beam.sdk.transforms.AppliedPTransform;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * A callback for completing a bundle of input.
  */
 interface CompletionCallback {
   /**
-   * Handle a successful result, returning the committed outputs of the result.
+   * Handle a successful result, returning the committed outputs of the result and the transforms
+   * that should consume those outputs.
    */
-  Iterable<? extends CommittedBundle<?>> handleResult(
+  Map<? extends CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> handleResult(
       CommittedBundle<?> inputBundle, InProcessTransformResult result);
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InMemoryWatermarkManager.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InMemoryWatermarkManager.java
@@ -808,7 +808,7 @@ public class InMemoryWatermarkManager {
       @Nullable CommittedBundle<?> completed,
       AppliedPTransform<?, ?, ?> transform,
       TimerUpdate timerUpdate,
-      Iterable<? extends CommittedBundle<?>> outputs,
+      Map<? extends CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> outputs,
       @Nullable Instant earliestHold) {
     updatePending(completed, transform, timerUpdate, outputs);
     TransformWatermarks transformWms = transformToWatermarks.get(transform);
@@ -841,15 +841,17 @@ public class InMemoryWatermarkManager {
       CommittedBundle<?> input,
       AppliedPTransform<?, ?, ?> transform,
       TimerUpdate timerUpdate,
-      Iterable<? extends CommittedBundle<?>> outputs) {
+      Map<? extends CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> outputs) {
     TransformWatermarks completedTransform = transformToWatermarks.get(transform);
     completedTransform.updateTimers(timerUpdate);
     if (input != null) {
       completedTransform.removePending(input);
     }
 
-    for (CommittedBundle<?> bundle : outputs) {
-      for (AppliedPTransform<?, ?, ?> consumer : consumers.get(bundle.getPCollection())) {
+    for (Map.Entry<? extends CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>>
+        outputEntry : outputs.entrySet()) {
+      CommittedBundle<?> bundle = outputEntry.getKey();
+      for (AppliedPTransform<?, ?, ?> consumer : outputEntry.getValue()) {
         TransformWatermarks watermarks = transformToWatermarks.get(consumer);
         watermarks.addPending(bundle);
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessEvaluationContext.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessEvaluationContext.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PValue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import java.util.Collection;
@@ -74,6 +75,11 @@ import javax.annotation.Nullable;
 class InProcessEvaluationContext {
   /** The step name for each {@link AppliedPTransform} in the {@link Pipeline}. */
   private final Map<AppliedPTransform<?, ?, ?>, String> stepNames;
+  /**
+   * The mapping from each {@link PValue} contained within the {@link Pipeline} to each
+   * {@link AppliedPTransform} that consumes it.
+   */
+  private final Map<PValue, Collection<AppliedPTransform<?, ?, ?>>> valueToConsumers;
 
   /** The options that were used to create this {@link Pipeline}. */
   private final InProcessPipelineOptions options;
@@ -114,7 +120,7 @@ class InProcessEvaluationContext {
     this.options = checkNotNull(options);
     this.bundleFactory = checkNotNull(bundleFactory);
     checkNotNull(rootTransforms);
-    checkNotNull(valueToConsumers);
+    this.valueToConsumers = checkNotNull(valueToConsumers);
     checkNotNull(stepNames);
     checkNotNull(views);
     this.stepNames = stepNames;
@@ -145,11 +151,11 @@ class InProcessEvaluationContext {
    * @param result the result of evaluating the input bundle
    * @return the committed bundles contained within the handled {@code result}
    */
-  public synchronized Iterable<? extends CommittedBundle<?>> handleResult(
+  public synchronized Map<CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> handleResult(
       @Nullable CommittedBundle<?> completedBundle,
       Iterable<TimerData> completedTimers,
       InProcessTransformResult result) {
-    Iterable<? extends CommittedBundle<?>> committedBundles =
+    Map<CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> committedBundles =
         commitBundles(result.getOutputBundles());
     // Update watermarks and timers
     watermarkManager.updateWatermarks(
@@ -179,10 +185,11 @@ class InProcessEvaluationContext {
     return committedBundles;
   }
 
-  private Iterable<? extends CommittedBundle<?>> commitBundles(
-      Iterable<? extends UncommittedBundle<?>> bundles) {
-    ImmutableList.Builder<CommittedBundle<?>> completed = ImmutableList.builder();
-    for (UncommittedBundle<?> inProgress : bundles) {
+  private Map<CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> commitBundles(
+        Iterable<? extends UncommittedBundle<?>> outputBundles) {
+    ImmutableMap.Builder<CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> outputs
+        = ImmutableMap.builder();
+    for (UncommittedBundle<?> inProgress : outputBundles) {
       AppliedPTransform<?, ?, ?> producing =
           inProgress.getPCollection().getProducingTransformInternal();
       TransformWatermarks watermarks = watermarkManager.getWatermarks(producing);
@@ -191,10 +198,10 @@ class InProcessEvaluationContext {
       // Empty bundles don't impact watermarks and shouldn't trigger downstream execution, so
       // filter them out
       if (!Iterables.isEmpty(committed.getElements())) {
-        completed.add(committed);
+        outputs.put(committed, valueToConsumers.get(committed.getPCollection()));
       }
     }
-    return completed.build();
+    return outputs.build();
   }
 
   private void fireAllAvailableCallbacks() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessPipelineRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/InProcessPipelineRunner.java
@@ -239,7 +239,6 @@ public class InProcessPipelineRunner
     InProcessExecutor executor =
         ExecutorServiceParallelExecutor.create(
             executorService,
-            consumerTrackingVisitor.getValueToConsumers(),
             keyedPValueVisitor.getKeyedPValues(),
             TransformEvaluatorRegistry.defaultRegistry(),
             defaultModelEnforcements(options),

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/TransformExecutor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/TransformExecutor.java
@@ -27,6 +27,7 @@ import com.google.common.base.Throwables;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -158,9 +159,10 @@ class TransformExecutor<T> implements Callable<InProcessTransformResult> {
       TransformEvaluator<T> evaluator, Collection<ModelEnforcement<T>> enforcements)
       throws Exception {
     InProcessTransformResult result = evaluator.finishBundle();
-    Iterable<? extends CommittedBundle<?>> outputs = onComplete.handleResult(inputBundle, result);
+    Map<? extends CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> outputs =
+        onComplete.handleResult(inputBundle, result);
     for (ModelEnforcement<T> enforcement : enforcements) {
-      enforcement.afterFinish(inputBundle, result, outputs);
+      enforcement.afterFinish(inputBundle, result, outputs.keySet());
     }
     return result;
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/inprocess/InProcessEvaluationContextTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/inprocess/InProcessEvaluationContextTest.java
@@ -460,7 +460,7 @@ public class InProcessEvaluationContextTest {
 
     UncommittedBundle<Integer> rootBundle = context.createRootBundle(created);
     rootBundle.add(WindowedValue.valueInGlobalWindow(1));
-    Iterable<? extends CommittedBundle<?>> handleResult =
+    Map<CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> handleResult =
         context.handleResult(
             null,
             ImmutableList.<TimerData>of(),
@@ -469,7 +469,7 @@ public class InProcessEvaluationContextTest {
                 .build());
     @SuppressWarnings("unchecked")
     CommittedBundle<Integer> committedBundle =
-        (CommittedBundle<Integer>) Iterables.getOnlyElement(handleResult);
+        (CommittedBundle<Integer>) Iterables.getOnlyElement(handleResult.keySet());
     context.handleResult(
         null,
         ImmutableList.<TimerData>of(),

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/inprocess/TransformExecutorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/inprocess/TransformExecutorTest.java
@@ -487,11 +487,11 @@ public class TransformExecutorTest {
     }
 
     @Override
-    public Iterable<? extends CommittedBundle<?>> handleResult(
+    public Map<CommittedBundle<?>, Collection<AppliedPTransform<?, ?, ?>>> handleResult(
         CommittedBundle<?> inputBundle, InProcessTransformResult result) {
       handledResult = result;
       onMethod.countDown();
-      return Collections.emptyList();
+      return Collections.emptyMap();
     }
 
     @Override


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This allows the executor to be ignorant of the mapping from PValue to
Consumers, as well as allowing the TransformExecutor to pass bundles
that should only be consumed by specific PTransforms. This can occur if
a transform is incapable of processing a bundle.

This lets us schedule unprocessed elements (caused, for example, by a
side input that is not ready) by placing them back on the work queue to be
consumed only by the transform that was not ready.