### PR TITLE
[BEAM-295] Remove erroneous close() calls in Flink Create Sources

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkCreateFunction.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkCreateFunction.java
@@ -57,7 +57,5 @@ public class FlinkCreateFunction<IN, OUT> implements FlatMapFunction<IN, OUT> {
         out.collect(outValue);
       }
     }
-
-    out.close();
   }
 }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/FlinkStreamingCreateFunction.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/FlinkStreamingCreateFunction.java
@@ -59,7 +59,5 @@ public class FlinkStreamingCreateFunction<IN, OUT> implements FlatMapFunction<IN
         out.collect(WindowedValue.of(outValue, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING));
       }
     }
-
-    out.close();
   }
 }


### PR DESCRIPTION
Collector.close() should only be called by internal Flink components,
not by user functions.