### PR TITLE
[BEAM-168] IntervalBEB: remove deprecated function

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IntervalBoundedExponentialBackOff.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IntervalBoundedExponentialBackOff.java
@@ -54,12 +54,6 @@ public class IntervalBoundedExponentialBackOff implements BackOff {
   private final long initialIntervalMillis;
   private int currentAttempt;
 
-  // BEAM-168: https://issues.apache.org/jira/browse/BEAM-168
-  @Deprecated
-  public IntervalBoundedExponentialBackOff(int maximumIntervalMillis, long initialIntervalMillis) {
-    this((long) maximumIntervalMillis, initialIntervalMillis);
-  }
-
   public IntervalBoundedExponentialBackOff(long maximumIntervalMillis, long initialIntervalMillis) {
     Preconditions.checkArgument(
         maximumIntervalMillis > 0, "Maximum interval must be greater than zero.");


### PR DESCRIPTION
The pre-commit wordcount test will confirm that this does not break the
Cloud Dataflow worker.

This resolves BEAM-168.