### PR TITLE
[BEAM-146] Remove references to multi-window representation from model

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/sdk/util/AssignWindowsDoFn.java
+++ b/runners/core-java/src/main/java/org/apache/beam/sdk/util/AssignWindowsDoFn.java
@@ -20,22 +20,27 @@ package org.apache.beam.sdk.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.RequiresWindowAccess;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
+
+import com.google.common.collect.Iterables;
 
 import org.joda.time.Instant;
 
 import java.util.Collection;
 
 /**
- * {@link DoFn} that tags elements of a PCollection with windows, according
- * to the provided {@link WindowFn}.
+ * {@link DoFn} that tags elements of a {@link PCollection} with windows, according to the provided
+ * {@link WindowFn}.
+ *
  * @param <T> Type of elements being windowed
  * @param <W> Window type
  */
 @SystemDoFnInternal
-public class AssignWindowsDoFn<T, W extends BoundedWindow> extends DoFn<T, T> {
+public class AssignWindowsDoFn<T, W extends BoundedWindow> extends DoFn<T, T>
+    implements RequiresWindowAccess {
   private WindowFn<? super T, W> fn;
 
   public AssignWindowsDoFn(WindowFn<? super T, W> fn) {
@@ -64,8 +69,8 @@ public class AssignWindowsDoFn<T, W extends BoundedWindow> extends DoFn<T, T> {
                 }
 
                 @Override
-                public Collection<? extends BoundedWindow> windows() {
-                  return c.windowingInternals().windows();
+                public BoundedWindow window() {
+                  return Iterables.getOnlyElement(c.windowingInternals().windows());
                 }
               });
 

--- a/runners/core-java/src/main/java/org/apache/beam/sdk/util/DoFnRunnerBase.java
+++ b/runners/core-java/src/main/java/org/apache/beam/sdk/util/DoFnRunnerBase.java
@@ -254,7 +254,7 @@ public abstract class DoFnRunnerBase<InputT, OutputT> implements DoFnRunner<Inpu
             }
 
             @Override
-            public Collection<? extends BoundedWindow> windows() {
+            public W window() {
               throw new UnsupportedOperationException(
                   "WindowFn attempted to access input windows when none were available");
             }

--- a/runners/core-java/src/test/java/org/apache/beam/sdk/util/ReduceFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/sdk/util/ReduceFnRunnerTest.java
@@ -82,7 +82,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -258,7 +257,7 @@ public class ReduceFnRunnerTest {
               }
 
               @Override
-              public Collection<? extends BoundedWindow> windows() {
+              public BoundedWindow window() {
                 throw new UnsupportedOperationException();
               }
             }));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -82,11 +82,13 @@ class WindowEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
