### PR TITLE
[BEAM-22] Remove redundant close in BoundedReadEvaluatorFactory

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/BoundedReadEvaluatorFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/inprocess/BoundedReadEvaluatorFactory.java
@@ -146,7 +146,6 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
                   reader.getCurrent(), reader.getCurrentTimestamp()));
           contentsRemaining = reader.advance();
         }
-        reader.close();
         return StepTransformResult.withHold(transform, BoundedWindow.TIMESTAMP_MAX_VALUE)
             .addOutput(output)
             .build();


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The reader is already closed by virtue of being the target of the
try-with-resources block that encompasses all of #finishBundle().

Calling close on the reader twice causes KafkaIO to throw an exception.