### PR TITLE
Remove inheritance from Create.TimestampedValues

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -519,7 +519,7 @@ public class Create<T> {
         Coder<T> coder = (Coder<T>) registry.getDefaultCoder(TypeDescriptor.of(elementClazz));
         return coder;
       } catch (CannotProvideCoderException exc) {
-        // let the next stage try
+        // Can't get a coder from the class of the elements, try with the elements next
       }
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -263,53 +263,9 @@ public class Create<T> {
     public Coder<T> getDefaultOutputCoder(PInput input) throws CannotProvideCoderException {
       if (coder.isPresent()) {
         return coder.get();
+      } else {
+        return getDefaultCreateCoder(input.getPipeline().getCoderRegistry(), elems);
       }
-      // First try to deduce a coder using the types of the elements.
-      Class<?> elementClazz = Void.class;
-      for (T elem : elems) {
-        if (elem == null) {
-          continue;
-        }
-        Class<?> clazz = elem.getClass();
-        if (elementClazz.equals(Void.class)) {
-          elementClazz = clazz;
-        } else if (!elementClazz.equals(clazz)) {
-          // Elements are not the same type, require a user-specified coder.
-          throw new CannotProvideCoderException(
-              "Cannot provide coder for Create: The elements are not all of the same class.");
-        }
-      }
-
-      if (elementClazz.getTypeParameters().length == 0) {
-        try {
-          @SuppressWarnings("unchecked") // elementClazz is a wildcard type
-          Coder<T> coder = (Coder<T>) input.getPipeline().getCoderRegistry()
-              .getDefaultCoder(TypeDescriptor.of(elementClazz));
-          return coder;
-        } catch (CannotProvideCoderException exc) {
-          // let the next stage try
-        }
-      }
-
-      // If that fails, try to deduce a coder using the elements themselves
-      Optional<Coder<T>> coder = Optional.absent();
-      for (T elem : elems) {
-        Coder<T> c = input.getPipeline().getCoderRegistry().getDefaultCoder(elem);
-        if (!coder.isPresent()) {
-          coder = Optional.of(c);
-        } else if (!Objects.equals(c, coder.get())) {
-          throw new CannotProvideCoderException(
-              "Cannot provide coder for elements of " + Create.class.getSimpleName() + ":"
-              + " For their common class, no coder could be provided."
-              + " Based on their values, they do not all default to the same Coder.");
-        }
-      }
-
-      if (!coder.isPresent()) {
-        throw new CannotProvideCoderException("Unable to infer a coder. Please register "
-            + "a coder for ");
-      }
-      return coder.get();
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -468,7 +424,7 @@ public class Create<T> {
    * A {@code PTransform} that creates a {@code PCollection} whose elements have
    * associated timestamps.
    */
-  public static class TimestampedValues<T> extends Values<T> {
+  public static class TimestampedValues<T> extends PTransform<PInput, PCollection<T>>{
     /**
      * Returns a {@link Create.TimestampedValues} PTransform like this one that uses the given
      * {@code Coder<T>} to decode each of the objects into a
@@ -482,17 +438,30 @@ public class Create<T> {
      * <p>Note that for {@link Create.TimestampedValues with no elements}, the {@link VoidCoder}
      * is used.
      */
-    @Override
     public TimestampedValues<T> withCoder(Coder<T> coder) {
-      return new TimestampedValues<>(elems, Optional.<Coder<T>>of(coder));
+      return new TimestampedValues<>(timestampedElements, Optional.<Coder<T>>of(coder));
     }
 
     @Override
     public PCollection<T> apply(PInput input) {
       try {
-        Coder<T> coder = getDefaultOutputCoder(input);
+        Iterable<T> rawElements =
+            Iterables.transform(
+                timestampedElements,
+                new Function<TimestampedValue<T>, T>() {
+                  @Override
+                  public T apply(TimestampedValue<T> input) {
+                    return input.getValue();
+                  }
+                });
+        Coder<T> coder;
+        if (elementCoder.isPresent()) {
+          coder = elementCoder.get();
+        } else {
+          coder = getDefaultCreateCoder(input.getPipeline().getCoderRegistry(), rawElements);
+        }
         PCollection<TimestampedValue<T>> intermediate = Pipeline.applyTransform(input,
-            Create.of(elems).withCoder(TimestampedValueCoder.of(coder)));
+            Create.of(timestampedElements).withCoder(TimestampedValueCoder.of(coder)));
 
         PCollection<T> output = intermediate.apply(ParDo.of(new ConvertTimestamps<T>()));
         output.setCoder(coder);
@@ -506,18 +475,14 @@ public class Create<T> {
     /////////////////////////////////////////////////////////////////////////////
 
     /** The timestamped elements of the resulting PCollection. */
-    private final transient Iterable<TimestampedValue<T>> elems;
+    private final transient Iterable<TimestampedValue<T>> timestampedElements;
 
-    private TimestampedValues(Iterable<TimestampedValue<T>> elems,
-        Optional<Coder<T>> coder) {
-      super(
-          Iterables.transform(elems, new Function<TimestampedValue<T>, T>() {
-            @Override
-            public T apply(TimestampedValue<T> input) {
-              return input.getValue();
-            }
-          }), coder);
-      this.elems = elems;
+    private final transient Optional<Coder<T>> elementCoder;
+
+    private TimestampedValues(
+        Iterable<TimestampedValue<T>> timestampedElements, Optional<Coder<T>> elementCoder) {
+      this.timestampedElements = timestampedElements;
+      this.elementCoder = elementCoder;
     }
 
     private static class ConvertTimestamps<T> extends DoFn<TimestampedValue<T>, T> {
@@ -526,5 +491,58 @@ public class Create<T> {
         c.outputWithTimestamp(c.element().getValue(), c.element().getTimestamp());
       }
     }
+  }
+
+  private static <T> Coder<T> getDefaultCreateCoder(CoderRegistry registry, Iterable<T> elems)
+      throws CannotProvideCoderException {
+    // First try to deduce a coder using the types of the elements.
+    Class<?> elementClazz = Void.class;
+    for (T elem : elems) {
+      if (elem == null) {
+        continue;
+      }
+      Class<?> clazz = elem.getClass();
+      if (elementClazz.equals(Void.class)) {
+        elementClazz = clazz;
+      } else if (!elementClazz.equals(clazz)) {
+        // Elements are not the same type, require a user-specified coder.
+        throw new CannotProvideCoderException(
+            String.format(
+                "Cannot provide coder for %s: The elements are not all of the same class.",
+                Create.class.getSimpleName()));
+      }
+    }
+
+    if (elementClazz.getTypeParameters().length == 0) {
+      try {
+        @SuppressWarnings("unchecked") // elementClazz is a wildcard type
+        Coder<T> coder = (Coder<T>) registry.getDefaultCoder(TypeDescriptor.of(elementClazz));
+        return coder;
+      } catch (CannotProvideCoderException exc) {
+        // let the next stage try
+      }
+    }
+
+    // If that fails, try to deduce a coder using the elements themselves
+    Optional<Coder<T>> coder = Optional.absent();
+    for (T elem : elems) {
+      Coder<T> c = registry.getDefaultCoder(elem);
+      if (!coder.isPresent()) {
+        coder = Optional.of(c);
+      } else if (!Objects.equals(c, coder.get())) {
+        throw new CannotProvideCoderException(
+            "Cannot provide coder for elements of "
+                + Create.class.getSimpleName()
+                + ":"
+                + " For their common class, no coder could be provided."
+                + " Based on their values, they do not all default to the same Coder.");
+      }
+    }
+
+    if (!coder.isPresent()) {
+      throw new CannotProvideCoderException(
+          "Unable to infer a coder. Please register " + "a coder for ");
+    }
+    return coder.get();
   }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Previously, Create.TimestampedValues extended Create.Values. This
actually resulted in confusing behavior in one runner because
Create.Values was overridden using `instanceof` checks, which
accidentally pulled in Create.TimestampedValues.

Now Create.TimeStampedValues is a simple composite transform.