### PR TITLE
Suppress spurious SDK builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,13 @@
               <!-- Uncomment the following args to display more warnings. -->
               <!-- -Xmaxwarns -->
               <!-- 10000 -->
+              <!-- 
+                Compile any non-empty package-info.java so Maven does not 
+                rebuild spuriously. Note that prior to JDK 8, the 
+                -Xpkginfo:always flag throws a NullPointerException 
+                (compiler bug) so it cannot be used.
+              -->
+              <arg>-Xpkginfo:nonempty</arg>
             </compilerArgs>
             <showWarnings>true</showWarnings>
             <!-- Another temp override, to be set to true in due course. -->

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -120,6 +120,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>src/main/resources/sdk.properties</exclude>
+          </excludes>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This is a low tech solution that mostly keeps the status quo but seems to eliminate the extra builds. The current method won't work if the SDK is ever shaded, since it depends on absolute paths in magic strings, but this PR doesn't try to solve that problem.