### PR TITLE
[BEAM-22] Return null evaluators from Unavailable Reads

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
@@ -51,6 +51,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
+  @Nullable
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
       @Nullable CommittedBundle<?> inputBundle,
@@ -62,12 +63,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
   private <OutputT> TransformEvaluator<?> getTransformEvaluator(
       final AppliedPTransform<?, PCollection<OutputT>, Bounded<OutputT>> transform,
       final InProcessEvaluationContext evaluationContext) {
-    BoundedReadEvaluator<?> evaluator =
-        getTransformEvaluatorQueue(transform, evaluationContext).poll();
-    if (evaluator == null) {
-      return EmptyTransformEvaluator.create(transform);
-    }
-    return evaluator;
+    return getTransformEvaluatorQueue(transform, evaluationContext).poll();
   }
 
   /**

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorFactory.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.direct;
 
 import org.apache.beam.runners.direct.InProcessPipelineRunner.CommittedBundle;
+import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -32,13 +33,18 @@ public interface TransformEvaluatorFactory {
   /**
    * Create a new {@link TransformEvaluator} for the application of the {@link PTransform}.
    *
-   * Any work that must be done before input elements are processed (such as calling
+   * <p>Any work that must be done before input elements are processed (such as calling
    * {@link DoFn#startBundle(DoFn.Context)}) must be done before the {@link TransformEvaluator} is
    * made available to the caller.
    *
+   * <p>May return null if the application cannot produce an evaluator (for example, it is a
+   * {@link Read} {@link PTransform} where all evaluators are in-use).
+   *
+   * @return An evaluator capable of processing the transform on the bundle, or null if no evaluator
+   * can be constructed.
    * @throws Exception whenever constructing the underlying evaluator throws an exception
    */
-  <InputT> TransformEvaluator<InputT> forApplication(
+  @Nullable <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application, @Nullable CommittedBundle<?> inputBundle,
       InProcessEvaluationContext evaluationContext) throws Exception;
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -52,6 +52,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
+  @Nullable
   public <InputT> TransformEvaluator<InputT> forApplication(AppliedPTransform<?, ?, ?> application,
       @Nullable CommittedBundle<?> inputBundle, InProcessEvaluationContext evaluationContext) {
     return getTransformEvaluator((AppliedPTransform) application, evaluationContext);
@@ -60,12 +61,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
   private <OutputT> TransformEvaluator<?> getTransformEvaluator(
       final AppliedPTransform<?, PCollection<OutputT>, Unbounded<OutputT>> transform,
       final InProcessEvaluationContext evaluationContext) {
-    UnboundedReadEvaluator<?> currentEvaluator =
-        getTransformEvaluatorQueue(transform, evaluationContext).poll();
-    if (currentEvaluator == null) {
-      return EmptyTransformEvaluator.create(transform);
-    }
-    return currentEvaluator;
+    return getTransformEvaluatorQueue(transform, evaluationContext).poll();
   }
 
   /**

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -117,15 +118,7 @@ public class BoundedReadEvaluatorFactoryTest {
     when(context.createRootBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null, context);
-    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
-    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
-    assertThat(secondResult.getOutputBundles(), emptyIterable());
-    assertThat(
-        secondOutput.commit(BoundedWindow.TIMESTAMP_MAX_VALUE).getElements(), emptyIterable());
-    assertThat(
-        outputElements,
-        containsInAnyOrder(
-            gw(1L), gw(2L), gw(4L), gw(8L), gw(9L), gw(7L), gw(6L), gw(5L), gw(3L), gw(0L)));
+    assertThat(secondEvaluator, nullValue());
   }
 
   /**
@@ -143,8 +136,7 @@ public class BoundedReadEvaluatorFactoryTest {
         factory.forApplication(longs.getProducingTransformInternal(), null, context);
     TransformEvaluator<?> secondEvaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null, context);
-
-    InProcessTransformResult secondResult = secondEvaluator.finishBundle();
+    assertThat(secondEvaluator, nullValue());
 
     InProcessTransformResult result = evaluator.finishBundle();
     assertThat(result.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
@@ -155,8 +147,6 @@ public class BoundedReadEvaluatorFactoryTest {
         outputElements,
         containsInAnyOrder(
             gw(1L), gw(2L), gw(4L), gw(8L), gw(9L), gw(7L), gw(6L), gw(5L), gw(3L), gw(0L)));
-    assertThat(secondResult.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE));
-    assertThat(secondResult.getOutputBundles(), emptyIterable());
     assertThat(
         secondOutput.commit(BoundedWindow.TIMESTAMP_MAX_VALUE).getElements(), emptyIterable());
     assertThat(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorServicesTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorServicesTest.java
@@ -67,8 +67,8 @@ public class TransformExecutorServicesTest {
     parallel.schedule(first);
     parallel.schedule(second);
 
-    verify(first).call();
-    verify(second).call();
+    verify(first).run();
+    verify(second).run();
     assertThat(
         scheduled,
         Matchers.allOf(
@@ -95,10 +95,10 @@ public class TransformExecutorServicesTest {
 
     TransformExecutorService serial = TransformExecutorServices.serial(executorService, scheduled);
     serial.schedule(first);
-    verify(first).call();
+    verify(first).run();
 
     serial.schedule(second);
-    verify(second, never()).call();
+    verify(second, never()).run();
 
     assertThat(scheduled, Matchers.<TransformExecutor<?>, Boolean>hasEntry(first, true));
     assertThat(
@@ -108,7 +108,7 @@ public class TransformExecutorServicesTest {
                 Matchers.<TransformExecutor<?>>equalTo(second), any(Boolean.class))));
 
     serial.complete(first);
-    verify(second).call();
+    verify(second).run();
     assertThat(scheduled, Matchers.<TransformExecutor<?>, Boolean>hasEntry(second, true));
     assertThat(
         scheduled,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
@@ -130,7 +130,7 @@ public class TransformExecutorTest {
             created.getProducingTransformInternal(),
             completionCallback,
             transformEvaluationState);
-    executor.call();
+    executor.run();
 
     assertThat(finishCalled.get(), is(true));
     assertThat(completionCallback.handledResult, equalTo(result));
@@ -349,7 +349,7 @@ public class TransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    executor.call();
+    executor.run();
     TestEnforcement<?> testEnforcement = enforcement.instance;
     assertThat(
         testEnforcement.beforeElements,
@@ -409,7 +409,7 @@ public class TransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    Future<InProcessTransformResult> task = Executors.newSingleThreadExecutor().submit(executor);
+    Future<?> task = Executors.newSingleThreadExecutor().submit(executor);
     testLatch.await();
     fooBytes.getValue()[0] = 'b';
     evaluatorLatch.countDown();
@@ -468,7 +468,7 @@ public class TransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    Future<InProcessTransformResult> task = Executors.newSingleThreadExecutor().submit(executor);
+    Future<?> task = Executors.newSingleThreadExecutor().submit(executor);
     testLatch.await();
     fooBytes.getValue()[0] = 'b';
     evaluatorLatch.countDown();


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Null TransformEvaluators for sources represent a source where all splits
are currently in use or completed.

Update TransformExecutor to handle null evaluators properly.

Change TransformExecutor to a Runnable.