### PR TITLE
 [BEAM-145] [BEAM-34] Make WindowingStrategy combine WindowFn with OutputTimeFn

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/FlinkGroupAlsoByWindowWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/FlinkGroupAlsoByWindowWrapper.java
@@ -412,7 +412,7 @@ public class FlinkGroupAlsoByWindowWrapper<K, VIN, VACC, VOUT>
     FlinkStateInternals<K> stateInternals = perKeyStateInternals.get(key);
     if (stateInternals == null) {
       Coder<? extends BoundedWindow> windowCoder = this.windowingStrategy.getWindowFn().windowCoder();
-      OutputTimeFn<? super BoundedWindow> outputTimeFn = this.windowingStrategy.getWindowFn().getOutputTimeFn();
+      OutputTimeFn<? super BoundedWindow> outputTimeFn = this.windowingStrategy.getOutputTimeFn();
       stateInternals = new FlinkStateInternals<>(key, inputKvCoder.getKeyCoder(), windowCoder, outputTimeFn);
       perKeyStateInternals.put(key, stateInternals);
     }

--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/GroupAlsoByWindowTest.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/GroupAlsoByWindowTest.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.OutputTimeFns;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
@@ -58,16 +59,19 @@ public class GroupAlsoByWindowTest {
 
   private final WindowingStrategy slidingWindowWithAfterWatermarkTriggerStrategy =
       WindowingStrategy.of(SlidingWindows.of(Duration.standardSeconds(10)).every(Duration.standardSeconds(5)))
+          .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
           .withTrigger(AfterWatermark.pastEndOfWindow()).withMode(WindowingStrategy.AccumulationMode.ACCUMULATING_FIRED_PANES);
 
   private final WindowingStrategy sessionWindowingStrategy =
       WindowingStrategy.of(Sessions.withGapDuration(Duration.standardSeconds(2)))
           .withTrigger(Repeatedly.forever(AfterWatermark.pastEndOfWindow()))
           .withMode(WindowingStrategy.AccumulationMode.ACCUMULATING_FIRED_PANES)
+          .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
           .withAllowedLateness(Duration.standardSeconds(100));
 
   private final WindowingStrategy fixedWindowingStrategy =
-      WindowingStrategy.of(FixedWindows.of(Duration.standardSeconds(10)));
+      WindowingStrategy.of(FixedWindows.of(Duration.standardSeconds(10)))
+          .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp());
 
   private final WindowingStrategy fixedWindowWithCountTriggerStrategy =
       fixedWindowingStrategy.withTrigger(AfterPane.elementCountAtLeast(5));
