### PR TITLE
[BEAM-304] KafkaIO: pin to current working version

### DIFF
--- a/sdks/java/io/kafka/pom.xml
+++ b/sdks/java/io/kafka/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>[0.9,)</version>
+      <version>0.9.0.1</version>
     </dependency>
 
     <!-- test dependencies-->


### PR DESCRIPTION
We have started picking up snapshot versions of the next version of Kafka, which cause
build breaks. Pin to 0.9.0.1 which is the version we've been building with
successfully.