### PR TITLE
Add wildcard to checkstyle ordering

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -97,7 +97,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <!-- Checks for out of order import statements. -->
 
       <property name="severity" value="error"/>
-      <property name="groups" value="org.apache.beam,com.google,android,com,io,Jama,junit,net,org,sun,java,javax"/>
+      <property name="groups" value="org.apache.beam,com.google,android,com,io,Jama,junit,net,org,sun,*,java,javax"/>
       <!-- This ensures that static imports go first. -->
       <property name="option" value="top"/>
       <property name="tokens" value="STATIC_IMPORT, IMPORT"/>


### PR DESCRIPTION
Add wildcard to checkstyle, to handle unexpected package prefixes.  These should still be ordered before the sun and java packages.