### PR TITLE
fix ConcurrentModificationException in KafkaIO

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1054,7 +1054,7 @@ public class KafkaIO {
 
         consumer.wakeup();
         offsetConsumer.wakeup();
-        availableRecordsQueue.poll();// drain unread batch, this unblocks consumer thread.
+        availableRecordsQueue.poll(); // drain unread batch, this unblocks consumer thread.
         try {
           isShutdown = consumerPollThread.awaitTermination(10, TimeUnit.SECONDS)
               && offsetFetcherThread.awaitTermination(10, TimeUnit.SECONDS);

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -796,7 +796,7 @@ public class KafkaIO {
       while (!closed.get()) {
         try {
           ConsumerRecords<byte[], byte[]> records = consumer.poll(KAFKA_POLL_TIMEOUT.getMillis());
-          if (!records.isEmpty()) {
+          if (!records.isEmpty() && !closed.get()) {
             availableRecordsQueue.put(records); // blocks until dequeued.
           }
         } catch (InterruptedException e) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -818,6 +818,7 @@ public class KafkaIO {
         records = availableRecordsQueue.poll(NEW_RECORDS_POLL_TIMEOUT.getMillis(),
                                              TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         LOG.warn("{}: Unexpected", this, e);
         return;
       }
@@ -1059,6 +1060,7 @@ public class KafkaIO {
           isShutdown = consumerPollThread.awaitTermination(10, TimeUnit.SECONDS)
               && offsetFetcherThread.awaitTermination(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           throw new RuntimeException(e); // not expected
         }
 


### PR DESCRIPTION
- after shutting down, wait for the threads to actually finish.
- handle a possible race between poll thread and close().