### PR TITLE
Upgrade versions of google libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <google-auto-service.version>1.0-rc2</google-auto-service.version>
     <google-auto-value.version>1.1</google-auto-value.version>
     <google-clients.version>1.22.0</google-clients.version>
-    <google-cloud-bigdataoss.version>1.4.3</google-cloud-bigdataoss.version>
+    <google-cloud-bigdataoss.version>1.4.5</google-cloud-bigdataoss.version>
     <google-cloud-dataflow-java-proto-library-all.version>0.5.160304</google-cloud-dataflow-java-proto-library-all.version>
     <guava.version>19.0</guava.version>
     <grpc.version>0.12.0</grpc.version>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -296,7 +296,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>0.3.1</version>
+      <version>0.4.0</version>
       <exclusions>
         <!-- Exclude an old version of guava that is being pulled in by a transitive 
           dependency of google-api-client -->

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>19.0</version>
     </dependency>
 
      <dependency>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

GCSIO 1.4.3 -> 1.4.5 (bug fixes)
Guava 18.0 -> 19.0 (only impacts maven archetypes, everything else was on 19.0)
google-auth-library-oauth2-http 0.3.1 -> 0.4.0 (bug fixes)
(transitively) com.google.auth:google-auth-library-credentials 0.3.1 -> 0.4.0
No other dependency changes occurred