@@ -94,6 +98,7 @@ public class GroupAlsoByWindowTest {
   public void testWithLateness() throws Exception {
     WindowingStrategy strategy = WindowingStrategy.of(FixedWindows.of(Duration.standardSeconds(2)))
         .withMode(WindowingStrategy.AccumulationMode.ACCUMULATING_FIRED_PANES)
+        .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
         .withAllowedLateness(Duration.millis(1000));
     long initialTime = 0L;
     Pipeline pipeline = FlinkTestPipeline.createForStreaming();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
@@ -201,7 +201,7 @@ public class WindowFnTestUtils {
 
     Instant instant = new Instant(timestamp);
     for (W window : windows) {
-      Instant outputTimestamp = windowFn.getOutputTimeFn().assignOutputTime(instant, window);
+      Instant outputTimestamp = windowFn.getOutputTime(instant, window);
       assertFalse("getOutputTime must be greater than or equal to input timestamp",
           outputTimestamp.isBefore(instant));
       assertFalse("getOutputTime must be less than or equal to the max timestamp",
@@ -232,7 +232,7 @@ public class WindowFnTestUtils {
     Instant instant = new Instant(timestamp);
     Instant endOfPrevious = null;
     for (W window : sortedWindows) {
-      Instant outputTimestamp = windowFn.getOutputTimeFn().assignOutputTime(instant, window);
+      Instant outputTimestamp = windowFn.getOutputTime(instant, window);
       if (endOfPrevious == null) {
         // If this is the first window, the output timestamp can be anything, as long as it is in
         // the valid range.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/OutputTimeFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/OutputTimeFn.java
@@ -61,7 +61,6 @@ public abstract class OutputTimeFn<W extends BoundedWindow> implements Serializa
    * Returns the output timestamp to use for data depending on the given
    * {@code inputTimestamp} in the specified {@code window}.
    *
-   *
    * <p>The result of this method must be between {@code inputTimestamp} and
    * {@code window.maxTimestamp()} (inclusive on both sides).
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Sessions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Sessions.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.transforms.windowing;
 
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 
@@ -86,12 +84,6 @@ public class Sessions extends WindowFn<Object, IntervalWindow> {
   @Override
   public IntervalWindow getSideInputWindow(BoundedWindow window) {
     throw new UnsupportedOperationException("Sessions is not allowed in side inputs");
-  }
-
-  @Experimental(Kind.OUTPUT_TIME)
-  @Override
-  public OutputTimeFn<? super IntervalWindow> getOutputTimeFn() {
-    return OutputTimeFns.outputAtEarliestInputTimestamp();
   }
 
   public Duration getGapDuration() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
@@ -185,26 +185,17 @@ public class SlidingWindows extends NonMergingWindowFn<Object, IntervalWindow> {
   /**
    * Ensures that later sliding windows have an output time that is past the end of earlier windows.
    *
-   * <p>If this is the earliest sliding window containing {@code inputTimestamp}, that's fine.
+   * <p>
+   * If this is the earliest sliding window containing {@code inputTimestamp}, that's fine.
    * Otherwise, we pick the earliest time that doesn't overlap with earlier windows.
    */
   @Experimental(Kind.OUTPUT_TIME)
   @Override
-  public OutputTimeFn<? super IntervalWindow> getOutputTimeFn() {
-    return new OutputTimeFn.Defaults<BoundedWindow>() {
-      @Override
-      public Instant assignOutputTime(Instant inputTimestamp, BoundedWindow window) {
-        Instant startOfLastSegment = window.maxTimestamp().minus(period);
-        return startOfLastSegment.isBefore(inputTimestamp)
-            ? inputTimestamp
-                : startOfLastSegment.plus(1);
-      }
-
-      @Override
-      public boolean dependsOnlyOnEarliestInputTimestamp() {
-        return true;
-      }
-    };
+  public Instant getOutputTime(Instant inputTimestamp, IntervalWindow window) {
+    Instant startOfLastSegment = window.maxTimestamp().minus(period);
+    return startOfLastSegment.isBefore(inputTimestamp)
+        ? inputTimestamp
+        : startOfLastSegment.plus(1);
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/join/CoGroupByKeyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/join/CoGroupByKeyTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.OutputTimeFns;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
@@ -239,7 +240,8 @@ public class CoGroupByKeyTest implements Serializable {
             idToClick,
             Arrays.asList(0L, 2L, 4L, 6L, 8L))
         .apply("WindowClicks", Window.<KV<Integer, String>>into(
-            FixedWindows.of(new Duration(4))));
+            FixedWindows.of(new Duration(4)))
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp()));
 
     PCollection<KV<Integer, String>> purchasesTable =
         createInput("CreatePurchases",
@@ -247,7 +249,8 @@ public class CoGroupByKeyTest implements Serializable {
             idToPurchases,
             Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L))
         .apply("WindowPurchases", Window.<KV<Integer, String>>into(
-            FixedWindows.of(new Duration(4))));
+            FixedWindows.of(new Duration(4)))
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp()));
 
     PCollection<KV<Integer, CoGbkResult>> coGbkResults =
         KeyedPCollectionTuple.of(clicksTag, clicksTable)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowingTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowingTest.java
@@ -72,11 +72,12 @@ public class WindowingTest implements Serializable {
     }
     @Override
     public PCollection<String> apply(PCollection<String> in) {
-      return in
-          .apply(Window.named("Window").<String>into(windowFn))
+      return in.apply(
+              Window.named("Window")
+                  .<String>into(windowFn)
+                  .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp()))
           .apply(Count.<String>perElement())
-          .apply(ParDo
-              .named("FormatCounts").of(new FormatCountsDoFn()))
+          .apply(ParDo.named("FormatCounts").of(new FormatCountsDoFn()))
           .setCoder(StringUtf8Coder.of());
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/GroupAlsoByWindowsViaOutputBufferDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/GroupAlsoByWindowsViaOutputBufferDoFnTest.java
@@ -64,7 +64,7 @@ public class GroupAlsoByWindowsViaOutputBufferDoFnTest {
 
   @Test
   public void testGroupsElementsIntoSlidingWindows() throws Exception {
-    GroupAlsoByWindowsProperties.groupsElementsIntoSlidingWindows(
+    GroupAlsoByWindowsProperties.groupsElementsIntoSlidingWindowsWithMinTimestamp(
         new BufferingGABWViaOutputBufferDoFnFactory<String, String>(StringUtf8Coder.of()));
   }
 
@@ -89,12 +89,6 @@ public class GroupAlsoByWindowsViaOutputBufferDoFnTest {
   @Test
   public void testGroupsElementsIntoFixedWindowsWithLatestTimestamp() throws Exception {
     GroupAlsoByWindowsProperties.groupsElementsIntoFixedWindowsWithLatestTimestamp(
-        new BufferingGABWViaOutputBufferDoFnFactory<String, String>(StringUtf8Coder.of()));
-  }
-
-  @Test
-  public void testGroupsElementsIntoFixedWindowsWithCustomTimestamp() throws Exception {
-    GroupAlsoByWindowsProperties.groupsElementsIntoFixedWindowsWithCustomTimestamp(
         new BufferingGABWViaOutputBufferDoFnFactory<String, String>(StringUtf8Coder.of()));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnRunnerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnRunnerTest.java
@@ -49,6 +49,7 @@ import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.OutputTimeFns;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
@@ -258,6 +259,7 @@ public class ReduceFnRunnerTest {
         .of(FixedWindows.of(Duration.millis(10)))
         .withTrigger(mockTrigger)
         .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
+        .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
         .withAllowedLateness(Duration.millis(100));
 
     TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
@@ -504,6 +506,7 @@ public class ReduceFnRunnerTest {
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
             .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));
@@ -556,6 +559,7 @@ public class ReduceFnRunnerTest {
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
             .withClosingBehavior(ClosingBehavior.FIRE_IF_NON_EMPTY));
 
     tester.advanceInputWatermark(new Instant(0));
@@ -582,6 +586,7 @@ public class ReduceFnRunnerTest {
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
             .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));
@@ -610,6 +615,7 @@ public class ReduceFnRunnerTest {
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
             .withAllowedLateness(Duration.millis(100))
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
             .withClosingBehavior(ClosingBehavior.FIRE_ALWAYS));
 
     tester.advanceInputWatermark(new Instant(0));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnTester.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ReduceFnTester.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.transforms.CombineWithContext.KeyedCombineFnWithConte
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.OutputTimeFns;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.Trigger;
 import org.apache.beam.sdk.transforms.windowing.TriggerBuilder;
@@ -134,6 +135,7 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
           Duration allowedDataLateness, ClosingBehavior closingBehavior) throws Exception {
     WindowingStrategy<?, W> strategy =
         WindowingStrategy.of(windowFn)
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
             .withTrigger(trigger.buildTrigger())
             .withMode(mode)
             .withAllowedLateness(allowedDataLateness)
@@ -185,8 +187,11 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
           Duration allowedDataLateness) throws Exception {
 
     WindowingStrategy<?, W> strategy =
-        WindowingStrategy.of(windowFn).withTrigger(trigger).withMode(mode).withAllowedLateness(
-            allowedDataLateness);
+        WindowingStrategy.of(windowFn)
+            .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp())
+            .withTrigger(trigger)
+            .withMode(mode)
+            .withAllowedLateness(allowedDataLateness);
 
     return combining(strategy, combineFn, outputCoder);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/state/CopyOnAccessInMemoryStateInternalsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/state/CopyOnAccessInMemoryStateInternalsTest.java
@@ -35,7 +35,6 @@ import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.Combine.KeyedCombineFn;
-import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.OutputTimeFn;
@@ -220,9 +219,8 @@ public class CopyOnAccessInMemoryStateInternalsTest {
     CopyOnAccessInMemoryStateInternals<String> underlying =
         CopyOnAccessInMemoryStateInternals.withUnderlying(key, null);
 
-    @SuppressWarnings("unchecked")
-    OutputTimeFn<BoundedWindow> outputTimeFn = (OutputTimeFn<BoundedWindow>)
-        TestPipeline.create().apply(Create.of("foo")).getWindowingStrategy().getOutputTimeFn();
+    OutputTimeFn<BoundedWindow> outputTimeFn =
+        OutputTimeFns.outputAtEarliestInputTimestamp();
 
     StateNamespace namespace = new StateNamespaceForTest("foo");
     StateTag<Object, WatermarkHoldState<BoundedWindow>> stateTag =


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Previously:

 - Any user-specified OutputTimeFn overrode the WindowFn#getOutputTime
 - WindowFn#getOutputTimeFn provided a default OutputTimeFn
 - The default varied from "earliest" to "end of window"

Now:

 - The user-specified OutputTimeFn is used to combine the WindowFn's
   assigned output timestamps.
 - The WindowFn does not provide the default.
 - The default is always to output at end of window.

For each of the tests that this effects, I had a choice: either update the timestamps in the test to be the end of window, or explicitly reset the windowing strategy to choose the minimum timestamp. The latter generally gets more useful coverage, since the latter is fairly trivial, so I generally favored it. It is also easier to migrate to. And most of the tests are overspecified anyhow and should not be examining the timestamps.