### PR TITLE
[BEAM-22] More regularly schedule additional roots

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutorServices.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutorServices.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.direct;
 
 import com.google.common.base.MoreObjects;
 
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -37,18 +36,16 @@ final class TransformExecutorServices {
    * Returns an EvaluationState that evaluates {@link TransformExecutor TransformExecutors} in
    * parallel.
    */
-  public static TransformExecutorService parallel(
-      ExecutorService executor, Map<TransformExecutor<?>, Boolean> scheduled) {
-    return new ParallelEvaluationState(executor, scheduled);
+  public static TransformExecutorService parallel(ExecutorService executor) {
+    return new ParallelEvaluationState(executor);
   }
 
   /**
    * Returns an EvaluationState that evaluates {@link TransformExecutor TransformExecutors} in
    * serial.
    */
-  public static TransformExecutorService serial(
-      ExecutorService executor, Map<TransformExecutor<?>, Boolean> scheduled) {
-    return new SerialEvaluationState(executor, scheduled);
+  public static TransformExecutorService serial(ExecutorService executor) {
+    return new SerialEvaluationState(executor);
   }
 
   /**
@@ -60,23 +57,18 @@ final class TransformExecutorServices {
    */
   private static class ParallelEvaluationState implements TransformExecutorService {
     private final ExecutorService executor;
-    private final Map<TransformExecutor<?>, Boolean> scheduled;
 
-    private ParallelEvaluationState(
-        ExecutorService executor, Map<TransformExecutor<?>, Boolean> scheduled) {
+    private ParallelEvaluationState(ExecutorService executor) {
       this.executor = executor;
-      this.scheduled = scheduled;
     }
 
     @Override
     public void schedule(TransformExecutor<?> work) {
       executor.submit(work);
-      scheduled.put(work, true);
     }
 
     @Override
     public void complete(TransformExecutor<?> completed) {
-      scheduled.remove(completed);
     }
   }
 
@@ -90,14 +82,11 @@ final class TransformExecutorServices {
    */
   private static class SerialEvaluationState implements TransformExecutorService {
     private final ExecutorService executor;
-    private final Map<TransformExecutor<?>, Boolean> scheduled;
 
     private AtomicReference<TransformExecutor<?>> currentlyEvaluating;
     private final Queue<TransformExecutor<?>> workQueue;
 
-    private SerialEvaluationState(
-        ExecutorService executor, Map<TransformExecutor<?>, Boolean> scheduled) {
-      this.scheduled = scheduled;
+    private SerialEvaluationState(ExecutorService executor) {
       this.executor = executor;
       this.currentlyEvaluating = new AtomicReference<>();
       this.workQueue = new ConcurrentLinkedQueue<>();
@@ -122,7 +111,6 @@ final class TransformExecutorServices {
                 + " but could not complete due to unexpected currently executing "
                 + currentlyEvaluating.get());
       }
-      scheduled.remove(completed);
       updateCurrentlyEvaluating();
     }
 
@@ -133,7 +121,6 @@ final class TransformExecutorServices {
           TransformExecutor<?> newWork = workQueue.poll();
           if (newWork != null) {
             if (currentlyEvaluating.compareAndSet(null, newWork)) {
-              scheduled.put(newWork, true);
               executor.submit(newWork);
             } else {
               workQueue.offer(newWork);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
@@ -55,9 +55,7 @@ import org.mockito.MockitoAnnotations;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -79,7 +77,6 @@ public class TransformExecutorTest {
   private BundleFactory bundleFactory;
   @Mock private InProcessEvaluationContext evaluationContext;
   @Mock private TransformEvaluatorRegistry registry;
-  private Map<TransformExecutor<?>, Boolean> scheduled;
 
   @Before
   public void setup() {
@@ -87,9 +84,8 @@ public class TransformExecutorTest {
 
     bundleFactory = InProcessBundleFactory.create();
 
-    scheduled = new HashMap<>();
     transformEvaluationState =
-        TransformExecutorServices.parallel(MoreExecutors.newDirectExecutorService(), scheduled);
+        TransformExecutorServices.parallel(MoreExecutors.newDirectExecutorService());
 
     evaluatorCompleted = new CountDownLatch(1);
     completionCallback = new RegisteringCompletionCallback(evaluatorCompleted);
@@ -135,7 +131,6 @@ public class TransformExecutorTest {
     assertThat(finishCalled.get(), is(true));
     assertThat(completionCallback.handledResult, equalTo(result));
     assertThat(completionCallback.handledThrowable, is(nullValue()));
-    assertThat(scheduled, not(Matchers.<TransformExecutor<?>>hasKey(executor)));
   }
 
   @Test
@@ -184,7 +179,6 @@ public class TransformExecutorTest {
     assertThat(elementsProcessed, containsInAnyOrder(spam, third, foo));
     assertThat(completionCallback.handledResult, equalTo(result));
     assertThat(completionCallback.handledThrowable, is(nullValue()));
-    assertThat(scheduled, not(Matchers.<TransformExecutor<?>>hasKey(executor)));
   }
 
   @Test
@@ -228,7 +222,6 @@ public class TransformExecutorTest {
 
     assertThat(completionCallback.handledResult, is(nullValue()));
     assertThat(completionCallback.handledThrowable, Matchers.<Throwable>equalTo(exception));
-    assertThat(scheduled, not(Matchers.<TransformExecutor<?>>hasKey(executor)));
   }
 
   @Test
@@ -267,7 +260,6 @@ public class TransformExecutorTest {
 
     assertThat(completionCallback.handledResult, is(nullValue()));
     assertThat(completionCallback.handledThrowable, Matchers.<Throwable>equalTo(exception));
-    assertThat(scheduled, not(Matchers.<TransformExecutor<?>>hasKey(executor)));
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This ensures that even when elements are pushed back into the Pipeline
Runner, roots are scheduled if necessary.

As elements may be rescheduled indefinitely, this is required to ensure
that unbounded roots are scheduled during pipeline execution when
existing elements are blocked on side inputs.