### PR TITLE
[BEAM-22] Add ShardWatermarkTracker

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EmptyTransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EmptyTransformEvaluator.java
@@ -29,14 +29,19 @@ import org.apache.beam.sdk.util.WindowedValue;
  * will not affect the watermark.
  */
 final class EmptyTransformEvaluator<T> implements TransformEvaluator<T> {
-  public static <T> TransformEvaluator<T> create(AppliedPTransform<?, ?, ?> transform) {
-    return new EmptyTransformEvaluator<T>(transform);
+  public static <T> TransformEvaluator<T> create(
+      AppliedPTransform<?, ?, ?> transform,
+      ShardWatermarkTracker tracker) {
+    return new EmptyTransformEvaluator<T>(transform, tracker);
   }
 
   private final AppliedPTransform<?, ?, ?> transform;
+  private final ShardWatermarkTracker tracker;
 
-  private EmptyTransformEvaluator(AppliedPTransform<?, ?, ?> transform) {
+  private EmptyTransformEvaluator(
+      AppliedPTransform<?, ?, ?> transform, ShardWatermarkTracker tracker) {
     this.transform = transform;
+    this.tracker = tracker;
   }
 
   @Override
@@ -44,7 +49,7 @@ final class EmptyTransformEvaluator<T> implements TransformEvaluator<T> {
 
   @Override
   public InProcessTransformResult finishBundle() throws Exception {
-    return StepTransformResult.withHold(transform, BoundedWindow.TIMESTAMP_MIN_VALUE)
+    return StepTransformResult.withHold(transform, tracker.getWatermark())
         .build();
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ShardWatermarkTracker.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ShardWatermarkTracker.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.direct;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+
+import org.joda.time.Instant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import autovalue.shaded.com.google.common.common.collect.Iterables;
+
+/**
+ * Tracks the value of a watermark across multiple shards of a TransformEvaluator.
+ */
+public class ShardWatermarkTracker {
+  public static ShardWatermarkTracker create() {
+    return new ShardWatermarkTracker();
+  }
+
+  private final Map<TransformEvaluator<?>, Instant> evaluatorWatermarks;
+
+  private ShardWatermarkTracker() {
+    evaluatorWatermarks = new HashMap<>();
+  }
+
+  public synchronized void setInitialShards(Iterable<? extends TransformEvaluator<?>> shards) {
+    checkArgument(!Iterables.isEmpty(shards),
+        "ShardWatermarkTracker must contain at least one shard");
+    checkArgument(evaluatorWatermarks.isEmpty(),
+        "ShardWatermarkTracker cannot be initialized multiple times");
+    for (TransformEvaluator<?> evaluator : shards) {
+      evaluatorWatermarks.put(evaluator, BoundedWindow.TIMESTAMP_MIN_VALUE);
+    }
+  }
+
+  public synchronized void updateWatermark(TransformEvaluator<?> evaluator, Instant newWatermark) {
+    evaluatorWatermarks.put(evaluator, newWatermark);
+  }
+
+  public synchronized Instant getWatermark() {
+    Instant minwm = null;
+    for (Instant wm : evaluatorWatermarks.values()) {
+      if (minwm == null || wm.isBefore(minwm)) {
+        minwm = wm;
+      }
+    }
+    checkState(minwm != null, "Cannot use a ShardWatermarkTracker before it is initalized");
+    return minwm;
+  }
+}

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EmptyTransformEvaluatorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EmptyTransformEvaluatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.direct;
+
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.AppliedPTransform;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PDone;
+
+import com.google.common.collect.ImmutableList;
+
+import org.hamcrest.Matchers;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link EmptyTransformEvaluator}.
+ */
+@RunWith(JUnit4.class)
+public class EmptyTransformEvaluatorTest {
+  @Test
+  public void updatesWatermarksWithTracker() throws Exception {
+    ShardWatermarkTracker tracker = ShardWatermarkTracker.create();
+    AppliedPTransform<PBegin, PDone, PTransform<PBegin, PDone>> mytransform = getTransform();
+    TransformEvaluator<?> evaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    TransformEvaluator<?> otherEvaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    tracker.setInitialShards(ImmutableList.of(evaluator, otherEvaluator));
+
+    assertThat(evaluator.finishBundle().getWatermarkHold(),
+        equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    tracker.updateWatermark(evaluator, new Instant(5));
+    assertThat(evaluator.finishBundle().getWatermarkHold(),
+        equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    tracker.updateWatermark(otherEvaluator, BoundedWindow.TIMESTAMP_MAX_VALUE);
+    assertThat(evaluator.finishBundle().getWatermarkHold(), equalTo(new Instant(5)));
+
+    tracker.updateWatermark(evaluator, BoundedWindow.TIMESTAMP_MAX_VALUE);
+    assertThat(evaluator.finishBundle().getWatermarkHold(),
+        equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
+  }
+
+  @Test
+  public void finishBundleProducesEmptyResult() throws Exception {
+    ShardWatermarkTracker tracker = ShardWatermarkTracker.create();
+    AppliedPTransform<PBegin, PDone, PTransform<PBegin, PDone>> mytransform = getTransform();
+    TransformEvaluator<?> evaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    tracker.setInitialShards(ImmutableList.of(evaluator));
+
+    InProcessTransformResult result = evaluator.finishBundle();
+    assertThat(result.getOutputBundles(), emptyIterable());
+    assertThat(result.getCounters(), nullValue());
+    assertThat(result.getTransform(), Matchers.<AppliedPTransform<?, ?, ?>>equalTo(mytransform));
+    assertThat(result.getState(), nullValue());
+    assertThat(result.getTimerUpdate().getCompletedTimers(), emptyIterable());
+    assertThat(result.getTimerUpdate().getSetTimers(), emptyIterable());
+    assertThat(result.getTimerUpdate().getDeletedTimers(), emptyIterable());
+  }
+
+  private AppliedPTransform<PBegin, PDone, PTransform<PBegin, PDone>> getTransform() {
+    TestPipeline p = TestPipeline.create();
+    PTransform<PBegin, PDone> pt = new PTransform<PBegin, PDone>() {
+    };
+    return AppliedPTransform.of("foo", PBegin.in(p), PDone.in(p), pt);
+  }
+}

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ShardWatermarkTrackerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ShardWatermarkTrackerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.direct;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.AppliedPTransform;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PDone;
+
+import com.google.common.collect.ImmutableList;
+
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link ShardWatermarkTracker}.
+ */
+@RunWith(JUnit4.class)
+public class ShardWatermarkTrackerTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+  ShardWatermarkTracker tracker;
+
+  @Before
+  public void setup() {
+    tracker = ShardWatermarkTracker.create();
+  }
+
+  @Test
+  public void getAfterSetReturnsMin() {
+    AppliedPTransform<PBegin, PDone, PTransform<PBegin, PDone>> mytransform = getTransform();
+    TransformEvaluator<?> evaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    TransformEvaluator<?> otherEvaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    tracker.setInitialShards(ImmutableList.of(evaluator, otherEvaluator));
+
+    assertThat(tracker.getWatermark(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    tracker.updateWatermark(evaluator, new Instant(5));
+    assertThat(tracker.getWatermark(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    tracker.updateWatermark(otherEvaluator, BoundedWindow.TIMESTAMP_MAX_VALUE);
+    assertThat(tracker.getWatermark(), equalTo(new Instant(5)));
+
+    tracker.updateWatermark(evaluator, BoundedWindow.TIMESTAMP_MAX_VALUE);
+    assertThat(tracker.getWatermark(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
+  }
+
+  @Test
+  public void setInitialShardsWithNoneThrows() {
+    thrown.expect(IllegalArgumentException.class);
+    tracker.setInitialShards(ImmutableList.<TransformEvaluator<?>>of());
+  }
+
+  @Test
+  public void setInitialShardsAfterSetInitialShardsThrows() {
+    AppliedPTransform<PBegin, PDone, PTransform<PBegin, PDone>> mytransform = getTransform();
+    TransformEvaluator<?> evaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    TransformEvaluator<?> otherEvaluator = EmptyTransformEvaluator.create(mytransform, tracker);
+    tracker.setInitialShards(ImmutableList.of(evaluator));
+
+    thrown.expect(IllegalArgumentException.class);
+    tracker.setInitialShards(ImmutableList.of(otherEvaluator));
+  }
+
+  @Test public void getWatermarkWithNoShardsThrows() {
+    thrown.expect(IllegalStateException.class);
+    tracker.getWatermark();
+  }
+
+  private AppliedPTransform<PBegin, PDone, PTransform<PBegin, PDone>> getTransform() {
+    TestPipeline p = TestPipeline.create();
+    PTransform<PBegin, PDone> pt = new PTransform<PBegin, PDone>() {
+    };
+    return AppliedPTransform.of("foo", PBegin.in(p), PDone.in(p), pt);
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This tracks the watermark across multiple instances of a source
transform.

Use ShardWatermarkTracker in EmptyTransformEvaluator to provide the
correct watermark hold.

This enables asynchronously updating watermarks.