### PR TITLE
[BEAM-52] KafkaIO sink support

### DIFF
--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -18,8 +18,12 @@
 package org.apache.beam.sdk.io.kafka;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
+import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.UnboundedSource;
@@ -49,20 +53,31 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.joda.time.Instant;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nullable;
 
@@ -78,6 +93,9 @@ public class KafkaIOTest {
    * Other tests to consider :
    *   - test KafkaRecordCoder
    */
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   // Update mock consumer with records distributed among the given topics, each with given number
   // of partitions. Records are assigned in round-robin order among the partitions.
@@ -113,8 +131,8 @@ public class KafkaIOTest {
               tp.topic(),
               tp.partition(),
               offsets[pIdx]++,
-              null, // key
-              ByteBuffer.wrap(new byte[8]).putLong(i).array())); // value is 8 byte record id.
+              ByteBuffer.wrap(new byte[8]).putInt(i).array(),    // key is 4 byte record id
+              ByteBuffer.wrap(new byte[8]).putLong(i).array())); // value is 8 byte record id
     }
 
     MockConsumer<byte[], byte[]> consumer =
@@ -161,16 +179,17 @@ public class KafkaIOTest {
    * Creates a consumer with two topics, with 5 partitions each.
    * numElements are (round-robin) assigned all the 10 partitions.
    */
-  private static KafkaIO.TypedRead<byte[], Long> mkKafkaReadTransform(
+  private static KafkaIO.TypedRead<Integer, Long> mkKafkaReadTransform(
       int numElements,
-      @Nullable SerializableFunction<KV<byte[], Long>, Instant> timestampFn) {
+      @Nullable SerializableFunction<KV<Integer, Long>, Instant> timestampFn) {
 
     List<String> topics = ImmutableList.of("topic_a", "topic_b");
 
-    KafkaIO.Read<byte[], Long> reader = KafkaIO.read()
+    KafkaIO.Read<Integer, Long> reader = KafkaIO.read()
         .withBootstrapServers("none")
         .withTopics(topics)
         .withConsumerFactoryFn(new ConsumerFactoryFn(topics, 10, numElements)) // 20 partitions
+        .withKeyCoder(BigEndianIntegerCoder.of())
         .withValueCoder(BigEndianLongCoder.of())
         .withMaxNumRecords(numElements);
 
@@ -305,9 +324,9 @@ public class KafkaIOTest {
     int numElements = 1000;
     int numSplits = 10;
 
-    UnboundedSource<KafkaRecord<byte[], Long>, ?> initial =
+    UnboundedSource<KafkaRecord<Integer, Long>, ?> initial =
         mkKafkaReadTransform(numElements, null).makeSource();
-    List<? extends UnboundedSource<KafkaRecord<byte[], Long>, ?>> splits =
+    List<? extends UnboundedSource<KafkaRecord<Integer, Long>, ?>> splits =
         initial.generateInitialSplits(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
@@ -317,7 +336,7 @@ public class KafkaIOTest {
     for (int i = 0; i < splits.size(); ++i) {
       pcollections = pcollections.and(
           p.apply("split" + i, Read.from(splits.get(i)).withMaxNumRecords(elementsPerSplit))
-           .apply("Remove Metadata " + i, ParDo.of(new RemoveKafkaMetadata<byte[], Long>()))
+           .apply("Remove Metadata " + i, ParDo.of(new RemoveKafkaMetadata<Integer, Long>()))
            .apply("collection " + i, Values.<Long>create()));
     }
     PCollection<Long> input = pcollections.apply(Flatten.<Long>pCollections());
@@ -330,9 +349,9 @@ public class KafkaIOTest {
    * A timestamp function that uses the given value as the timestamp.
    */
   private static class ValueAsTimestampFn
-                       implements SerializableFunction<KV<byte[], Long>, Instant> {
+                       implements SerializableFunction<KV<Integer, Long>, Instant> {
     @Override
-    public Instant apply(KV<byte[], Long> input) {
+    public Instant apply(KV<Integer, Long> input) {
       return new Instant(input.getValue());
     }
   }
@@ -352,13 +371,13 @@ public class KafkaIOTest {
     int numElements = 85; // 85 to make sure some partitions have more records than other.
 
     // create a single split:
-    UnboundedSource<KafkaRecord<byte[], Long>, KafkaCheckpointMark> source =
+    UnboundedSource<KafkaRecord<Integer, Long>, KafkaCheckpointMark> source =
         mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
           .makeSource()
           .generateInitialSplits(1, PipelineOptionsFactory.fromArgs(new String[0]).create())
           .get(0);
 
-    UnboundedReader<KafkaRecord<byte[], Long>> reader = source.createReader(null, null);
+    UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
     final int numToSkip = 3;
 
     // advance numToSkip elements
@@ -391,6 +410,263 @@ public class KafkaIOTest {
       assertEquals(i, reader.getCurrentTimestamp().getMillis());
       if ((i + 1) < numElements) {
         advanceOnce(reader);
+      }
+    }
+  }
+
+  @Test
+  public void testSink() throws Exception {
+    // Simply read from kafka source and write to kafka sink. Then verify the records
+    // are correctly published to mock kafka producer.
+
+    int numElements = 1000;
+
+    synchronized (MOCK_PRODUCER_LOCK) {
+
+      MOCK_PRODUCER.clear();
+
+      ProducerSendCompletionThread completionThread = new ProducerSendCompletionThread().start();
+
+      Pipeline pipeline = TestPipeline.create();
+      String topic = "test";
+
+      pipeline
+        .apply(mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
+            .withoutMetadata())
+        .apply(KafkaIO.write()
+            .withBootstrapServers("none")
+            .withTopic(topic)
+            .withKeyCoder(BigEndianIntegerCoder.of())
+            .withValueCoder(BigEndianLongCoder.of())
+            .withProducerFactoryFn(new ProducerFactoryFn()));
+
+      pipeline.run();
+
+      completionThread.shutdown();
+
+      verifyProducerRecords(topic, numElements, false);
+     }
+  }
+
+  @Test
+  public void testValuesSink() throws Exception {
+    // similar to testSink(), but use values()' interface.
+
+    int numElements = 1000;
+
+    synchronized (MOCK_PRODUCER_LOCK) {
+
+      MOCK_PRODUCER.clear();
+
+      ProducerSendCompletionThread completionThread = new ProducerSendCompletionThread().start();
+
+      Pipeline pipeline = TestPipeline.create();
+      String topic = "test";
+
+      pipeline
+        .apply(mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
+            .withoutMetadata())
+        .apply(Values.<Long>create()) // there are no keys
+        .apply(KafkaIO.write()
+            .withBootstrapServers("none")
+            .withTopic(topic)
+            .withKeyCoder(BigEndianIntegerCoder.of())
+            .withValueCoder(BigEndianLongCoder.of())
+            .withProducerFactoryFn(new ProducerFactoryFn())
+            .values());
+
+      pipeline.run();
+
+      completionThread.shutdown();
+
+      verifyProducerRecords(topic, numElements, true);
+    }
+  }
+
+  @Test
+  public void testSinkWithSendErrors() throws Throwable {
+    // similar to testSink(), except that up to 10 of the send calls to producer will fail
+    // asynchronously.
+
+    // TODO: Ideally we want the pipeline to run to completion by retrying bundles that fail.
+    // We limit the number of errors injected to 10 below. This would reflect a real streaming
+    // pipeline. But I am sure how to achieve that. For now expect an exception:
+
+    thrown.expect(InjectedErrorException.class);
+    thrown.expectMessage("Injected Error #1");
+
+    int numElements = 1000;
+
+    synchronized (MOCK_PRODUCER_LOCK) {
+
+      MOCK_PRODUCER.clear();
+
+      Pipeline pipeline = TestPipeline.create();
+      String topic = "test";
+
+      ProducerSendCompletionThread completionThreadWithErrors =
+          new ProducerSendCompletionThread(10, 100).start();
+
+      pipeline
+        .apply(mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
+            .withoutMetadata())
+        .apply(KafkaIO.write()
+            .withBootstrapServers("none")
+            .withTopic(topic)
+            .withKeyCoder(BigEndianIntegerCoder.of())
+            .withValueCoder(BigEndianLongCoder.of())
+            .withProducerFactoryFn(new ProducerFactoryFn()));
+
+      try {
+        pipeline.run();
+      } catch (PipelineExecutionException e) {
+        // throwing inner exception helps assert that first exception is thrown from the Sink
+        throw e.getCause().getCause();
+      } finally {
+        completionThreadWithErrors.shutdown();
+      }
+    }
+  }
+
+  private static void verifyProducerRecords(String topic, int numElements, boolean keyIsAbsent) {
+
+    // verify that appropriate messages are written to kafka
+    List<ProducerRecord<Integer, Long>> sent = MOCK_PRODUCER.history();
+
+    // sort by values
+    Collections.sort(sent, new Comparator<ProducerRecord<Integer, Long>>() {
+      @Override
+      public int compare(ProducerRecord<Integer, Long> o1, ProducerRecord<Integer, Long> o2) {
+        return Long.compare(o1.value(), o2.value());
+      }
+    });
+
+    for (int i = 0; i < numElements; i++) {
+      ProducerRecord<Integer, Long> record = sent.get(i);
+      assertEquals(topic, record.topic());
+      if (keyIsAbsent) {
+        assertNull(record.key());
+      } else {
+        assertEquals(i, record.key().intValue());
+      }
+      assertEquals(i, record.value().longValue());
+    }
+  }
+
+  /**
+   * Singleton MockProudcer. Using a singleton here since we need access to the object to fetch
+   * the actual records published to the producer. This prohibits running the tests using
+   * the producer in parallel, but there are only one or two tests.
+   */
+  private static final MockProducer<Integer, Long> MOCK_PRODUCER =
+    new MockProducer<Integer, Long>(
+      false, // disable synchronous completion of send. see ProducerSendCompletionThread below.
+      new KafkaIO.CoderBasedKafkaSerializer<Integer>(),
+      new KafkaIO.CoderBasedKafkaSerializer<Long>()) {
+
+      // override flush() so that it does not complete all the waiting sends, giving a chance to
+      // ProducerCompletionThread to inject errors.
+
+      @Override
+      public void flush() {
+        while (completeNext()) {
+          // there are some uncompleted records. let the completion thread handle them.
+          try {
+            Thread.sleep(10);
+          } catch (InterruptedException e) {
+          }
+        }
+      }
+    };
+
+  // use a separate object serialize tests using MOCK_PRODUCER so that we don't interfere
+  // with Kafka MockProducer locking itself.
+  private static final Object MOCK_PRODUCER_LOCK = new Object();
+
+  private static class ProducerFactoryFn
+    implements SerializableFunction<Map<String, Object>, Producer<Integer, Long>> {
+
+    @Override
+    public Producer<Integer, Long> apply(Map<String, Object> config) {
+      return MOCK_PRODUCER;
+    }
+  }
+
+  private static class InjectedErrorException extends RuntimeException {
+    public InjectedErrorException(String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * We start MockProducer with auto-completion disabled. That implies a record is not marked sent
+   * until #completeNext() is called on it. This class starts a thread to asynchronously 'complete'
+   * the the sends. During completion, we can also make those requests fail. This error injection
+   * is used in one of the tests.
+   */
+  private static class ProducerSendCompletionThread {
+
+    private final int maxErrors;
+    private final int errorFrequency;
+    private final AtomicBoolean done = new AtomicBoolean(false);
+    private final ExecutorService injectorThread;
+    private int numCompletions = 0;
+
+    ProducerSendCompletionThread() {
+      // complete everything successfully
+      this(0, 0);
+    }
+
+    ProducerSendCompletionThread(final int maxErrors, final int errorFrequency) {
+      this.maxErrors = maxErrors;
+      this.errorFrequency = errorFrequency;
+      injectorThread = Executors.newSingleThreadExecutor();
+    }
+
+    ProducerSendCompletionThread start() {
+      injectorThread.submit(new Runnable() {
+        @Override
+        public void run() {
+          int errorsInjected = 0;
+
+          while (!done.get()) {
+            boolean successful;
+
+            if (errorsInjected < maxErrors && ((numCompletions + 1) % errorFrequency) == 0) {
+              successful = MOCK_PRODUCER.errorNext(
+                  new InjectedErrorException("Injected Error #" + (errorsInjected + 1)));
+
+              if (successful) {
+                errorsInjected++;
+              }
+            } else {
+              successful = MOCK_PRODUCER.completeNext();
+            }
+
+            if (successful) {
+              numCompletions++;
+            } else {
+              // wait a bit since there are no unsent records
+              try {
+                Thread.sleep(1);
+              } catch (InterruptedException e) {
+              }
+            }
+          }
+        }
+      });
+
+      return this;
+    }
+
+    void shutdown() {
+      done.set(true);
+      injectorThread.shutdown();
+      try {
+        assertTrue(injectorThread.awaitTermination(10, TimeUnit.SECONDS));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
       }
     }
   }


### PR DESCRIPTION
Added sink/write support in KafkaIO. The interface is similar to KafkaIO source. `KafkaIO.write()` returns a transform that writes the records to a Kafka topic.

TODO:

- [x] decide on caching scheme for producer
- [x] decide on what we want to do with Kafka write failures
- [x] fix coder issue with KafkaValueWriter (unit test disabled)