-    public void processElement(WindowedValue<InputT> element) throws Exception {
-      Collection<? extends BoundedWindow> windows = assignWindows(windowFn, element);
-      outputBundle.add(
-          WindowedValue.<InputT>of(
-              element.getValue(), element.getTimestamp(), windows, PaneInfo.NO_FIRING));
+    public void processElement(WindowedValue<InputT> compressedElement) throws Exception {
+      for (WindowedValue<InputT> element : compressedElement.explodeWindows()) {
+        Collection<? extends BoundedWindow> windows = assignWindows(windowFn, element);
+        outputBundle.add(
+            WindowedValue.<InputT>of(
+                element.getValue(), element.getTimestamp(), windows, PaneInfo.NO_FIRING));
+      }
     }
 
     private <W extends BoundedWindow> Collection<? extends BoundedWindow> assignWindows(

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -29,6 +29,8 @@ import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollection;
 
+import com.google.common.collect.Iterables;
+
 import org.joda.time.Instant;
 
 import java.util.Collection;
@@ -125,8 +127,8 @@ class WindowEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
-    public Collection<? extends BoundedWindow> windows() {
-      return value.getWindows();
+    public BoundedWindow window() {
+      return Iterables.getOnlyElement(value.getWindows());
     }
 
   }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -326,11 +326,11 @@ public class WindowEvaluatorFactoryTest {
   private static class EvaluatorTestWindowFn extends NonMergingWindowFn<Long, BoundedWindow> {
     @Override
     public Collection<BoundedWindow> assignWindows(AssignContext c) throws Exception {
-      if (c.windows().contains(GlobalWindow.INSTANCE)) {
+      if (c.window().equals(GlobalWindow.INSTANCE)) {
         return Collections.<BoundedWindow>singleton(new IntervalWindow(c.timestamp(),
             c.timestamp().plus(1L)));
       }
-      return (Collection<BoundedWindow>) c.windows();
+      return Collections.singleton(c.window());
     }
 
     @Override

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingTransformTranslators.java
@@ -59,6 +59,7 @@ import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 
 import com.google.api.client.util.Maps;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import org.apache.flink.api.common.functions.FilterFunction;
@@ -359,8 +360,8 @@ public class FlinkStreamingTransformTranslators {
                 }
 
                 @Override
-                public Collection<? extends BoundedWindow> windows() {
-                  return c.windowingInternals().windows();
+                public BoundedWindow window() {
+                  return Iterables.getOnlyElement(c.windowingInternals().windows());
                 }
               });
 

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkAssignContext.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkAssignContext.java
@@ -17,9 +17,13 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.util.WindowedValue;
+
+import com.google.common.collect.Iterables;
 
 import org.joda.time.Instant;
 
@@ -35,6 +39,13 @@ class FlinkAssignContext<InputT, W extends BoundedWindow>
 
   FlinkAssignContext(WindowFn<InputT, W> fn, WindowedValue<InputT> value) {
     fn.super();
+    checkArgument(
+        Iterables.size(value.getWindows()) == 1,
+        String.format(
+            "%s passed to window assignment must be in a single window, but it was in %s: %s",
+            WindowedValue.class.getSimpleName(),
+            Iterables.size(value.getWindows()),
+            value.getWindows()));
     this.value = value;
   }
 
@@ -49,8 +60,8 @@ class FlinkAssignContext<InputT, W extends BoundedWindow>
   }
 
   @Override
-  public Collection<? extends BoundedWindow> windows() {
-    return value.getWindows();
+  public BoundedWindow window() {
+    return Iterables.getOnlyElement(value.getWindows());
   }
 
 }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkNoElementAssignContext.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkNoElementAssignContext.java
@@ -65,7 +65,7 @@ class FlinkNoElementAssignContext<InputT, W extends BoundedWindow>
   }
 
   @Override
-  public Collection<? extends BoundedWindow> windows() {
-    throw new UnsupportedOperationException("No windows available.");
+  public BoundedWindow window() {
+    throw new UnsupportedOperationException("No window available.");
   }
 }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/FlinkAbstractParDoWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/FlinkAbstractParDoWrapper.java
@@ -245,9 +245,9 @@ public abstract class FlinkAbstractParDoWrapper<IN, OUTDF, OUTFL> extends RichFl
           }
 
           @Override
-          public Collection<? extends BoundedWindow> windows() {
+          public BoundedWindow window() {
             throw new UnsupportedOperationException(
-                "WindowFn attempted to access input windows when none were available");
+                "WindowFn attempted to access input window when none was available");
           }
         });
       } catch (Exception e) {

--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/GroupAlsoByWindowTest.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/GroupAlsoByWindowTest.java
@@ -508,7 +508,7 @@ public class GroupAlsoByWindowTest extends StreamingMultipleProgramsTestBase {
           }
 
           @Override
-          public Collection<? extends BoundedWindow> windows() {
+          public BoundedWindow window() {
             throw new UnsupportedOperationException(
                 "WindowFn attempted to access input windows when none were available");
           }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.OutputTimeFn;
 import org.apache.beam.sdk.transforms.windowing.OutputTimeFns;
@@ -115,8 +116,8 @@ public class WindowFnTestUtils {
     }
 
     @Override
-    public Collection<? extends BoundedWindow> windows() {
-      return null;
+    public BoundedWindow window() {
+      return GlobalWindow.INSTANCE;
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindows.java
@@ -53,11 +53,6 @@ public class GlobalWindows extends NonMergingWindowFn<Object, GlobalWindow> {
   }
 
   @Override
-  public boolean assignsToSingleWindow() {
-    return true;
-  }
-
-  @Override
   public Instant getOutputTime(Instant inputTimestamp, GlobalWindow window) {
     return inputTimestamp;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java
@@ -292,6 +292,10 @@ public final class PaneInfo {
 
   @Override
   public String toString() {
+    if (this == PaneInfo.NO_FIRING) {
+      return "PaneInfo.NO_FIRING";
+    }
+
     return MoreObjects.toStringHelper(getClass())
         .omitNullValues()
         .add("isFirst", isFirst ? true : null)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java
@@ -51,11 +51,6 @@ public abstract class PartitioningWindowFn<T, W extends BoundedWindow>
   }
 
   @Override
-  public boolean assignsToSingleWindow() {
-    return true;
-  }
-
-  @Override
   public Instant getOutputTime(Instant inputTimestamp, W window) {
     return inputTimestamp;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowFn.java
@@ -65,10 +65,10 @@ public abstract class WindowFn<T, W extends BoundedWindow>
     public abstract Instant timestamp();
 
     /**
-     * Returns the windows the current element was in, prior to this
+     * Returns the window of the current element prior to this
      * {@code WindowFn} being called.
      */
-    public abstract Collection<? extends BoundedWindow> windows();
+    public abstract BoundedWindow window();
   }
 
   /**
@@ -157,13 +157,6 @@ public abstract class WindowFn<T, W extends BoundedWindow>
    * Returns true if this {@code WindowFn} never needs to merge any windows.
    */
   public boolean isNonMerging() {
-    return false;
-  }
-
-  /**
-   * Returns true if this {@code WindowFn} assigns each element to a single window.
-   */
-  public boolean assignsToSingleWindow() {
     return false;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/GatherAllPanes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/GatherAllPanes.java
@@ -62,8 +62,7 @@ public class GatherAllPanes<T>
         .apply(
             Window.into(
                     new IdentityWindowFn<KV<Void, WindowedValue<T>>>(
-                        originalWindowFn.windowCoder(),
-                        input.getWindowingStrategy().getWindowFn().assignsToSingleWindow()))
+                        originalWindowFn.windowCoder()))
                 .triggering(Never.ever()))
         // all values have the same key so they all appear as a single output element
         .apply(GroupByKey.<Void, WindowedValue<T>>create())

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Instant;
 
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * A {@link WindowFn} that leaves all associations between elements and windows unchanged.
@@ -55,25 +56,21 @@ class IdentityWindowFn<T> extends NonMergingWindowFn<T, BoundedWindow> {
    * these windows.
    */
   private final Coder<BoundedWindow> coder;
-  private final boolean assignsToSingleWindow;
 
-  public IdentityWindowFn(Coder<? extends BoundedWindow> coder, boolean assignsToSingleWindow) {
+  public IdentityWindowFn(Coder<? extends BoundedWindow> coder) {
     // Safe because it is only used privately here.
     // At every point where a window is returned or accepted, it has been provided
-    // by priorWindowFn, so it is of the expected type.
+    // by the prior WindowFn, so it is of the expected type.
     @SuppressWarnings("unchecked")
     Coder<BoundedWindow> windowCoder = (Coder<BoundedWindow>) coder;
     this.coder = windowCoder;
-    this.assignsToSingleWindow = assignsToSingleWindow;
   }
 
   @Override
   public Collection<BoundedWindow> assignWindows(WindowFn<T, BoundedWindow>.AssignContext c)
       throws Exception {
-    // The windows are provided by priorWindowFn, which also provides the coder for them
-    @SuppressWarnings("unchecked")
-    Collection<BoundedWindow> priorWindows = (Collection<BoundedWindow>) c.windows();
-    return priorWindows;
+    // The window is provided by the prior WindowFn, which also provides the coder for them
+    return Collections.singleton(c.window());
   }
 
   @Override
@@ -88,14 +85,9 @@ class IdentityWindowFn<T> extends NonMergingWindowFn<T, BoundedWindow> {
 
   @Override
   public Coder<BoundedWindow> windowCoder() {
-    // Safe because the previous WindowFn provides both the windows and the coder.
+    // Safe because the prior WindowFn provides both the windows and the coder.
     // The Coder is _not_ actually a coder for an arbitrary BoundedWindow.
     return coder;
-  }
-
-  @Override
-  public boolean assignsToSingleWindow() {
-    return assignsToSingleWindow;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Reshuffle.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Reshuffle.java
@@ -58,8 +58,7 @@ public class Reshuffle<K, V> extends PTransform<PCollection<KV<K, V>>, PCollecti
     Window.Bound<KV<K, V>> rewindow =
         Window.<KV<K, V>>into(
                 new IdentityWindowFn<>(
-                    originalStrategy.getWindowFn().windowCoder(),
-                    originalStrategy.getWindowFn().assignsToSingleWindow()))
+                    originalStrategy.getWindowFn().windowCoder()))
             .triggering(new ReshuffleTrigger<>())
             .discardingFiredPanes()
             .withAllowedLateness(Duration.millis(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/WindowMatchers.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/WindowMatchers.java
@@ -22,6 +22,8 @@ import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
 
+import com.google.common.collect.Lists;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -37,19 +39,51 @@ import java.util.Objects;
 public class WindowMatchers {
 
   public static <T> Matcher<WindowedValue<? extends T>> isWindowedValue(
-      Matcher<? super T> valueMatcher, Matcher<? super Instant> timestampMatcher,
+      T value,
+      Instant timestamp,
+      Collection<? extends BoundedWindow> windows,
+      PaneInfo paneInfo) {
+
+    Collection<Matcher<? super BoundedWindow>> windowMatchers =
+        Lists.newArrayListWithCapacity(windows.size());
+    for (BoundedWindow window : windows) {
+      windowMatchers.add(Matchers.equalTo(window));
+    }
+
+    return isWindowedValue(
+        Matchers.equalTo(value),
+        Matchers.equalTo(timestamp),
+        Matchers.containsInAnyOrder(windowMatchers),
+        Matchers.equalTo(paneInfo));
+  }
+
+  public static <T> Matcher<WindowedValue<? extends T>> isWindowedValue(
+      Matcher<? super T> valueMatcher,
+      Matcher<? super Instant> timestampMatcher,
+      Matcher<? super Collection<? extends BoundedWindow>> windowsMatcher,
+      Matcher<? super PaneInfo> paneInfoMatcher) {
+    return new WindowedValueMatcher<>(
+        valueMatcher, timestampMatcher, windowsMatcher, paneInfoMatcher);
+  }
+
+  public static <T> Matcher<WindowedValue<? extends T>> isWindowedValue(
+      Matcher<? super T> valueMatcher,
+      Matcher<? super Instant> timestampMatcher,
       Matcher<? super Collection<? extends BoundedWindow>> windowsMatcher) {
-    return new WindowedValueMatcher<>(valueMatcher, timestampMatcher, windowsMatcher);
+    return new WindowedValueMatcher<>(
+        valueMatcher, timestampMatcher, windowsMatcher, Matchers.anything());
   }
 
   public static <T> Matcher<WindowedValue<? extends T>> isWindowedValue(
       Matcher<? super T> valueMatcher, Matcher<? super Instant> timestampMatcher) {
-    return new WindowedValueMatcher<>(valueMatcher, timestampMatcher, Matchers.anything());
+    return new WindowedValueMatcher<>(
+        valueMatcher, timestampMatcher, Matchers.anything(), Matchers.anything());
   }
 
   public static <T> Matcher<WindowedValue<? extends T>> isWindowedValue(
       Matcher<? super T> valueMatcher) {
-    return new WindowedValueMatcher<>(valueMatcher, Matchers.anything(), Matchers.anything());
+    return new WindowedValueMatcher<>(
+        valueMatcher, Matchers.anything(), Matchers.anything(), Matchers.anything());
   }
 
   public static <T> Matcher<WindowedValue<? extends T>> isSingleWindowedValue(
@@ -59,20 +93,46 @@ public class WindowMatchers {
   }
 
   public static <T> Matcher<WindowedValue<? extends T>> isSingleWindowedValue(
+      T value, Instant timestamp, BoundedWindow window, PaneInfo paneInfo) {
+    return WindowMatchers.<T>isSingleWindowedValue(
+        Matchers.equalTo(value),
+        Matchers.equalTo(timestamp),
+        Matchers.equalTo(window),
+        Matchers.equalTo(paneInfo));
+  }
+
+  public static <T> Matcher<WindowedValue<? extends T>> isSingleWindowedValue(
+      T value, Instant timestamp, BoundedWindow window) {
+    return WindowMatchers.<T>isSingleWindowedValue(
+        Matchers.equalTo(value), Matchers.equalTo(timestamp), Matchers.equalTo(window));
+  }
+
+  public static <T> Matcher<WindowedValue<? extends T>> isSingleWindowedValue(
       Matcher<T> valueMatcher, long timestamp, long windowStart, long windowEnd) {
     IntervalWindow intervalWindow =
         new IntervalWindow(new Instant(windowStart), new Instant(windowEnd));
     return WindowMatchers.<T>isSingleWindowedValue(
         valueMatcher,
         Matchers.describedAs("%0", Matchers.equalTo(new Instant(timestamp)), timestamp),
-        Matchers.<BoundedWindow>equalTo(intervalWindow));
+        Matchers.<BoundedWindow>equalTo(intervalWindow),
+        Matchers.anything());
   }
 
   public static <T> Matcher<WindowedValue<? extends T>> isSingleWindowedValue(
-      Matcher<? super T> valueMatcher, Matcher<? super Instant> timestampMatcher,
+      Matcher<? super T> valueMatcher,
+      Matcher<? super Instant> timestampMatcher,
       Matcher<? super BoundedWindow> windowMatcher) {
     return new WindowedValueMatcher<T>(
-        valueMatcher, timestampMatcher, Matchers.contains(windowMatcher));
+        valueMatcher, timestampMatcher, Matchers.contains(windowMatcher), Matchers.anything());
+  }
+
+  public static <T> Matcher<WindowedValue<? extends T>> isSingleWindowedValue(
+      Matcher<? super T> valueMatcher,
+      Matcher<? super Instant> timestampMatcher,
+      Matcher<? super BoundedWindow> windowMatcher,
+      Matcher<? super PaneInfo> paneInfoMatcher) {
+    return new WindowedValueMatcher<T>(
+        valueMatcher, timestampMatcher, Matchers.contains(windowMatcher), paneInfoMatcher);
   }
 
   public static Matcher<IntervalWindow> intervalWindow(long start, long end) {
@@ -114,14 +174,17 @@ public class WindowMatchers {
     private Matcher<? super T> valueMatcher;
     private Matcher<? super Instant> timestampMatcher;
     private Matcher<? super Collection<? extends BoundedWindow>> windowsMatcher;
+    private Matcher<? super PaneInfo> paneInfoMatcher;
 
     private WindowedValueMatcher(
         Matcher<? super T> valueMatcher,
         Matcher<? super Instant> timestampMatcher,
-        Matcher<? super Collection<? extends BoundedWindow>> windowsMatcher) {
+        Matcher<? super Collection<? extends BoundedWindow>> windowsMatcher,
+        Matcher<? super PaneInfo> paneInfoMatcher) {
       this.valueMatcher = valueMatcher;
       this.timestampMatcher = timestampMatcher;
       this.windowsMatcher = windowsMatcher;
+      this.paneInfoMatcher = paneInfoMatcher;
     }
 
     @Override
@@ -130,6 +193,7 @@ public class WindowMatchers {
           .appendText("a WindowedValue(").appendValue(valueMatcher)
           .appendText(", ").appendValue(timestampMatcher)
           .appendText(", ").appendValue(windowsMatcher)
+          .appendText(", ").appendValue(paneInfoMatcher)
           .appendText(")");
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/WindowMatchersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/WindowMatchersTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk;
+
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.util.WindowedValue;
+
+import com.google.common.collect.ImmutableList;
+
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link WindowMatchers}.
+ */
+@RunWith(JUnit4.class)
+public class WindowMatchersTest {
+
+  @Test
+  public void testIsWindowedValueExact() {
+    long timestamp = 100;
+    long windowStart = 0;
+    long windowEnd = 200;
+
+    assertThat(
+        WindowedValue.of(
+            "hello",
+            new Instant(timestamp),
+            new IntervalWindow(new Instant(windowStart), new Instant(windowEnd)),
+            PaneInfo.NO_FIRING),
+        WindowMatchers.isWindowedValue(
+            "hello",
+            new Instant(timestamp),
+            ImmutableList.of(new IntervalWindow(new Instant(windowStart), new Instant(windowEnd))),
+            PaneInfo.NO_FIRING));
+  }
+
+  @Test
+  public void testIsWindowedValueReorderedWindows() {
+    long timestamp = 100;
+    long windowStart = 0;
+    long windowEnd = 200;
+    long windowStart2 = 50;
+    long windowEnd2 = 150;
+
+    assertThat(
+        WindowedValue.of(
+            "hello",
+            new Instant(timestamp),
+            ImmutableList.of(
+                new IntervalWindow(new Instant(windowStart), new Instant(windowEnd)),
+                new IntervalWindow(new Instant(windowStart2), new Instant(windowEnd2))),
+            PaneInfo.NO_FIRING),
+        WindowMatchers.isWindowedValue(
+            "hello",
+            new Instant(timestamp),
+            ImmutableList.of(
+                new IntervalWindow(new Instant(windowStart), new Instant(windowEnd)),
+                new IntervalWindow(new Instant(windowStart2), new Instant(windowEnd2))),
+            PaneInfo.NO_FIRING));
+  }
+}
+
+

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/IdentitySideInputWindowFn.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/IdentitySideInputWindowFn.java
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.transforms.windowing.NonMergingWindowFn;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * A {@link WindowFn} for use during tests that returns the input window for calls to
@@ -33,7 +34,7 @@ public class IdentitySideInputWindowFn extends NonMergingWindowFn<Integer, Bound
   @Override
   public Collection<BoundedWindow> assignWindows(WindowFn<Integer, BoundedWindow>.AssignContext c)
       throws Exception {
-    return (Collection<BoundedWindow>) c.windows();
+    return Collections.singleton(c.window());
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MergingActiveWindowSetTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MergingActiveWindowSetTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
 import org.apache.beam.sdk.util.state.InMemoryStateInternals;
@@ -39,7 +40,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,8 +87,8 @@ public class MergingActiveWindowSetTest {
         }
 
         @Override
-        public Collection<? extends BoundedWindow> windows() {
-          return ImmutableList.of();
+        public BoundedWindow window() {
+          return GlobalWindow.INSTANCE;
         }
       };
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/TriggerTester.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/TriggerTester.java
@@ -245,7 +245,7 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
         InputT value = input.getValue();
         Instant timestamp = input.getTimestamp();
         Collection<W> assignedWindows = windowFn.assignWindows(new TestAssignContext<W>(
-            windowFn, value, timestamp, Arrays.asList(GlobalWindow.INSTANCE)));
+            windowFn, value, timestamp, GlobalWindow.INSTANCE));
 
         for (W window : assignedWindows) {
           activeWindows.addActiveForTesting(window);
@@ -401,14 +401,14 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
       extends WindowFn<Object, W>.AssignContext {
     private Object element;
     private Instant timestamp;
-    private Collection<? extends BoundedWindow> windows;
+    private BoundedWindow window;
 
-    public TestAssignContext(WindowFn<Object, W> windowFn, Object element, Instant timestamp,
-        Collection<? extends BoundedWindow> windows) {
+    public TestAssignContext(
+        WindowFn<Object, W> windowFn, Object element, Instant timestamp, BoundedWindow window) {
       windowFn.super();
       this.element = element;
       this.timestamp = timestamp;
-      this.windows = windows;
+      this.window = window;
     }
 
     @Override
@@ -422,8 +422,8 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
     }
 
     @Override
-    public Collection<? extends BoundedWindow> windows() {
-      return windows;
+    public BoundedWindow window() {
+      return window;
     }
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Some areas of the Beam model in the SDK allude to the use of a
compressed representation of an element along with the set
of windows it is assigned to. However, the model itself views
elements in different windows as fully independent, so the SDK
should not place any obligation on the part of the runner or
user to use a particular representation.

This change removes those places in the SDK where an element
is treated in multiple windows at once.