### PR TITLE
Add CrashingRunner for use in TestPipeline

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CrashingRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CrashingRunner.java
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.transforms.Aggregator;
  * A {@link PipelineRunner} that applies no overrides and throws an exception on calls to
  * {@link Pipeline#run()}. For use in {@link TestPipeline} to construct but not execute pipelines.
  */
-class CrashingRunner extends PipelineRunner<PipelineResult>{
+public class CrashingRunner extends PipelineRunner<PipelineResult>{
 
   public static CrashingRunner fromOptions(PipelineOptions opts) {
     return new CrashingRunner();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CrashingRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CrashingRunner.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.testing;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.runners.AggregatorRetrievalException;
+import org.apache.beam.sdk.runners.AggregatorValues;
+import org.apache.beam.sdk.runners.PipelineRunner;
+import org.apache.beam.sdk.transforms.Aggregator;
+
+/**
+ * A {@link PipelineRunner} that applies no overrides and throws an exception on calls to
+ * {@link Pipeline#run()}. For use in {@link TestPipeline} to construct but not execute pipelines.
+ */
+class CrashingRunner extends PipelineRunner<PipelineResult>{
+
+  public static CrashingRunner fromOptions(PipelineOptions opts) {
+    return new CrashingRunner();
+  }
+
+  @Override
+  public PipelineResult run(Pipeline pipeline) {
+    throw new IllegalArgumentException(String.format("Cannot call #run(Pipeline) on an instance "
+            + "of %s. %s should only be used as the default to construct a Transform Hierarchy "
+            + "using %s, and cannot execute Pipelines. Instead, specify a %s "
+            + "by providing Pipeline Options in the environment variable '%s'.",
+        getClass().getSimpleName(),
+        getClass().getSimpleName(),
+        TestPipeline.class.getSimpleName(),
+        PipelineRunner.class.getSimpleName(),
+        TestPipeline.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS));
+  }
+
+  private static class TestPipelineResult implements PipelineResult {
+    private TestPipelineResult() {
+      // Should never be instantiated by the enclosing class
+      throw new AssertionError(String.format("Forbidden to instantiate %s",
+          getClass().getSimpleName()));
+    }
+
+    @Override
+    public State getState() {
+      throw new AssertionError(String.format("Forbidden to instantiate %s",
+          getClass().getSimpleName()));
+    }
+
+    @Override
+    public <T> AggregatorValues<T> getAggregatorValues(Aggregator<?, T> aggregator)
+        throws AggregatorRetrievalException {
+      throw new AssertionError(String.format("Forbidden to instantiate %s",
+          getClass().getSimpleName()));
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CrashingRunner.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CrashingRunner.java
@@ -39,9 +39,9 @@ class CrashingRunner extends PipelineRunner<PipelineResult>{
   @Override
   public PipelineResult run(Pipeline pipeline) {
     throw new IllegalArgumentException(String.format("Cannot call #run(Pipeline) on an instance "
-            + "of %s. %s should only be used as the default to construct a Transform Hierarchy "
+            + "of %s. %s should only be used as the default to construct a Pipeline "
             + "using %s, and cannot execute Pipelines. Instead, specify a %s "
-            + "by providing Pipeline Options in the environment variable '%s'.",
+            + "by providing PipelineOptions in the environment variable '%s'.",
         getClass().getSimpleName(),
         getClass().getSimpleName(),
         TestPipeline.class.getSimpleName(),
@@ -52,13 +52,13 @@ class CrashingRunner extends PipelineRunner<PipelineResult>{
   private static class TestPipelineResult implements PipelineResult {
     private TestPipelineResult() {
       // Should never be instantiated by the enclosing class
-      throw new AssertionError(String.format("Forbidden to instantiate %s",
+      throw new UnsupportedOperationException(String.format("Forbidden to instantiate %s",
           getClass().getSimpleName()));
     }
 
     @Override
     public State getState() {
-      throw new AssertionError(String.format("Forbidden to instantiate %s",
+      throw new UnsupportedOperationException(String.format("Forbidden to instantiate %s",
           getClass().getSimpleName()));
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -84,7 +84,8 @@ import javax.annotation.Nullable;
  * containing the message from the {@link PAssert} that failed.
  */
 public class TestPipeline extends Pipeline {
-  private static final String PROPERTY_BEAM_TEST_PIPELINE_OPTIONS = "beamTestPipelineOptions";
+  static final String PROPERTY_BEAM_TEST_PIPELINE_OPTIONS = "beamTestPipelineOptions";
+  static final String PROPERTY_USE_DEFAULT_DUMMY_RUNNER = "beamUseDummyRunner";
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
@@ -145,8 +146,13 @@ public class TestPipeline extends Pipeline {
                   .as(TestPipelineOptions.class);
 
       options.as(ApplicationNameOptions.class).setAppName(getAppName());
-      // If no options were specified, use a test credential object on all pipelines.
+      // If no options were specified, set some reasonable defaults
       if (Strings.isNullOrEmpty(beamTestPipelineOptions)) {
+        // If there are no provided options, check to see if a dummy runner should be used.
+        String useDefaultDummy = System.getProperty(PROPERTY_USE_DEFAULT_DUMMY_RUNNER);
+        if (!Strings.isNullOrEmpty(useDefaultDummy) && Boolean.valueOf(useDefaultDummy)) {
+          options.setRunner(CrashingRunner.class);
+        }
         options.as(GcpOptions.class).setGcpCredential(new TestCredential());
       }
       options.setStableUniqueNames(CheckEnabled.ERROR);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/CrashingRunnerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/CrashingRunnerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.testing;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.runners.PipelineRunner;
+import org.apache.beam.sdk.transforms.Create;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link CrashingRunner}.
+ */
+@RunWith(JUnit4.class)
+public class CrashingRunnerTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void fromOptionsCreatesInstance() {
+    PipelineOptions opts = PipelineOptionsFactory.create();
+    opts.setRunner(CrashingRunner.class);
+    PipelineRunner<? extends PipelineResult> runner = PipelineRunner.fromOptions(opts);
+
+    assertTrue("Should have created a CrashingRunner", runner instanceof CrashingRunner);
+  }
+
+  @Test
+  public void applySucceeds() {
+    PipelineOptions opts = PipelineOptionsFactory.create();
+    opts.setRunner(CrashingRunner.class);
+
+    Pipeline p = Pipeline.create(opts);
+    p.apply(Create.of(1, 2, 3));
+  }
+
+  @Test
+  public void runThrows() {
+    PipelineOptions opts = PipelineOptionsFactory.create();
+    opts.setRunner(CrashingRunner.class);
+
+    Pipeline p = Pipeline.create(opts);
+    p.apply(Create.of(1, 2, 3));
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Cannot call #run");
+    thrown.expectMessage(TestPipeline.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS);
+
+    p.run();
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.options.GcpOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.DirectPipelineRunner;
+import org.apache.beam.sdk.transforms.Create;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -143,11 +144,14 @@ public class TestPipelineTest {
 
   @Test
   public void testRunWithDummyEnvironmentVariableFails() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Cannot call #run");
     System.getProperties()
         .setProperty(TestPipeline.PROPERTY_USE_DEFAULT_DUMMY_RUNNER, Boolean.toString(true));
-    TestPipeline.create().run();
+    TestPipeline pipeline = TestPipeline.create();
+    pipeline.apply(Create.of(1, 2, 3));
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Cannot call #run");
+    pipeline.run();
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.beam.sdk.testing;
 
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -36,6 +36,7 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -49,6 +50,7 @@ import java.util.UUID;
 @RunWith(JUnit4.class)
 public class TestPipelineTest {
   @Rule public TestRule restoreSystemProperties = new RestoreSystemProperties();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testCreationUsingDefaults() {
@@ -137,6 +139,15 @@ public class TestPipelineTest {
 
     assertEquals(m1, newOpts.getOnCreateMatcher());
     assertEquals(m2, newOpts.getOnSuccessMatcher());
+  }
+
+  @Test
+  public void testRunWithDummyEnvironmentVariableFails() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Cannot call #run");
+    System.getProperties()
+        .setProperty(TestPipeline.PROPERTY_USE_DEFAULT_DUMMY_RUNNER, Boolean.toString(true));
+    TestPipeline.create().run();
   }
 
   /**


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

CrashingRunner is a PipelineRunner that crashes on calls to run() with
an IllegalArgumentException. As a runner is currently required to
construct a Pipeline object, this allows removal of all Pipeline Runners
from the core SDK while retaining tests that depend only on the graph
construction behavior.