### PR TITLE
[BEAM-117] Evaluate display data from InProcessPipelineRunner

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DisplayDataValidator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DisplayDataValidator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.direct;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.runners.TransformTreeNode;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.HasDisplayData;
+
+/**
+ * Validate correct implementation of {@link DisplayData} by evaluating
+ * {@link HasDisplayData#populateDisplayData(DisplayData.Builder)} during pipeline construction.
+ */
+class DisplayDataValidator {
+  // Do not instantiate
+  private DisplayDataValidator() {}
+
+  static void validatePipeline(Pipeline pipeline) {
+    validateOptions(pipeline);
+    validateTransforms(pipeline);
+  }
+
+  private static void validateOptions(Pipeline pipeline) {
+    evaluateDisplayData(pipeline.getOptions());
+  }
+
+  private static void validateTransforms(Pipeline pipeline) {
+    pipeline.traverseTopologically(Visitor.INSTANCE);
+  }
+
+  private static void evaluateDisplayData(HasDisplayData component) {
+    DisplayData.from(component);
+  }
+
+  private static class Visitor extends Pipeline.PipelineVisitor.Defaults {
+    private static final Visitor INSTANCE = new Visitor();
+
+    @Override
+    public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
+      if (!node.isRootNode()) {
+        evaluateDisplayData(node.getTransform());
+      }
+
+      return CompositeBehavior.ENTER_TRANSFORM;
+    }
+
+    @Override
+    public void visitPrimitiveTransform(TransformTreeNode node) {
+      evaluateDisplayData(node.getTransform());
+    }
+  }
+}

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/InProcessPipelineRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/InProcessPipelineRunner.java
@@ -222,6 +222,8 @@ public class InProcessPipelineRunner
                 GroupByKey.class, InProcessGroupByKeyOnly.class));
     pipeline.traverseTopologically(keyedPValueVisitor);
 
+    DisplayDataValidator.validatePipeline(pipeline);
+
     InProcessEvaluationContext context =
         InProcessEvaluationContext.create(
             getPipelineOptions(),

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -84,7 +84,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * {@link PipelineOptions#as(Class)}.
  */
 @ThreadSafe
-class ProxyInvocationHandler implements InvocationHandler {
+class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   /**
    * No two instances of this class are considered equivalent hence we generate a random hash code
@@ -141,7 +141,8 @@ class ProxyInvocationHandler implements InvocationHandler {
         && args[0] instanceof DisplayData.Builder) {
       @SuppressWarnings("unchecked")
       DisplayData.Builder builder = (DisplayData.Builder) args[0];
-      populateDisplayData(builder);
+      // Explicitly set display data namespace so thrown exceptions will have sensible type.
+      builder.include(this, PipelineOptions.class);
       return Void.TYPE;
     }
     String methodName = method.getName();
@@ -266,7 +267,7 @@ class ProxyInvocationHandler implements InvocationHandler {
    * Populate display data. See {@link HasDisplayData#populateDisplayData}. All explicitly set
    * pipeline options will be added as display data.
    */
-  private void populateDisplayData(DisplayData.Builder builder) {
+  public void populateDisplayData(DisplayData.Builder builder) {
     Set<PipelineOptionSpec> optionSpecs = PipelineOptionsReflector.getOptionSpecs(knownInterfaces);
     Multimap<String, PipelineOptionSpec> optionsMap = buildOptionNameToSpecMap(optionSpecs);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -602,16 +602,28 @@ public class DisplayData implements Serializable {
 
         try {
           subComponent.populateDisplayData(this);
+        } catch (PopulateDisplayDataException e) {
+          // Don't re-wrap exceptions recursively.
+          throw e;
         } catch (Throwable e) {
           String msg = String.format("Error while populating display data for component: %s",
               namespace);
-          throw new RuntimeException(msg, e);
+          throw new PopulateDisplayDataException(msg, e);
         }
 
         this.latestNs = prevNs;
       }
 
       return this;
+    }
+
+    /**
+     * Marker exception class for exceptions encountered while populating display data.
+     */
+    private class PopulateDisplayDataException extends RuntimeException {
+      PopulateDisplayDataException(String message, Throwable cause) {
+        super(message, cause);
+      }
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -1026,6 +1026,25 @@ public class DisplayDataTest implements Serializable {
     DisplayData.from(component);
   }
 
+  @Test
+  public void testExceptionsNotWrappedRecursively() {
+    final RuntimeException cause = new RuntimeException("oh noes!");
+    HasDisplayData component = new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.include(new HasDisplayData() {
+          @Override
+          public void populateDisplayData(Builder builder) {
+            throw cause;
+          }
+        });
+      }
+    };
+
+    thrown.expectCause(is(cause));
+    DisplayData.from(component);
+  }
+
   private static class IdentityTransform<T> extends PTransform<PCollection<T>, PCollection<T>> {
     @Override
     public PCollection<T> apply(PCollection<T> input) {


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Display data can be added to any PTransform to be used
for display from any runner. Runners are not required to
consume display data, and currently many don't.

This changes InProcessRunner to consumer display data (and then
discard it) in order to validate that display data is properly
implemented on transforms within a pipeline. Exceptions thrown
within HasDisplayData implementations will cause Pipeline.run()
to fail.