### PR TITLE
[BEAM-271] Option to configure remote Dataflow windmill service endpoint

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -191,6 +191,18 @@ public interface DataflowPipelineDebugOptions extends PipelineOptions {
   void setOverrideWindmillBinary(String value);
 
   /**
+   * Custom windmill service endpoint.
+   */
+  @Description("Custom windmill service endpoint.")
+  String getWindmillServiceEndpoint();
+  void setWindmillServiceEndpoint(String value);
+
+  @Description("Port for communicating with a remote windmill service.")
+  @Default.Integer(443)
+  int getWindmillServicePort();
+  void setWindmillServicePort(int value);
+
+  /**
    * Number of threads to use on the Dataflow worker harness. If left unspecified,
    * the Dataflow service will compute an appropriate number of threads to use.
    */


### PR DESCRIPTION
Add two options to DataflowPipelineDebugOptions to configure Dataflow remove windmill service. This lets Dataflow users to configure the streaming pipelines to point to remote windmill service.