### PR TITLE
[BEAM-117] Runners should be resilient to DisplayData failure

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -72,6 +72,10 @@ public class DisplayData implements Serializable {
    * Collect the {@link DisplayData} from a component. This will traverse all subcomponents
    * specified via {@link Builder#include} in the given component. Data in this component will be in
    * a namespace derived from the component.
+   *
+   * <p>Pipeline runners should call this method in order to collect display data. While it should
+   * be safe to call {@code DisplayData.from} on any component which implements it, runners should
+   * be resilient to exceptions thrown while collecting display data.
    */
   public static DisplayData from(HasDisplayData component) {
     checkNotNull(component, "component argument cannot be null");

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/DatastoreIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/DatastoreIOTest.java
@@ -194,7 +194,7 @@ public class DatastoreIOTest {
   }
 
   @Test
-  public void testSourceDipslayData() {
+  public void testSourceDisplayData() {
   DatastoreIO.Source source = DatastoreIO.source()
       .withDataset(DATASET)
       .withQuery(QUERY)
@@ -242,7 +242,7 @@ public class DatastoreIOTest {
   }
 
   @Test
-  public void testSinkDipslayData() {
+  public void testSinkDisplayData() {
     DatastoreIO.Sink sink = DatastoreIO.sink()
         .withDataset(DATASET)
         .withHost(HOST);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -972,7 +972,7 @@ public class DisplayDataTest implements Serializable {
    */
   @Test
   @Category(RunnableOnService.class)
-  public void testRunnersResilientToDispalyDataExceptions() {
+  public void testRunnersResilientToDisplayDataExceptions() {
     Pipeline p = TestPipeline.create();
     PCollection<Integer> pCol = p
         .apply(Create.of(1, 2, 3))

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -39,7 +39,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.RunnableOnService;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.display.DisplayData.Item;
 import org.apache.beam.sdk.values.PCollection;
@@ -62,11 +69,13 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -75,8 +84,8 @@ import java.util.regex.Pattern;
  * Tests for {@link DisplayData} class.
  */
 @RunWith(JUnit4.class)
-public class DisplayDataTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
+public class DisplayDataTest implements Serializable {
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
   private static final DateTimeFormatter ISO_FORMATTER = ISODateTimeFormat.dateTime();
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -956,6 +965,38 @@ public class DisplayDataTest {
     assertThat(json, hasExpectedJson(
         component, "JAVA_CLASS", "class", quoted(DisplayDataTest.class.getName()),
         quoted("DisplayDataTest"), "baz", "http://abc"));
+  }
+
+  /**
+   * Validate that all runners are resilient to exceptions thrown while retrieving display data.
+   */
+  @Test
+  @Category(RunnableOnService.class)
+  public void testRunnersResilientToDispalyDataExceptions() {
+    Pipeline p = TestPipeline.create();
+    PCollection<Integer> pCol = p
+        .apply(Create.of(1, 2, 3))
+        .apply(new IdentityTransform<Integer>() {
+          @Override
+          public void populateDisplayData(Builder builder) {
+            throw new RuntimeException("bug!");
+          }
+        });
+
+    PAssert.that(pCol).containsInAnyOrder(1, 2, 3);
+    p.run();
+  }
+
+  private static class IdentityTransform<T> extends PTransform<PCollection<T>, PCollection<T>> {
+    @Override
+    public PCollection<T> apply(PCollection<T> input) {
+      return input.apply(ParDo.of(new DoFn<T, T>() {
+        @Override
+        public void processElement(ProcessContext c) throws Exception {
+          c.output(c.element());
+        }
+      }));
+    }
   }
 
   private String quoted(Object obj) {


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Display data is collected from PTransforms at Pipeline construction
time. Collecting display data runs user code from provided transforms
and fn's. These components should be designed not to throw during
pipeline construction, however we also shouldn't fail a pipeline
if this code does fail.

This PR adds resiliency to the DataflowPipelineTranslator, where
we collect display data for the Dataflow runner, and also a
RunnableOnService test to verify that all runners are resilient to
display data failures. Other runners are not yet using display data,
but will get this validation for free when they do.