### PR TITLE
Removes spurious re-builds of sdks/java/core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -674,6 +674,9 @@
             <showWarnings>true</showWarnings>
             <!-- Another temp override, to be set to true in due course. -->
             <showDeprecation>false</showDeprecation>
+            <excludes>
+              <exclude>**/package-info.java</exclude>
+            </excludes>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -689,6 +689,13 @@
               </goals>
             </execution>
           </executions>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Build-timestamp>${timestamp}</Build-timestamp>
+              </manifestEntries>
+            </archive>
+          </configuration>
         </plugin>
 
         <plugin>

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineRunnerTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -399,6 +400,17 @@ public class DataflowPipelineRunnerTest {
     assertEquals(
         ReleaseInfo.getReleaseInfo().getVersion(),
         workflowJob.getEnvironment().getUserAgent().get("version"));
+
+    // The version should not be unknown, as the SDK should be in a separate jar
+    assertNotEquals(
+        ReleaseInfo.getReleaseInfo().getVersion(),
+        ReleaseInfo.UNKNOWN_VERSION_STRING);
+
+    // We should know what SDK we have depended upon, since we put it in the user agent string
+    assertNotNull(ReleaseInfo.getReleaseInfo().getBuildTimestamp());
+    assertEquals(
+        ReleaseInfo.getReleaseInfo().getBuildTimestamp(),
+        workflowJob.getEnvironment().getUserAgent().get("build.date"));
   }
 
   @Test

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ReleaseInfo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ReleaseInfo.java
@@ -24,8 +24,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import javax.annotation.Nullable;
 
 /**
  * Utilities for working with release information.
@@ -33,56 +37,77 @@ import java.util.Properties;
 public final class ReleaseInfo extends GenericJson {
   private static final Logger LOG = LoggerFactory.getLogger(ReleaseInfo.class);
 
-  private static final String PROPERTIES_PATH =
-      "/org/apache/beam/sdk/sdk.properties";
+  private static final String MANIFEST_TIMESTAMP_ATTRIBUTE = "Build-timestamp";
 
   private static class LazyInit {
-    private static final ReleaseInfo INSTANCE =
-        new ReleaseInfo(PROPERTIES_PATH);
+    private static final ReleaseInfo INSTANCE = new ReleaseInfo();
   }
 
   /**
-   * Returns an instance of DataflowReleaseInfo.
+   * The string that will be used as a version if none can be ascertained.
+   */
+  public static final String UNKNOWN_VERSION_STRING = "Unknown";
+
+  /**
+   * Returns an instance of {@link ReleaseInfo}.
    */
   public static ReleaseInfo getReleaseInfo() {
     return LazyInit.INSTANCE;
   }
 
   @Key private String name = "Apache Beam SDK for Java";
-  @Key private String version = "Unknown";
+  @Key private String version = UNKNOWN_VERSION_STRING;
+  @Nullable @Key("build.date") private String timestamp = null;
 
   /** Provides the SDK name. */
   public String getName() {
     return name;
   }
 
-  /** Provides the SDK version. */
+  /**
+   * The version of the packaged artifact for the core Apache Beam Java SDK, or
+   * {@link #UNKNOWN_VERSION_STRING} if unknown.
+   *
+   * <p>
+   * This should only be unknown if the class is used outside of a built artifact.
+   */
   public String getVersion() {
     return version;
   }
 
