### PR TITLE
Add BoundedReader APIs for expressing remaining and consumed parallelism

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -571,7 +571,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
     }
 
     @Override
-    public long getParallelismRemaining() {
+    public long getSplitPointsRemaining() {
       if (isDone()) {
         return 0;
       }
@@ -581,7 +581,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
           return 1;
         }
       }
-      return super.getParallelismRemaining();
+      return super.getSplitPointsRemaining();
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -487,10 +487,10 @@ public class AvroSource<T> extends BlockBasedSource<T> {
     }
 
     // Precondition: the stream is positioned after the sync marker in the current (about to be
-    // previous) block. currentBlockSize equals the size of the current (previous) block, or zero
-    // if this reader was just started.
+    // previous) block. currentBlockSize equals the size of the current block, or zero if this
+    // reader was just started.
     //
-    // Postcondition: same as above, but for the current (formerly next) block.
+    // Postcondition: same as above, but for the new current (formerly next) block.
     @Override
     public boolean readNextBlock() throws IOException {
       // Before reading the variable-sized block header, record the current number of bytes read.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.io;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -40,17 +42,22 @@ import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.snappy.SnappyCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
+import org.apache.commons.compress.utils.CountingInputStream;
 
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
 import java.util.Collection;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
+
+import javax.annotation.concurrent.GuardedBy;
 
 // CHECKSTYLE.OFF: JavadocStyle
 /**
@@ -439,10 +446,6 @@ public class AvroSource<T> extends BlockBasedSource<T> {
    * the total number of records in the block and the block's size in bytes, followed by the
    * block's (optionally-encoded) records. Each block is terminated by a 16-bit sync marker.
    *
-   * <p>Here, we consider the sync marker that precedes a block to be its offset, as this allows
-   * a reader that begins reading at that offset to detect the sync marker and the beginning of
-   * the block.
-   *
    * @param <T> The type of records contained in the block.
    */
   @Experimental(Experimental.Kind.SOURCE_SINK)
@@ -450,24 +453,25 @@ public class AvroSource<T> extends BlockBasedSource<T> {
     // The current block.
     private AvroBlock<T> currentBlock;
 
-    // Offset of the block.
+    // A lock used to synchronize block offsets for getRemainingParallelism
+    private final Object progressLock = new Object();
+
+    // Offset of the current block.
+    @GuardedBy("progressLock")
     private long currentBlockOffset = 0;
 
     // Size of the current block.
+    @GuardedBy("progressLock")
     private long currentBlockSizeBytes = 0;
 
-    // Current offset within the stream.
-    private long currentOffset = 0;
-
     // Stream used to read from the underlying file.
-    // A pushback stream is used to restore bytes buffered during seeking/decoding.
+    // A pushback stream is used to restore bytes buffered during seeking.
     private PushbackInputStream stream;
+    // Counts the number of bytes read. Used only to tell how many bytes are taken up in
+    // a block's variable-length header.
+    private CountingInputStream countStream;
 
-    // Small buffer for reading encoded values from the stream.
-    // The maximum size of an encoded long is 10 bytes, and this buffer will be used to read two.
-    private final byte[] readBuffer = new byte[20];
-
-    // Decoder to decode binary-encoded values from the buffer.
+    // Caches the Avro DirectBinaryDecoder used to decode binary-encoded values from the buffer.
     private BinaryDecoder decoder;
 
     /**
@@ -482,51 +486,56 @@ public class AvroSource<T> extends BlockBasedSource<T> {
       return (AvroSource<T>) super.getCurrentSource();
     }
 
+    // Precondition: the stream is positioned after the sync marker in the current (about to be
+    // previous) block. currentBlockSize equals the size of the current (previous) block, or zero
+    // if this reader was just started.
+    //
+    // Postcondition: same as above, but for the current (formerly next) block.
     @Override
     public boolean readNextBlock() throws IOException {
-      // The next block in the file is after the first sync marker that can be read starting from
-      // the current offset. First, we seek past the next sync marker, if it exists. After a sync
-      // marker is the start of a block. A block begins with the number of records contained in
-      // the block, encoded as a long, followed by the size of the block in bytes, encoded as a
-      // long. The currentOffset after this method should be last byte after this block, and the
-      // currentBlockOffset should be the start of the sync marker before this block.
+      // First, we mark the previous block as read by adding the now-previous block size to the
+      // current block offset.
+      synchronized (progressLock) {
+        currentBlockOffset += currentBlockSizeBytes;
+      }
 
-      // Seek to the next sync marker, if one exists.
-      currentOffset += advancePastNextSyncMarker(stream, getCurrentSource().getSyncMarker());
-
-      // The offset of the current block includes its preceding sync marker.
-      currentBlockOffset = currentOffset - getCurrentSource().getSyncMarker().length;
-
-      // Read a small buffer to parse the block header.
-      // We cannot use a BinaryDecoder to do this directly from the stream because a BinaryDecoder
-      // internally buffers data and we only want to read as many bytes from the stream as the size
-      // of the header. Though BinaryDecoder#InputStream returns an input stream that is aware of
-      // its internal buffering, we would have to re-wrap this input stream to seek for the next
-      // block in the file.
-      int read = stream.read(readBuffer);
-      // We reached the last sync marker in the file.
-      if (read <= 0) {
+      // Before reading the variable-sized block header, record the current number of bytes read.
+      long preHeaderCount = countStream.getBytesRead();
+      decoder = DecoderFactory.get().directBinaryDecoder(countStream, decoder);
+      long numRecords;
+      try {
+        numRecords = decoder.readLong();
+      } catch (EOFException e) {
+        // Expected for the last block, at which the start position is the EOF. The way to detect
+        // stream ending is to try reading from it.
         return false;
       }
-      decoder = DecoderFactory.get().binaryDecoder(readBuffer, decoder);
-      long numRecords = decoder.readLong();
       long blockSize = decoder.readLong();
 
-      // The decoder buffers data internally, but since we know the size of the stream the
-      // decoder has constructed from the readBuffer, the number of bytes available in the
-      // input stream is equal to the number of unconsumed bytes.
-      int headerSize = readBuffer.length - decoder.inputStream().available();
-      stream.unread(readBuffer, headerSize, read - headerSize);
+      // Mark header size as the change in the number of bytes read.
+      long headerSize = countStream.getBytesRead() - preHeaderCount;
 
       // Create the current block by reading blockSize bytes. Block sizes permitted by the Avro
       // specification are [32, 2^30], so this narrowing is ok.
       byte[] data = new byte[(int) blockSize];
-      stream.read(data);
+      int read = stream.read(data);
+      checkState(blockSize == read, "Only %s/%s bytes in the block were read", read, blockSize);
       currentBlock = new AvroBlock<>(data, numRecords, getCurrentSource());
-      currentBlockSizeBytes = blockSize;
 
-      // Update current offset with the number of bytes we read to get the next block.
-      currentOffset += headerSize + blockSize;
+      // Read the end of this block, which MUST be a sync marker for correctness.
+      byte[] syncMarker = getCurrentSource().getSyncMarker();
+      long bytesToReadSyncMarker = advancePastNextSyncMarker(stream, syncMarker);
+      checkState(
+          bytesToReadSyncMarker == syncMarker.length,
+          "Should be positioned at a sync marker, but required %s [!= %s] bytes to read one",
+          bytesToReadSyncMarker,
+          syncMarker.length);
+
+      // Total block size includes the header, block content, and trailing sync marker.
+      synchronized (progressLock) {
+        currentBlockSizeBytes = headerSize + blockSize + syncMarker.length;
+      }
+
       return true;
     }
 
@@ -537,32 +546,65 @@ public class AvroSource<T> extends BlockBasedSource<T> {
 
     @Override
     public long getCurrentBlockOffset() {
-      return currentBlockOffset;
+      synchronized (progressLock) {
+        return currentBlockOffset;
+      }
     }
 
     @Override
     public long getCurrentBlockSize() {
-      return currentBlockSizeBytes;
+      synchronized (progressLock) {
+        return currentBlockSizeBytes;
+      }
+    }
+
+    @Override
+    public long getParallelismRemaining() {
+      if (isDone()) {
+        return 0;
+      }
+      synchronized (progressLock) {
+        if (currentBlockOffset + currentBlockSizeBytes >= getCurrentSource().getEndOffset()) {
+          // This block is known to be the last block in the range.
+          return 1;
+        }
+      }
+      return super.getParallelismRemaining();
     }
 
     /**
      * Creates a {@link PushbackInputStream} that has a large enough pushback buffer to be able
-     * to push back the syncBuffer and the readBuffer.
+     * to push back the syncBuffer.
      */
     private PushbackInputStream createStream(ReadableByteChannel channel) {
       return new PushbackInputStream(
           Channels.newInputStream(channel),
-          getCurrentSource().getSyncMarker().length + readBuffer.length);
+          getCurrentSource().getSyncMarker().length);
     }
 
-    /**
-     * Starts reading from the provided channel. Assumes that the channel is already seeked to
-     * the source's start offset.
-     */
+    // Postcondition: the stream is positioned at the start of the first block after the start of
+    // the current source, and currentBlockOffset is that position. Additionally, the
+    // currentBlockSizeBytes will be set to 0 indicating that the previous block was empty.
     @Override
     protected void startReading(ReadableByteChannel channel) throws IOException {
+      long startOffset = getCurrentSource().getStartOffset();
+      byte[] syncMarker = getCurrentSource().getSyncMarker();
+      long syncMarkerLength = syncMarker.length;
+
+      if (startOffset != 0) {
+        // Rewind order to find the sync marker ending the previous block.
+        long position = Math.max(0, startOffset - syncMarkerLength);
+        ((SeekableByteChannel) channel).position(position);
+        startOffset = position;
+      }
+
+      // Satisfy the post condition.
       stream = createStream(channel);
-      currentOffset = getCurrentSource().getStartOffset();
+      countStream = new CountingInputStream(stream);
+      synchronized (progressLock) {
+        currentBlockOffset = startOffset + advancePastNextSyncMarker(stream, syncMarker);
+        currentBlockSizeBytes = 0;
+      }
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
@@ -207,20 +207,26 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
 
     @Override
     public Double getFractionConsumed() {
-      if (getCurrentSource().getEndOffset() == Long.MAX_VALUE) {
+      if (!isStarted()) {
+        return 0.0;
+      }
+      if (isDone()) {
+        return 1.0;
+      }
+      FileBasedSource<T> source = getCurrentSource();
+      if (source.getEndOffset() == Long.MAX_VALUE) {
         return null;
       }
-      Block<T> currentBlock = getCurrentBlock();
+
       long currentBlockOffset = getCurrentBlockOffset();
-      long startOffset = getCurrentSource().getStartOffset();
-      long endOffset = getCurrentSource().getEndOffset();
+      long startOffset = source.getStartOffset();
+      long endOffset = source.getEndOffset();
       double fractionAtBlockStart =
           ((double) (currentBlockOffset - startOffset)) / (endOffset - startOffset);
       double fractionAtBlockEnd =
           ((double) (currentBlockOffset + getCurrentBlockSize() - startOffset)
               / (endOffset - startOffset));
-      double blockFraction = (currentBlock == null)
-          ? 0.0 : currentBlock.getFractionOfBlockConsumed();
+      double blockFraction = getCurrentBlock().getFractionOfBlockConsumed();
       return Math.min(
           1.0,
           fractionAtBlockStart + blockFraction * (fractionAtBlockEnd - fractionAtBlockStart));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
@@ -206,6 +206,7 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
     }
 
     @Override
+    @Nullable
     public Double getFractionConsumed() {
       if (!isStarted()) {
         return 0.0;
@@ -215,6 +216,7 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
       }
       FileBasedSource<T> source = getCurrentSource();
       if (source.getEndOffset() == Long.MAX_VALUE) {
+        // Unknown end offset, so we cannot tell.
         return null;
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
@@ -211,10 +211,6 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
         return null;
       }
       Block<T> currentBlock = getCurrentBlock();
-      if (currentBlock == null) {
-        // There is no current block (i.e., the read has not yet begun).
-        return 0.0;
-      }
       long currentBlockOffset = getCurrentBlockOffset();
       long startOffset = getCurrentSource().getStartOffset();
       long endOffset = getCurrentSource().getEndOffset();
@@ -223,11 +219,11 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
       double fractionAtBlockEnd =
           ((double) (currentBlockOffset + getCurrentBlockSize() - startOffset)
               / (endOffset - startOffset));
+      double blockFraction = (currentBlock == null)
+          ? 0.0 : currentBlock.getFractionOfBlockConsumed();
       return Math.min(
           1.0,
-          fractionAtBlockStart
-          + currentBlock.getFractionOfBlockConsumed()
-            * (fractionAtBlockEnd - fractionAtBlockStart));
+          fractionAtBlockStart + blockFraction * (fractionAtBlockEnd - fractionAtBlockStart));
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -46,8 +46,8 @@ import javax.annotation.Nullable;
  *     <ul>
  *       <li>Progress estimation ({@link BoundedReader#getFractionConsumed})
  *       <li>Tracking of parallelism, to determine with the current source can be split
- *        ({@link BoundedReader#getParallelismConsumed()} and
- *        {@link BoundedReader#getParallelismRemaining()}).
+ *        ({@link BoundedReader#getSplitPointsConsumed()} and
+ *        {@link BoundedReader#getSplitPointsRemaining()}).
  *       <li>Dynamic splitting of the current source ({@link BoundedReader#splitAtFraction}).
  *     </ul>
  *     </li>
@@ -93,14 +93,14 @@ public abstract class BoundedSource<T> extends Source<T> {
    *
    * <h3>Thread safety</h3>
    * All methods will be run from the same thread except {@link #splitAtFraction},
-   * {@link #getFractionConsumed}, {@link #getCurrentSource}, {@link #getParallelismConsumed()},
-   * and {@link #getParallelismRemaining()}, all of which can be called concurrently
+   * {@link #getFractionConsumed}, {@link #getCurrentSource}, {@link #getSplitPointsConsumed()},
+   * and {@link #getSplitPointsRemaining()}, all of which can be called concurrently
    * from a different thread. There will not be multiple concurrent calls to
    * {@link #splitAtFraction}.
    *
    * <p>It must be safe to call {@link #splitAtFraction}, {@link #getFractionConsumed},
-   * {@link #getCurrentSource}, {@link #getParallelismConsumed()}, and
-   * {@link #getParallelismRemaining()} concurrently with other methods.
+   * {@link #getCurrentSource}, {@link #getSplitPointsConsumed()}, and
+   * {@link #getSplitPointsRemaining()} concurrently with other methods.
    *
    * <p>Additionally, a successful {@link #splitAtFraction} call must, by definition, cause
    * {@link #getCurrentSource} to start returning a different value.
@@ -146,10 +146,10 @@ public abstract class BoundedSource<T> extends Source<T> {
     }
 
     /**
-     * A constant to use as the return value for {@link #getParallelismConsumed()} or
-     * {@link #getParallelismRemaining()} when the exact value is unknown.
+     * A constant to use as the return value for {@link #getSplitPointsConsumed()} or
+     * {@link #getSplitPointsRemaining()} when the exact value is unknown.
      */
-    public static final long PARALLELISM_UNKNOWN = -1;
+    public static final long SPLIT_POINTS_UNKNOWN = -1;
 
     /**
      * Returns the total amount of parallelism in the consumed (returned and processed) range of
@@ -194,16 +194,16 @@ public abstract class BoundedSource<T> extends Source<T> {
      * range tracker's ability to count split points to implement this method. See
      * {@link OffsetBasedSource.OffsetBasedReader} and {@link OffsetRangeTracker} for an example.
      *
-     * <p>Defaults to {@link #PARALLELISM_UNKNOWN}. Any value less than 0 will be interpreted
+     * <p>Defaults to {@link #SPLIT_POINTS_UNKNOWN}. Any value less than 0 will be interpreted
      * as unknown.
      *
      * <h3>Thread safety</h3>
      * See the javadoc on {@link BoundedReader} for information about thread safety.
      *
-     * @see #getParallelismRemaining()
+     * @see #getSplitPointsRemaining()
      */
-    public long getParallelismConsumed() {
-      return PARALLELISM_UNKNOWN;
+    public long getSplitPointsConsumed() {
+      return SPLIT_POINTS_UNKNOWN;
     }
 
     /**
@@ -213,7 +213,7 @@ public abstract class BoundedSource<T> extends Source<T> {
      * split point returned, in the remainder part of the source.
      *
      * <p>This function should be implemented only <strong>in addition to
-     * {@link #getParallelismConsumed()}</strong> and only if <em>an exact value can be
+     * {@link #getSplitPointsConsumed()}</strong> and only if <em>an exact value can be
      * returned</em>.
      *
      * <p>Consider the following examples: (1) An input that can be read in parallel down to the
@@ -247,16 +247,16 @@ public abstract class BoundedSource<T> extends Source<T> {
      * remainder can be split off.
      * </ul>
      *
-     * <p>Defaults to {@link #PARALLELISM_UNKNOWN}. Any value less than 0 will be interpreted as
+     * <p>Defaults to {@link #SPLIT_POINTS_UNKNOWN}. Any value less than 0 will be interpreted as
      * unknown.
      *
      * <h3>Thread safety</h3>
      * See the javadoc on {@link BoundedReader} for information about thread safety.
      *
-     * @see #getParallelismConsumed()
+     * @see #getSplitPointsConsumed()
      */
-    public long getParallelismRemaining() {
-      return PARALLELISM_UNKNOWN;
+    public long getSplitPointsRemaining() {
+      return SPLIT_POINTS_UNKNOWN;
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import javax.annotation.Nullable;
+
 /**
  * A {@link Source} that reads a finite amount of input and, because of that, supports
  * some additional operations.
@@ -131,6 +133,7 @@ public abstract class BoundedSource<T> extends Source<T> {
      * methods (including itself), and it is therefore critical for it to be implemented
      * in a thread-safe way.
      */
+    @Nullable
     public Double getFractionConsumed() {
       return null;
     }
@@ -365,6 +368,7 @@ public abstract class BoundedSource<T> extends Source<T> {
      *
      * <p>By default, returns null to indicate that splitting is not possible.
      */
+    @Nullable
     public BoundedSource<T> splitAtFraction(double fraction) {
       return null;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -396,9 +396,9 @@ public class CompressedSource<T> extends FileBasedSource<T> {
     }
 
     @Override
-    public final long getParallelismConsumed() {
+    public final long getSplitPointsConsumed() {
       if (splittable) {
-        return readerDelegate.getParallelismConsumed();
+        return readerDelegate.getSplitPointsConsumed();
       } else {
         synchronized (progressLock) {
           return (isDone() && numRecordsRead > 0) ? 1 : 0;
@@ -407,9 +407,9 @@ public class CompressedSource<T> extends FileBasedSource<T> {
     }
 
     @Override
-    public final long getParallelismRemaining() {
+    public final long getSplitPointsRemaining() {
       if (splittable) {
-        return readerDelegate.getParallelismRemaining();
+        return readerDelegate.getSplitPointsRemaining();
       } else {
         return isDone() ? 0 : 1;
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -362,8 +362,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
     private final FileBasedReader<T> readerDelegate;
     private final CompressedSource<T> source;
     private final boolean splittable;
-    private int numRecordsRead;
-    private volatile boolean done = false;
+    private volatile int numRecordsRead;
 
     /**
      * Create a {@code CompressedReader} from a {@code CompressedSource} and delegate reader.
@@ -395,7 +394,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
         return readerDelegate.getParallelismConsumed();
       }
 
-      return done ? 1 : 0;
+      return (isDone() && numRecordsRead > 0) ? 1 : 0;
     }
 
     @Override
@@ -404,7 +403,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
         return readerDelegate.getParallelismRemaining();
       }
 
-      return done ? 0 : 1;
+      return isDone() ? 0 : 1;
     }
 
     /**
@@ -448,7 +447,6 @@ public class CompressedSource<T> extends FileBasedSource<T> {
     @Override
     protected final boolean readNextRecord() throws IOException {
       if (!readerDelegate.readNextRecord()) {
-        done = true;
         return false;
       }
       ++numRecordsRead;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
@@ -210,6 +210,11 @@ public class CountingSource {
     }
 
     @Override
+    public synchronized long getParallelismRemaining() {
+      return Math.max(0, getCurrentSource().getEndOffset() - current);
+    }
+
+    @Override
     public synchronized BoundedCountingSource getCurrentSource()  {
       return (BoundedCountingSource) super.getCurrentSource();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
@@ -210,7 +210,7 @@ public class CountingSource {
     }
 
     @Override
-    public synchronized long getParallelismRemaining() {
+    public synchronized long getSplitPointsRemaining() {
       return Math.max(0, getCurrentSource().getEndOffset() - current);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/DatastoreIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/DatastoreIO.java
@@ -887,12 +887,12 @@ public class DatastoreIO {
     }
 
     @Override
-    public final long getParallelismConsumed() {
+    public final long getSplitPointsConsumed() {
       return done ? 1 : 0;
     }
 
     @Override
-    public final long getParallelismRemaining() {
+    public final long getSplitPointsRemaining() {
       return done ? 0 : 1;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/DatastoreIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/DatastoreIO.java
@@ -865,6 +865,8 @@ public class DatastoreIO {
      */
     private int userLimit;
 
+    private volatile boolean done = false;
+
     private Entity currentEntity;
 
     /**
@@ -885,6 +887,16 @@ public class DatastoreIO {
     }
 
     @Override
+    public final long getParallelismConsumed() {
+      return done ? 1 : 0;
+    }
+
+    @Override
+    public final long getParallelismRemaining() {
+      return done ? 0 : 1;
+    }
+
+    @Override
     public boolean start() throws IOException {
       return advance();
     }
@@ -901,6 +913,7 @@ public class DatastoreIO {
 
       if (entities == null || !entities.hasNext()) {
         currentEntity = null;
+        done = true;
         return false;
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -489,7 +489,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
     }
 
     @Override
-    public FileBasedSource<T> getCurrentSource() {
+    public synchronized FileBasedSource<T> getCurrentSource() {
       return (FileBasedSource<T>) super.getCurrentSource();
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -230,8 +230,21 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
    */
   public abstract static class OffsetBasedReader<T> extends BoundedReader<T> {
     private static final Logger LOG = LoggerFactory.getLogger(OffsetBasedReader.class);
-
     private OffsetBasedSource<T> source;
+
+    /**
+     * Returns true if the last call to {@link #start} or {@link #advance} returned false.
+     */
+    public final boolean isDone() {
+      return rangeTracker.isDone();
+    }
+
+    /**
+     * Returns true if there has been a call to {@link #start}.
+     */
+    public final boolean isStarted() {
+      return rangeTracker.isStarted();
+    }
 
     /** The {@link OffsetRangeTracker} managing the range and current position of the source. */
     private final OffsetRangeTracker rangeTracker;
@@ -266,12 +279,14 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
 
     @Override
     public final boolean start() throws IOException {
-      return startImpl() && rangeTracker.tryReturnRecordAt(isAtSplitPoint(), getCurrentOffset());
+      return startImpl() && rangeTracker.tryReturnRecordAt(isAtSplitPoint(), getCurrentOffset())
+          || rangeTracker.markDone();
     }
 
     @Override
     public final boolean advance() throws IOException {
-      return advanceImpl() && rangeTracker.tryReturnRecordAt(isAtSplitPoint(), getCurrentOffset());
+      return advanceImpl() && rangeTracker.tryReturnRecordAt(isAtSplitPoint(), getCurrentOffset())
+          || rangeTracker.markDone();
     }
 
     /**
@@ -312,6 +327,30 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
     @Override
     public Double getFractionConsumed() {
       return rangeTracker.getFractionConsumed();
+    }
+
+    @Override
+    public long getParallelismConsumed() {
+      return rangeTracker.getSplitPointsProcessed();
+    }
+
+    @Override
+    public long getParallelismRemaining() {
+      if (isDone()) {
+        return 0;
+      }
+      if (!isStarted()) {
+        // Note that even if the current source does not allow splitting, we don't know that
+        // it's non-empty so we return UNKNOWN instead of 1.
+        return BoundedReader.PARALLELISM_UNKNOWN;
+      }
+      if (!getCurrentSource().allowsDynamicSplitting()) {
+        return 1;
+      }
+      if (getCurrentOffset() + 1 >= rangeTracker.getStopPosition()) {
+        return 1;
+      }
+      return super.getParallelismRemaining();
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -330,18 +330,18 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
     }
 
     @Override
-    public long getParallelismConsumed() {
+    public long getSplitPointsConsumed() {
       return rangeTracker.getSplitPointsProcessed();
     }
 
     @Override
-    public long getParallelismRemaining() {
+    public long getSplitPointsRemaining() {
       if (isDone()) {
         return 0;
       } else if (!isStarted()) {
         // Note that even if the current source does not allow splitting, we don't know that
         // it's non-empty so we return UNKNOWN instead of 1.
-        return BoundedReader.PARALLELISM_UNKNOWN;
+        return BoundedReader.SPLIT_POINTS_UNKNOWN;
       } else if (!getCurrentSource().allowsDynamicSplitting()) {
         // Started (so non-empty) and unsplittable, so only the current task.
         return 1;
@@ -351,7 +351,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
         return 1;
       } else {
         // Use the default.
-        return super.getParallelismRemaining();
+        return super.getSplitPointsRemaining();
       }
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -839,11 +839,11 @@ public class TextIO {
       }
 
       @Override
-      public long getParallelismRemaining() {
+      public long getSplitPointsRemaining() {
         if (isStarted() && startOfNextRecord >= getCurrentSource().getEndOffset()) {
           return isDone() ? 0 : 1;
         }
-        return super.getParallelismRemaining();
+        return super.getSplitPointsRemaining();
       }
 
       @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRangeTracker.java
@@ -196,7 +196,7 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
    * {@link #tryReturnRecordAt(boolean, long)} with {@code isAtSplitPoint} true and at a larger
    * offset.
    *
-   * <p>Note that for correctness when implementing {@link BoundedReader#getParallelismConsumed()},
+   * <p>Note that for correctness when implementing {@link BoundedReader#getSplitPointsConsumed()},
    * if a reader finishes before {@link #tryReturnRecordAt(boolean, long)} returns false,
    * the reader should add an additional call to {@link #markDone()}. This will indicate that
    * processing for the last seen split point has been finished.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRangeTracker.java
@@ -179,6 +179,9 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
     if (stopOffset == OFFSET_INFINITY) {
       return 0.0;
     }
+    if (lastRecordStart >= stopOffset) {
+      return 1.0;
+    }
     // E.g., when reading [3, 6) and lastRecordStart is 4, that means we consumed 3,4 of 3,4,5
     // which is (4 - 3 + 1) / (6 - 3) = 67%.
     // Also, clamp to at most 1.0 because the last consumed position can extend past the

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/OffsetRangeTracker.java
@@ -17,6 +17,10 @@
  */
 package org.apache.beam.sdk.io.range;
 
+import static com.google.common.base.Preconditions.checkState;
+
+import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import org.slf4j.Logger;
@@ -32,6 +36,8 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
   private long stopOffset;
   private long lastRecordStart = -1L;
   private long offsetOfLastSplitPoint = -1L;
+  private long splitPointsSeen = 0L;
+  private boolean done = false;
 
   /**
    * Offset corresponding to infinity. This can only be used as the upper-bound of a range, and
@@ -47,6 +53,15 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
   public OffsetRangeTracker(long startOffset, long stopOffset) {
     this.startOffset = startOffset;
     this.stopOffset = stopOffset;
+  }
+
+  public synchronized boolean isStarted() {
+    // done => started: handles the case when the reader was empty.
+    return (offsetOfLastSplitPoint != -1) || done;
+  }
+
+  public synchronized boolean isDone() {
+    return done;
   }
 
   @Override
@@ -65,9 +80,17 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
   }
 
   public synchronized boolean tryReturnRecordAt(boolean isAtSplitPoint, long recordStart) {
-    if (lastRecordStart == -1 && !isAtSplitPoint) {
+    if (!isStarted() && !isAtSplitPoint) {
       throw new IllegalStateException(
           String.format("The first record [starting at %d] must be at a split point", recordStart));
+    }
+    if (recordStart < startOffset) {
+      throw new IllegalStateException(
+          String.format(
+              "Trying to return record [starting at %d] which is before the start offset [%d]",
+              recordStart,
+              startOffset));
+
     }
     if (recordStart < lastRecordStart) {
       throw new IllegalStateException(
@@ -77,8 +100,11 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
               recordStart,
               lastRecordStart));
     }
+
+    lastRecordStart = recordStart;
+
     if (isAtSplitPoint) {
-      if (offsetOfLastSplitPoint != -1L && recordStart == offsetOfLastSplitPoint) {
+      if (recordStart == offsetOfLastSplitPoint) {
         throw new IllegalStateException(
             String.format(
                 "Record at a split point has same offset as the previous split point: "
@@ -86,12 +112,13 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
                 offsetOfLastSplitPoint, recordStart));
       }
       if (recordStart >= stopOffset) {
+        done = true;
         return false;
       }
       offsetOfLastSplitPoint = recordStart;
+      ++splitPointsSeen;
     }
 
-    lastRecordStart = recordStart;
     return true;
   }
 
@@ -105,7 +132,7 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
       LOG.debug("Refusing to split {} at {}: stop position unspecified", this, splitOffset);
       return false;
     }
-    if (lastRecordStart == -1) {
+    if (!isStarted()) {
       LOG.debug("Refusing to split {} at {}: unstarted", this, splitOffset);
       return false;
     }
@@ -143,10 +170,13 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
 
   @Override
   public synchronized double getFractionConsumed() {
-    if (stopOffset == OFFSET_INFINITY) {
+    if (!isStarted()) {
       return 0.0;
     }
-    if (lastRecordStart == -1) {
+    if (isDone()) {
+      return 1.0;
+    }
+    if (stopOffset == OFFSET_INFINITY) {
       return 0.0;
     }
     // E.g., when reading [3, 6) and lastRecordStart is 4, that means we consumed 3,4 of 3,4,5
@@ -154,6 +184,57 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
     // Also, clamp to at most 1.0 because the last consumed position can extend past the
     // stop position.
     return Math.min(1.0, 1.0 * (lastRecordStart - startOffset + 1) / (stopOffset - startOffset));
+  }
+
+  /**
+   * Returns the total number of split points that have been processed.
+   *
+   * <p>A split point at a particular offset has been seen if there has been a corresponding call
+   * to {@link #tryReturnRecordAt(boolean, long)} with {@code isAtSplitPoint} true. It has been
+   * processed if there has been a <em>subsequent</em> call to
+   * {@link #tryReturnRecordAt(boolean, long)} with {@code isAtSplitPoint} true and at a larger
+   * offset.
+   *
+   * <p>Note that for correctness when implementing {@link BoundedReader#getParallelismConsumed()},
+   * if a reader finishes before {@link #tryReturnRecordAt(boolean, long)} returns false,
+   * the reader should add an additional call to {@link #markDone()} This will indicate that
+   * processing for the last seen split point has been finished.
+   *
+   * @see org.apache.beam.sdk.io.OffsetBasedSource for a {@link BoundedReader}
+   * implemented using {@link OffsetRangeTracker}.
+   */
+  public synchronized long getSplitPointsProcessed() {
+    if (!isStarted()) {
+      return 0;
+    } else if (isDone()) {
+      return splitPointsSeen;
+    } else {
+      // There is a current split point, and it has not finished processing.
+      checkState(
+          splitPointsSeen > 0,
+          "A started rangeTracker should have seen > 0 split points (is %s)",
+          splitPointsSeen);
+      return splitPointsSeen - 1;
+    }
+  }
+
+
+  /**
+   * Marks this range tracker as being done. Specifically, this will mark the current split point,
+   * if one exists, as being finished.
+   *
+   * <p>Always returns false, so that it can be used in an implementation of
+   * {@link BoundedReader#start()} or {@link BoundedReader#advance()} as follows:
+   *
+   * <pre> {@code
+   * public boolean start() {
+   *   return startImpl() && rangeTracker.tryReturnRecordAt(isAtSplitPoint, position)
+   *       || rangeTracker.markDone();
+   * }} </pre>
+   */
+  public synchronized boolean markDone() {
+    done = true;
+    return false;
   }
 
   @Override
@@ -177,7 +258,10 @@ public class OffsetRangeTracker implements RangeTracker<Long> {
   @VisibleForTesting
   OffsetRangeTracker copy() {
     OffsetRangeTracker res = new OffsetRangeTracker(startOffset, stopOffset);
+    res.offsetOfLastSplitPoint = this.offsetOfLastSplitPoint;
     res.lastRecordStart = this.lastRecordStart;
+    res.done = this.done;
+    res.splitPointsSeen = this.splitPointsSeen;
     return res;
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
@@ -215,41 +215,41 @@ public class AvroSourceTest {
 
       // Before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // First 2 records are in the same block.
       assertTrue(reader.start());
       assertTrue(reader.isAtSplitPoint());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
       // continued
       assertTrue(reader.advance());
       assertFalse(reader.isAtSplitPoint());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Second block -> parallelism consumed becomes 1.
       assertTrue(reader.advance());
       assertTrue(reader.isAtSplitPoint());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
       // continued
       assertTrue(reader.advance());
       assertFalse(reader.isAtSplitPoint());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Third and final block -> parallelism consumed becomes 2, remaining becomes 1.
       assertTrue(reader.advance());
       assertTrue(reader.isAtSplitPoint());
-      assertEquals(2, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(2, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // Done
       assertFalse(reader.advance());
-      assertEquals(3, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(3, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
     }
   }
@@ -268,15 +268,15 @@ public class AvroSourceTest {
 
       // before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // confirm empty
       assertFalse(reader.start());
 
       // after reading empty source
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
@@ -18,9 +18,9 @@
 package org.apache.beam.sdk.io;
 
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
-
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -28,6 +28,8 @@ import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.io.AvroSource.AvroReader;
 import org.apache.beam.sdk.io.AvroSource.AvroReader.Seeker;
+import org.apache.beam.sdk.io.BlockBasedSource.BlockBasedReader;
+import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.SourceTestUtils;
@@ -44,6 +46,7 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.Nullable;
 import org.apache.avro.reflect.ReflectData;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -57,6 +60,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PushbackInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -194,6 +198,86 @@ public class AvroSourceTest {
       try (BoundedSource.BoundedReader<FixedRecord> reader = subSource.createReader(null)) {
         assertEquals(new Double(0.0), reader.getFractionConsumed());
       }
+    }
+  }
+
+  @Test
+  public void testProgress() throws Exception {
+    // 5 records, 2 per block.
+    List<FixedRecord> records = createFixedRecords(5);
+    String filename = generateTestFile("tmp.avro", records, SyncBehavior.SYNC_REGULAR, 2,
+        AvroCoder.of(FixedRecord.class), DataFileConstants.NULL_CODEC);
+
+    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    try (BoundedSource.BoundedReader<FixedRecord> readerOrig = source.createReader(null)) {
+      assertThat(readerOrig, Matchers.instanceOf(BlockBasedReader.class));
+      BlockBasedReader<FixedRecord> reader = (BlockBasedReader<FixedRecord>) readerOrig;
+
+      // Before starting
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // First 2 records are in the same block.
+      assertTrue(reader.start());
+      assertTrue(reader.isAtSplitPoint());
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      // continued
+      assertTrue(reader.advance());
+      assertFalse(reader.isAtSplitPoint());
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Second block -> parallelism consumed becomes 1.
+      assertTrue(reader.advance());
+      assertTrue(reader.isAtSplitPoint());
+      assertEquals(1, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      // continued
+      assertTrue(reader.advance());
+      assertFalse(reader.isAtSplitPoint());
+      assertEquals(1, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Third and final block -> parallelism consumed becomes 2, remaining becomes 1.
+      assertTrue(reader.advance());
+      assertTrue(reader.isAtSplitPoint());
+      assertEquals(2, reader.getParallelismConsumed());
+      assertEquals(1, reader.getParallelismRemaining());
+
+      // Done
+      assertFalse(reader.advance());
+      assertEquals(3, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+    }
+  }
+
+  @Test
+  public void testProgressEmptySource() throws Exception {
+    // 0 records, 20 per block.
+    List<FixedRecord> records = Collections.emptyList();
+    String filename = generateTestFile("tmp.avro", records, SyncBehavior.SYNC_REGULAR, 2,
+        AvroCoder.of(FixedRecord.class), DataFileConstants.NULL_CODEC);
+
+    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    try (BoundedSource.BoundedReader<FixedRecord> readerOrig = source.createReader(null)) {
+      assertThat(readerOrig, Matchers.instanceOf(BlockBasedReader.class));
+      BlockBasedReader<FixedRecord> reader = (BlockBasedReader<FixedRecord>) readerOrig;
+
+      // before starting
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // confirm empty
+      assertFalse(reader.start());
+
+      // after reading empty source
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -520,16 +520,16 @@ public class CompressedSourceTest {
       CompressedReader<Byte> reader = (CompressedReader<Byte>) readerOrig;
       // before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // confirm empty
       assertFalse(reader.start());
 
       // after reading empty source
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 
@@ -547,8 +547,8 @@ public class CompressedSourceTest {
       CompressedReader<Byte> reader = (CompressedReader<Byte>) readerOrig;
       // before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // confirm has three records
       for (int i = 0; i < numRecords; ++i) {
@@ -557,15 +557,15 @@ public class CompressedSourceTest {
         } else {
           assertTrue(reader.advance());
         }
-        assertEquals(0, reader.getParallelismConsumed());
-        assertEquals(1, reader.getParallelismRemaining());
+        assertEquals(0, reader.getSplitPointsConsumed());
+        assertEquals(1, reader.getSplitPointsRemaining());
       }
       assertFalse(reader.advance());
 
       // after reading empty source
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 
@@ -584,24 +584,24 @@ public class CompressedSourceTest {
 
       // Check preconditions before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // First record: none consumed, unknown remaining.
       assertTrue(reader.start());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Second record: 1 consumed, know that we're on the last record.
       assertTrue(reader.advance());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // Confirm empty and check post-conditions
       assertFalse(reader.advance());
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(2, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(2, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -462,11 +462,12 @@ public class CompressedSourceTest {
     private static class ByteReader extends FileBasedReader<Byte> {
       ByteBuffer buff = ByteBuffer.allocate(1);
       Byte current;
-      long offset = -1;
+      long offset;
       ReadableByteChannel channel;
 
       public ByteReader(ByteSource source) {
         super(source);
+        offset = source.getStartOffset() - 1;
       }
 
       @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
@@ -127,21 +127,21 @@ public class CountingSourceTest {
       // Check preconditions before starting. Note that CountingReader can always give an accurate
       // remaining parallelism.
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(numRecords, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(numRecords, reader.getSplitPointsRemaining());
 
       assertTrue(reader.start());
       int i = 0;
       do {
-        assertEquals(i, reader.getParallelismConsumed());
-        assertEquals(numRecords - i, reader.getParallelismRemaining());
+        assertEquals(i, reader.getSplitPointsConsumed());
+        assertEquals(numRecords - i, reader.getSplitPointsRemaining());
         ++i;
       } while (reader.advance());
 
       assertEquals(numRecords, i); // exactly numRecords calls to advance()
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(numRecords, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(numRecords, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
@@ -24,9 +24,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
 import org.apache.beam.sdk.io.CountingSource.CounterMark;
 import org.apache.beam.sdk.io.CountingSource.UnboundedCountingSource;
 import org.apache.beam.sdk.io.UnboundedSource.UnboundedReader;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.RunnableOnService;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -49,6 +51,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -113,6 +116,33 @@ public class CountingSourceTest {
 
     addCountingAsserts(input, numElements);
     p.run();
+  }
+
+  @Test
+  public void testProgress() throws IOException {
+    final int numRecords = 5;
+    @SuppressWarnings("deprecation")  // testing CountingSource
+    BoundedSource<Long> source = CountingSource.upTo(numRecords);
+    try (BoundedReader<Long> reader = source.createReader(PipelineOptionsFactory.create())) {
+      // Check preconditions before starting. Note that CountingReader can always give an accurate
+      // remaining parallelism.
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(numRecords, reader.getParallelismRemaining());
+
+      assertTrue(reader.start());
+      int i = 0;
+      do {
+        assertEquals(i, reader.getParallelismConsumed());
+        assertEquals(numRecords - i, reader.getParallelismRemaining());
+        ++i;
+      } while (reader.advance());
+
+      assertEquals(numRecords, i); // exactly numRecords calls to advance()
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(numRecords, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+    }
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
@@ -446,7 +446,7 @@ public class FileBasedSourceTest {
         assertTrue(fractionConsumed > lastFractionConsumed);
         lastFractionConsumed = fractionConsumed;
       }
-      assertTrue(reader.getFractionConsumed() < 1.0);
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io;
 
 import static org.apache.beam.sdk.testing.SourceTestUtils.assertSplitAtFractionExhaustive;
 import static org.apache.beam.sdk.testing.SourceTestUtils.readFromSource;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -28,6 +27,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
+import org.apache.beam.sdk.io.OffsetBasedSource.OffsetBasedReader;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 
@@ -86,13 +87,12 @@ public class OffsetBasedSourceTest {
     }
 
     @Override
-    public BoundedReader<Integer> createReader(PipelineOptions options) throws IOException {
+    public OffsetBasedReader<Integer> createReader(PipelineOptions options) throws IOException {
       return new CoarseRangeReader(this);
     }
   }
 
-  private static class CoarseRangeReader
-      extends OffsetBasedSource.OffsetBasedReader<Integer> {
+  private static class CoarseRangeReader extends OffsetBasedReader<Integer> {
     private long current = -1;
     private long granularity;
 
@@ -235,6 +235,69 @@ public class OffsetBasedSourceTest {
     }
     try (BoundedSource.BoundedReader<Integer> reader = source.createReader(options)) {
       assertFalse(reader.start());
+    }
+  }
+
+  @Test
+  public void testProgress() throws IOException {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    CoarseRangeSource source = new CoarseRangeSource(13, 17, 1, 2);
+    try (OffsetBasedReader<Integer> reader = source.createReader(options)) {
+      // Unstarted reader
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Start and produce the element 14 since granularity is 2.
+      assertTrue(reader.start());
+      assertTrue(reader.isAtSplitPoint());
+      assertEquals(14, reader.getCurrent().intValue());
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      // Advance and produce the element 15, not a split point.
+      assertTrue(reader.advance());
+      assertEquals(15, reader.getCurrent().intValue());
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Advance and produce the element 16, is a split point. Since the next offset (17) is
+      // outside the range [13, 17), remaining parallelism should become 1 from UNKNOWN.
+      assertTrue(reader.advance());
+      assertTrue(reader.isAtSplitPoint());
+      assertEquals(16, reader.getCurrent().intValue());
+      assertEquals(1, reader.getParallelismConsumed());
+      assertEquals(1, reader.getParallelismRemaining()); // The next offset is outside the range.
+      // Advance and produce the element 17, not a split point.
+      assertTrue(reader.advance());
+      assertEquals(17, reader.getCurrent().intValue());
+      assertEquals(1, reader.getParallelismConsumed());
+      assertEquals(1, reader.getParallelismRemaining());
+
+      // Advance and reach the end of the reader.
+      assertFalse(reader.advance());
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(2, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+    }
+  }
+
+  @Test
+  public void testProgressEmptySource() throws IOException {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    CoarseRangeSource source = new CoarseRangeSource(13, 17, 1, 100);
+    try (OffsetBasedReader<Integer> reader = source.createReader(options)) {
+      // before starting
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // confirm empty
+      assertFalse(reader.start());
+
+      // after reading empty source
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
@@ -245,39 +245,39 @@ public class OffsetBasedSourceTest {
     try (OffsetBasedReader<Integer> reader = source.createReader(options)) {
       // Unstarted reader
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Start and produce the element 14 since granularity is 2.
       assertTrue(reader.start());
       assertTrue(reader.isAtSplitPoint());
       assertEquals(14, reader.getCurrent().intValue());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
       // Advance and produce the element 15, not a split point.
       assertTrue(reader.advance());
       assertEquals(15, reader.getCurrent().intValue());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Advance and produce the element 16, is a split point. Since the next offset (17) is
       // outside the range [13, 17), remaining parallelism should become 1 from UNKNOWN.
       assertTrue(reader.advance());
       assertTrue(reader.isAtSplitPoint());
       assertEquals(16, reader.getCurrent().intValue());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining()); // The next offset is outside the range.
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining()); // The next offset is outside the range.
       // Advance and produce the element 17, not a split point.
       assertTrue(reader.advance());
       assertEquals(17, reader.getCurrent().intValue());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // Advance and reach the end of the reader.
       assertFalse(reader.advance());
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(2, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(2, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 
@@ -288,16 +288,16 @@ public class OffsetBasedSourceTest {
     try (OffsetBasedReader<Integer> reader = source.createReader(options)) {
       // before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // confirm empty
       assertFalse(reader.start());
 
       // after reading empty source
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -22,10 +22,10 @@ import static org.apache.beam.sdk.TestUtils.LINES_ARRAY;
 import static org.apache.beam.sdk.TestUtils.NO_INTS_ARRAY;
 import static org.apache.beam.sdk.TestUtils.NO_LINES_ARRAY;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
-
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.TextualIntegerCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
 import org.apache.beam.sdk.io.TextIO.CompressionType;
 import org.apache.beam.sdk.io.TextIO.TextSource;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -420,6 +421,117 @@ public class TextIOTest {
     assertEquals("TextIO.Read", TextIO.Read.from("somefile").toString());
     assertEquals(
         "ReadMyFile [TextIO.Read]", TextIO.Read.named("ReadMyFile").from("somefile").toString());
+  }
+
+  @Test
+  public void testProgressEmptyFile() throws IOException {
+    try (BoundedReader<String> reader =
+        prepareSource(new byte[0]).createReader(PipelineOptionsFactory.create())) {
+      // Check preconditions before starting.
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Assert empty
+      assertFalse(reader.start());
+
+      // Check postconditions after finishing
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+    }
+  }
+
+  @Test
+  public void testProgressTextFile() throws IOException {
+    String file = "line1\nline2\nline3";
+    try (BoundedReader<String> reader =
+        prepareSource(file.getBytes()).createReader(PipelineOptionsFactory.create())) {
+      // Check preconditions before starting
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Line 1
+      assertTrue(reader.start());
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Line 2
+      assertTrue(reader.advance());
+      assertEquals(1, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Line 3
+      assertTrue(reader.advance());
+      assertEquals(2, reader.getParallelismConsumed());
+      assertEquals(1, reader.getParallelismRemaining());
+
+      // Check postconditions after finishing
+      assertFalse(reader.advance());
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(3, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+    }
+  }
+
+  @Test
+  public void testProgressAfterSplitting() throws IOException {
+    String file = "line1\nline2\nline3";
+    BoundedSource source = prepareSource(file.getBytes());
+    BoundedSource remainder;
+
+    // Create the remainder, verifying properties pre- and post-splitting.
+    try (BoundedReader<String> readerOrig = source.createReader(PipelineOptionsFactory.create())) {
+      // Preconditions.
+      assertEquals(0.0, readerOrig.getFractionConsumed(), 1e-6);
+      assertEquals(0, readerOrig.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, readerOrig.getParallelismRemaining());
+
+      // First record, before splitting.
+      assertTrue(readerOrig.start());
+      assertEquals(0, readerOrig.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, readerOrig.getParallelismRemaining());
+
+      // Split. 0.1 is in line1, so should now be able to detect last record.
+      remainder = readerOrig.splitAtFraction(0.1);
+      System.err.println(readerOrig.getCurrentSource());
+      assertNotNull(remainder);
+
+      // First record, after splitting.
+      assertEquals(0, readerOrig.getParallelismConsumed());
+      assertEquals(1, readerOrig.getParallelismRemaining());
+
+      // Finish and postconditions.
+      assertFalse(readerOrig.advance());
+      assertEquals(1.0, readerOrig.getFractionConsumed(), 1e-6);
+      assertEquals(1, readerOrig.getParallelismConsumed());
+      assertEquals(0, readerOrig.getParallelismRemaining());
+    }
+
+    // Check the properties of the remainder.
+    try (BoundedReader<String> reader = remainder.createReader(PipelineOptionsFactory.create())) {
+      // Preconditions.
+      assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // First record should be line 2.
+      assertTrue(reader.start());
+      assertEquals(0, reader.getParallelismConsumed());
+      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+
+      // Second record is line 3
+      assertTrue(reader.advance());
+      assertEquals(1, reader.getParallelismConsumed());
+      assertEquals(1, reader.getParallelismRemaining());
+
+      // Check postconditions after finishing
+      assertFalse(reader.advance());
+      assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
+      assertEquals(2, reader.getParallelismConsumed());
+      assertEquals(0, reader.getParallelismRemaining());
+    }
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -429,16 +429,16 @@ public class TextIOTest {
         prepareSource(new byte[0]).createReader(PipelineOptionsFactory.create())) {
       // Check preconditions before starting.
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Assert empty
       assertFalse(reader.start());
 
       // Check postconditions after finishing
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 
@@ -449,29 +449,29 @@ public class TextIOTest {
         prepareSource(file.getBytes()).createReader(PipelineOptionsFactory.create())) {
       // Check preconditions before starting
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Line 1
       assertTrue(reader.start());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Line 2
       assertTrue(reader.advance());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Line 3
       assertTrue(reader.advance());
-      assertEquals(2, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(2, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // Check postconditions after finishing
       assertFalse(reader.advance());
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(3, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(3, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 
@@ -485,13 +485,13 @@ public class TextIOTest {
     try (BoundedReader<String> readerOrig = source.createReader(PipelineOptionsFactory.create())) {
       // Preconditions.
       assertEquals(0.0, readerOrig.getFractionConsumed(), 1e-6);
-      assertEquals(0, readerOrig.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, readerOrig.getParallelismRemaining());
+      assertEquals(0, readerOrig.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, readerOrig.getSplitPointsRemaining());
 
       // First record, before splitting.
       assertTrue(readerOrig.start());
-      assertEquals(0, readerOrig.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, readerOrig.getParallelismRemaining());
+      assertEquals(0, readerOrig.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, readerOrig.getSplitPointsRemaining());
 
       // Split. 0.1 is in line1, so should now be able to detect last record.
       remainder = readerOrig.splitAtFraction(0.1);
@@ -499,38 +499,38 @@ public class TextIOTest {
       assertNotNull(remainder);
 
       // First record, after splitting.
-      assertEquals(0, readerOrig.getParallelismConsumed());
-      assertEquals(1, readerOrig.getParallelismRemaining());
+      assertEquals(0, readerOrig.getSplitPointsConsumed());
+      assertEquals(1, readerOrig.getSplitPointsRemaining());
 
       // Finish and postconditions.
       assertFalse(readerOrig.advance());
       assertEquals(1.0, readerOrig.getFractionConsumed(), 1e-6);
-      assertEquals(1, readerOrig.getParallelismConsumed());
-      assertEquals(0, readerOrig.getParallelismRemaining());
+      assertEquals(1, readerOrig.getSplitPointsConsumed());
+      assertEquals(0, readerOrig.getSplitPointsRemaining());
     }
 
     // Check the properties of the remainder.
     try (BoundedReader<String> reader = remainder.createReader(PipelineOptionsFactory.create())) {
       // Preconditions.
       assertEquals(0.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // First record should be line 2.
       assertTrue(reader.start());
-      assertEquals(0, reader.getParallelismConsumed());
-      assertEquals(BoundedReader.PARALLELISM_UNKNOWN, reader.getParallelismRemaining());
+      assertEquals(0, reader.getSplitPointsConsumed());
+      assertEquals(BoundedReader.SPLIT_POINTS_UNKNOWN, reader.getSplitPointsRemaining());
 
       // Second record is line 3
       assertTrue(reader.advance());
-      assertEquals(1, reader.getParallelismConsumed());
-      assertEquals(1, reader.getParallelismRemaining());
+      assertEquals(1, reader.getSplitPointsConsumed());
+      assertEquals(1, reader.getSplitPointsRemaining());
 
       // Check postconditions after finishing
       assertFalse(reader.advance());
       assertEquals(1.0, reader.getFractionConsumed(), 1e-6);
-      assertEquals(2, reader.getParallelismConsumed());
-      assertEquals(0, reader.getParallelismRemaining());
+      assertEquals(2, reader.getSplitPointsConsumed());
+      assertEquals(0, reader.getSplitPointsRemaining());
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/range/OffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/range/OffsetRangeTrackerTest.java
@@ -104,7 +104,6 @@ public class OffsetRangeTrackerTest {
     assertFalse(tracker.tryReturnRecordAt(true, 150));
     assertFalse(tracker.tryReturnRecordAt(true, 151));
     // Should accept non-splitpoint records starting after stop offset.
-    assertTrue(tracker.tryReturnRecordAt(false, 135));
     assertTrue(tracker.tryReturnRecordAt(false, 152));
     assertTrue(tracker.tryReturnRecordAt(false, 160));
     assertFalse(tracker.tryReturnRecordAt(true, 171));

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
@@ -435,7 +435,7 @@ public class HDFSFileSource<K, V> extends BoundedSource<KV<K, V>> {
     }
 
     @Override
-    public final long getParallelismRemaining() {
+    public final long getSplitPointsRemaining() {
       if (done) {
         return 0;
       }

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
@@ -282,6 +282,7 @@ public class HDFSFileSource<K, V> extends BoundedSource<KV<K, V>> {
     private Configuration conf;
     private RecordReader<K, V> currentReader;
     private KV<K, V> currentPair;
+    private volatile boolean done = false;
 
     /**
      * Create a {@code HDFSFileReader} based on a file or a file pattern specification.
@@ -356,6 +357,7 @@ public class HDFSFileSource<K, V> extends BoundedSource<KV<K, V>> {
           }
           // either no next split or all readers were empty
           currentPair = null;
+          done = true;
           return false;
         }
       } catch (InterruptedException e) {
@@ -430,6 +432,16 @@ public class HDFSFileSource<K, V> extends BoundedSource<KV<K, V>> {
       } catch (IOException | InterruptedException e) {
         return null;
       }
+    }
+
+    @Override
+    public final long getParallelismRemaining() {
+      if (done) {
+        return 0;
+      }
+      // This source does not currently support dynamic work rebalancing, so remaining
+      // parallelism is always 1.
+      return 1;
     }
 
     @Override


### PR DESCRIPTION
These are useful for dynamic work rebalancing and autoscaling.