-  private ReleaseInfo(String resourcePath) {
-    Properties properties = new Properties();
+  /**
+   * The build time of the packaged artifact for the core Apache Beam Java SDK, or {@code null} if
+   * unknown.
+   *
+   * <p>
+   * This should only be {@code null} if the class is used outside of a built artifact.
+   */
+  @Nullable
+  public String getBuildTimestamp() {
+    return timestamp;
+  }
 
-    InputStream in = ReleaseInfo.class.getResourceAsStream(
-        PROPERTIES_PATH);
-    if (in == null) {
-      LOG.warn("Dataflow properties resource not found: {}", resourcePath);
+  private ReleaseInfo() {
+    // This may not actually be a jar; in that case we cannot learn anything from the manifest
+    URL jarLocation = getClass().getProtectionDomain().getCodeSource().getLocation();
+
+    // Get the version via standard channels
+    @Nullable String maybeVersion = getClass().getPackage().getImplementationVersion();
+    if (maybeVersion != null) {
+      version = maybeVersion;
+    }
+
+    // Read the timestamp, which is a custom manifest entry
+    Manifest manifest;
+    try (JarFile jarFile = new JarFile(jarLocation.toURI().getPath())) {
+      manifest = jarFile.getManifest();
+    } catch (IOException exc) {
+      LOG.warn("Beam SDK jar manifest not found at " + jarLocation, exc);
+      return;
+    } catch (URISyntaxException exc) {
+      LOG.warn("Beam SDK code location appears to be invalid at " + jarLocation, exc);
       return;
     }
-
-    try {
-      properties.load(in);
-    } catch (IOException e) {
-      LOG.warn("Error loading Dataflow properties resource: ", e);
-    }
-
-    for (String name : properties.stringPropertyNames()) {
-      if (name.equals("name")) {
-        // We don't allow the properties to override the SDK name.
-        continue;
-      }
-      put(name, properties.getProperty(name));
-    }
+    timestamp = manifest.getMainAttributes().getValue(MANIFEST_TIMESTAMP_ATTRIBUTE);
   }
 }

--- a/sdks/java/core/src/main/resources/org/apache/beam/sdk/sdk.properties
+++ b/sdks/java/core/src/main/resources/org/apache/beam/sdk/sdk.properties
@@ -1,5 +1,0 @@
-# SDK source version.
-version=${pom.version}
-
-build.date=${timestamp}
-

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -36,7 +36,6 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.util.ReleaseInfo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -1005,12 +1004,15 @@ public class BigtableIO {
    */
   private static String getUserAgent() {
     String javaVersion = System.getProperty("java.specification.version");
-    ReleaseInfo info = ReleaseInfo.getReleaseInfo();
     return String.format(
-        "%s/%s (%s); %s",
-        info.getName(),
-        info.getVersion(),
-        javaVersion,
-        "0.2.3" /* TODO get Bigtable client version directly from jar. */);
+        "%s/%s %s/%s %s/%s java/%s",
+        org.apache.beam.sdk.io.gcp.bigtable.ReleaseInfo.getReleaseInfo().getName(),
+        org.apache.beam.sdk.io.gcp.bigtable.ReleaseInfo.getReleaseInfo().getVersion(),
+        org.apache.beam.sdk.util.ReleaseInfo.getReleaseInfo().getName(),
+        org.apache.beam.sdk.util.ReleaseInfo.getReleaseInfo().getVersion(),
+        BigtableOptions.class.getPackage().getName(),
+        // TODO: get this programmatically; can't use ReleaseInfo naively since it is repackaged
+        "0.2.3",
+        javaVersion);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/ReleaseInfo.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/ReleaseInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigtable;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utilities for working with release information.
+ */
+public final class ReleaseInfo {
+
+  private static final ReleaseInfo INSTANCE = new ReleaseInfo();
+
+  /**
+   * Returns the release info of the distributed artifact for the Apache Beam GCP connectors, or
+   * {@code null} if unknown.
+   */
+  public static ReleaseInfo getReleaseInfo() {
+    return INSTANCE;
+  }
+
+  private ReleaseInfo() { }
+
+  /**
+   * The name of the root java package for the Apache Beam GCP connectors.
+   */
+  public String getName() {
+    return ReleaseInfo.class.getPackage().getName();
+  }
+
+  /**
+   * The version of the distributed artifact for the Apache Beam GCP connectors, or {@code null}
+   * if unknown.
+   *
+   * <p>This should only be {@code null} if the class is used outside of a built artifact.
+   */
+  @Nullable public String getVersion() {
+    return ReleaseInfo.class.getPackage().getImplementationVersion();
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

We mutate a source file during maven pre-processing, so the build is always stale. It seems we want to have a timestamp in the jar. We need to find a better way to do this anyhow so the build isn't always rebuilding pointlessly.

After fixing that, I discovered [MCOMPILER-205](https://issues.apache.org/jira/browse/MCOMPILER-205) which needs a workaround for our `package-info.java` that exist just for javadoc.