### PR TITLE
[BEAM-299] Fix invariant failure in MergingActiveWindowSet

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MergingActiveWindowSet.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MergingActiveWindowSet.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.util.state.ValueState;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,71 +40,30 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
 /**
  * An {@link ActiveWindowSet} for merging {@link WindowFn} implementations.
- * <p>
- * <p>The underlying notion of {@link MergingActiveWindowSet} is that of representing equivalence
- * classes of merged windows as a mapping from the merged "super-window" to a set of
- * <i>state address</i> windows in which some state has been persisted. The mapping need not
- * contain EPHEMERAL windows, because they are created and merged without any persistent state.
- * Each window must be a state address window for at most one window, so the mapping is
- * invertible.
- * <p>
- * <p>The states of a non-expired window are treated as follows:
- * <p>
- * <ul>
- * <li><b>NEW</b>: a NEW has an empty set of associated state address windows.</li>
- * <li><b>ACTIVE</b>: an ACTIVE window will be associated with some nonempty set of state
- * address windows. If the window has not merged, this will necessarily be the singleton set
- * containing just itself, but it is not required that an ACTIVE window be amongst its
- * state address windows.</li>
- * <li><b>MERGED</b>: a MERGED window will be in the set of associated windows for some
- * other window - that window is retrieved via {@link #mergeResultWindow} (this reverse
- * association is implemented in O(1) time).</li>
- * <li><b>EPHEMERAL</b>: EPHEMERAL windows are not persisted but are tracked transiently;
- * an EPHEMERAL window must be registered with this {@link ActiveWindowSet} by a call
- * to {@link #recordMerge} prior to any request for a {@link #mergeResultWindow}.</li>
- * </ul>
- * <p>
- * <p>To illustrate why an ACTIVE window need not be amongst its own state address windows,
- * consider two active windows W1 and W2 that are merged to form W12. Further writes may be
- * applied to either of W1 or W2, since a read of W12 implies reading both of W12 and merging
- * their results. Hence W12 need not have state directly associated with it.
  */
 public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWindowSet<W> {
   private final WindowFn<Object, W> windowFn;
 
   /**
    * Map ACTIVE and NEW windows to their state address windows. Persisted.
+   * <ul>
+   * <li>A NEW window has the empty set as its value.
+   * <li>An ACTIVE window has its (typically singleton) set of state address windows as
+   * its value.
+   * </ul>
    */
   private final Map<W, Set<W>> activeWindowToStateAddressWindows;
 
   /**
-   * As above, but only for EPHEMERAL windows. Does not need to be persisted.
-   */
-  private final Map<W, Set<W>> activeWindowToEphemeralWindows;
-
-  /**
-   * A map from window to the ACTIVE window it has been merged into. Does not need to be persisted.
-   * <p>
-   * <ul>
-   * <li>Key window may be ACTIVE, MERGED or EPHEMERAL.
-   * <li>ACTIVE windows map to themselves.
-   * <li>If W1 maps to W2 then W2 is in {@link #activeWindowToStateAddressWindows}.
-   * <li>If W1 = W2 then W1 is ACTIVE. If W1 is in the state address window set for W2 then W1 is
-   * MERGED. Otherwise W1 is EPHEMERAL.
-   * </ul>
-   */
-  private final Map<W, W> windowToActiveWindow;
-
-  /**
    * Deep clone of {@link #activeWindowToStateAddressWindows} as of last commit.
-   * <p>
-   * <p>Used to avoid writing to state if no changes have been made during the work unit.
+   * Used to avoid writing to state if no changes have been made during the work unit.
    */
   private final Map<W, Set<W>> originalActiveWindowToStateAddressWindows;
 
@@ -115,42 +75,32 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
   public MergingActiveWindowSet(WindowFn<Object, W> windowFn, StateInternals<?> state) {
     this.windowFn = windowFn;
 
-    StateTag<Object, ValueState<Map<W, Set<W>>>> mergeTreeAddr =
+    StateTag<Object, ValueState<Map<W, Set<W>>>> tag =
         StateTags.makeSystemTagInternal(StateTags.value(
             "tree", MapCoder.of(windowFn.windowCoder(), SetCoder.of(windowFn.windowCoder()))));
-    valueState = state.state(StateNamespaces.global(), mergeTreeAddr);
-    // Little use trying to prefetch this state since the ReduceFnRunner is stymied until it is
-    // available.
+    valueState = state.state(StateNamespaces.global(), tag);
+    // Little use trying to prefetch this state since the ReduceFnRunner
+    // is stymied until it is available.
     activeWindowToStateAddressWindows = emptyIfNull(valueState.read());
-    activeWindowToEphemeralWindows = new HashMap<>();
     originalActiveWindowToStateAddressWindows = deepCopy(activeWindowToStateAddressWindows);
-    windowToActiveWindow = invert(activeWindowToStateAddressWindows);
   }
 
   @Override
   public void cleanupTemporaryWindows() {
-    // All NEW windows can be forgotten.
-    Iterator<Map.Entry<W, Set<W>>> iter =
-        activeWindowToStateAddressWindows.entrySet().iterator();
+    // All NEW windows can be forgotten since they must have ended up being merged into
+    // some other ACTIVE window.
+    Iterator<Map.Entry<W, Set<W>>> iter = activeWindowToStateAddressWindows.entrySet().iterator();
     while (iter.hasNext()) {
       Map.Entry<W, Set<W>> entry = iter.next();
       if (entry.getValue().isEmpty()) {
-        windowToActiveWindow.remove(entry.getKey());
         iter.remove();
       }
     }
-
-    // All EPHEMERAL windows can be forgotten.
-    for (Map.Entry<W, Set<W>> entry : activeWindowToEphemeralWindows.entrySet()) {
-      for (W ephemeral : entry.getValue()) {
-        windowToActiveWindow.remove(ephemeral);
-      }
-    }
-    activeWindowToEphemeralWindows.clear();
   }
 
   @Override
   public void persist() {
+    checkInvariants();
     if (activeWindowToStateAddressWindows.isEmpty()) {
       // Force all persistent state to disappear.
       valueState.clear();
@@ -160,42 +110,32 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
       // No change.
       return;
     }
-    // All NEW windows must have been accounted for.
-    for (Map.Entry<W, Set<W>> entry : activeWindowToStateAddressWindows.entrySet()) {
-      Preconditions.checkState(
-          !entry.getValue().isEmpty(), "Cannot persist NEW window %s", entry.getKey());
-    }
-    // Should be no EPHEMERAL windows.
-    Preconditions.checkState(
-        activeWindowToEphemeralWindows.isEmpty(), "Unexpected EPHEMERAL windows before persist");
-
     valueState.write(activeWindowToStateAddressWindows);
     // No need to update originalActiveWindowToStateAddressWindows since this object is about to
     // become garbage.
   }
 
   @Override
-  @Nullable
-  public W mergeResultWindow(W window) {
-    return windowToActiveWindow.get(window);
-  }
-
-  @Override
-  public Set<W> getActiveWindows() {
+  public Set<W> getActiveAndNewWindows() {
     return activeWindowToStateAddressWindows.keySet();
   }
 
   @Override
   public boolean isActive(W window) {
+    Set<W> stateAddressWindows = activeWindowToStateAddressWindows.get(window);
+    return stateAddressWindows != null && !stateAddressWindows.isEmpty();
+  }
+
+  @Override
+  public boolean isActiveOrNew(W window) {
     return activeWindowToStateAddressWindows.containsKey(window);
   }
 
   @Override
   public void ensureWindowExists(W window) {
-    if (!windowToActiveWindow.containsKey(window)) {
-      Preconditions.checkState(!activeWindowToStateAddressWindows.containsKey(window));
+    if (!activeWindowToStateAddressWindows.containsKey(window)) {
+      // Add window as NEW.
       activeWindowToStateAddressWindows.put(window, new LinkedHashSet<W>());
-      windowToActiveWindow.put(window, window);
     }
   }
 
@@ -203,48 +143,40 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
   public void ensureWindowIsActive(W window) {
     Set<W> stateAddressWindows = activeWindowToStateAddressWindows.get(window);
     Preconditions.checkState(stateAddressWindows != null,
-        "Cannot ensure window %s is active since it is neither ACTIVE nor NEW",
-        window);
+                             "Cannot ensure window %s is active since it is neither ACTIVE nor NEW",
+                             window);
     if (stateAddressWindows.isEmpty()) {
-      // Window was NEW, make it ACTIVE.
-      Preconditions.checkState(windowToActiveWindow.containsKey(window)
-                               && windowToActiveWindow.get(window).equals(window));
+      // Window was NEW, make it ACTIVE with itself as its state address window.
       stateAddressWindows.add(window);
     }
   }
 
   @Override
   @VisibleForTesting
-  public void addActive(W window) {
-    if (!windowToActiveWindow.containsKey(window)) {
+  public void addActiveForTesting(W window) {
+    if (!activeWindowToStateAddressWindows.containsKey(window)) {
+      // Make window ACTIVE with itself as its state address window.
       Set<W> stateAddressWindows = new LinkedHashSet<>();
       stateAddressWindows.add(window);
       activeWindowToStateAddressWindows.put(window, stateAddressWindows);
-      windowToActiveWindow.put(window, window);
+    }
+  }
+
+  @VisibleForTesting
+  public void addActiveForTesting(W window, Iterable<W> stateAddressWindows) {
+    if (!activeWindowToStateAddressWindows.containsKey(window)) {
+      activeWindowToStateAddressWindows.put(window, Sets.newLinkedHashSet(stateAddressWindows));
     }
   }
 
   @Override
   public void remove(W window) {
-    Set<W> stateAddressWindows = activeWindowToStateAddressWindows.remove(window);
-    if (stateAddressWindows != null) {
-      for (W stateAddressWindow : stateAddressWindows) {
-        windowToActiveWindow.remove(stateAddressWindow);
-      }
-    }
-    Set<W> ephemeralWindows = activeWindowToEphemeralWindows.remove(window);
-    if (ephemeralWindows != null) {
-      for (W ephemeralWindow : ephemeralWindows) {
-        windowToActiveWindow.remove(ephemeralWindow);
-      }
-    }
-    windowToActiveWindow.remove(window);
+    activeWindowToStateAddressWindows.remove(window);
   }
 
   private class MergeContextImpl extends WindowFn<Object, W>.MergeContext {
     private MergeCallback<W> mergeCallback;
     private final List<Collection<W>> allToBeMerged;
-    private final List<Collection<W>> allActiveToBeMerged;
     private final List<W> allMergeResults;
     private final Set<W> seen;
 
@@ -252,7 +184,6 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
       windowFn.super();
       this.mergeCallback = mergeCallback;
       allToBeMerged = new ArrayList<>();
-      allActiveToBeMerged = new ArrayList<>();
       allMergeResults = new ArrayList<>();
       seen = new HashSet<>();
     }
@@ -268,12 +199,11 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
       Preconditions.checkNotNull(toBeMerged);
       Preconditions.checkNotNull(mergeResult);
       List<W> copyOfToBeMerged = new ArrayList<>(toBeMerged.size());
-      List<W> activeToBeMerged = new ArrayList<>(toBeMerged.size());
       boolean includesMergeResult = false;
       for (W window : toBeMerged) {
         Preconditions.checkNotNull(window);
         Preconditions.checkState(
-            isActive(window), "Expecting merge window %s to be active", window);
+            isActiveOrNew(window), "Expecting merge window %s to be ACTIVE or NEW", window);
         if (window.equals(mergeResult)) {
           includesMergeResult = true;
         }
@@ -281,31 +211,24 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
         Preconditions.checkState(
             notDup, "Expecting merge window %s to appear in at most one merge set", window);
         copyOfToBeMerged.add(window);
-        if (!activeWindowToStateAddressWindows.get(window).isEmpty()) {
-          activeToBeMerged.add(window);
-        }
       }
       if (!includesMergeResult) {
         Preconditions.checkState(
-            !isActive(mergeResult), "Expecting result window %s to be new", mergeResult);
+            !isActive(mergeResult), "Expecting result window %s to be NEW", mergeResult);
       }
       allToBeMerged.add(copyOfToBeMerged);
-      allActiveToBeMerged.add(activeToBeMerged);
       allMergeResults.add(mergeResult);
     }
 
     public void recordMerges() throws Exception {
       for (int i = 0; i < allToBeMerged.size(); i++) {
-        mergeCallback.prefetchOnMerge(
-            allToBeMerged.get(i), allActiveToBeMerged.get(i), allMergeResults.get(i));
+        mergeCallback.prefetchOnMerge(allToBeMerged.get(i), allMergeResults.get(i));
       }
       for (int i = 0; i < allToBeMerged.size(); i++) {
-        mergeCallback.onMerge(
-            allToBeMerged.get(i), allActiveToBeMerged.get(i), allMergeResults.get(i));
+        mergeCallback.onMerge(allToBeMerged.get(i), allMergeResults.get(i));
         recordMerge(allToBeMerged.get(i), allMergeResults.get(i));
       }
       allToBeMerged.clear();
-      allActiveToBeMerged.clear();
       allMergeResults.clear();
       seen.clear();
     }
@@ -330,6 +253,11 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
    * the active window set.
    */
   private void recordMerge(Collection<W> toBeMerged, W mergeResult) throws Exception {
+    // Note that mergedWriteStateAddress must predict the result of writeStateAddress
+    // after the corresponding merge has been applied.
+    // Thus we must ensure the first state address window in the merged result here is
+    // deterministic.
+    // Thus we use a linked hash set.
     Set<W> newStateAddressWindows = new LinkedHashSet<>();
     Set<W> existingStateAddressWindows = activeWindowToStateAddressWindows.get(mergeResult);
     if (existingStateAddressWindows != null) {
@@ -337,70 +265,35 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
       newStateAddressWindows.addAll(existingStateAddressWindows);
     }
 
-    Set<W> newEphemeralWindows = new HashSet<>();
-    Set<W> existingEphemeralWindows = activeWindowToEphemeralWindows.get(mergeResult);
-    if (existingEphemeralWindows != null) {
-      // Preserve all the existing EPHEMERAL windows for meregResult.
-      newEphemeralWindows.addAll(existingEphemeralWindows);
-    }
-
     for (W other : toBeMerged) {
       Set<W> otherStateAddressWindows = activeWindowToStateAddressWindows.get(other);
-      Preconditions.checkState(otherStateAddressWindows != null, "Window %s is not ACTIVE", other);
+      Preconditions.checkState(otherStateAddressWindows != null,
+                               "Window %s is not ACTIVE or NEW", other);
 
       for (W otherStateAddressWindow : otherStateAddressWindows) {
         // Since otherTarget equiv other AND other equiv mergeResult
         // THEN otherTarget equiv mergeResult.
         newStateAddressWindows.add(otherStateAddressWindow);
-        windowToActiveWindow.put(otherStateAddressWindow, mergeResult);
       }
       activeWindowToStateAddressWindows.remove(other);
 
-      Set<W> otherEphemeralWindows = activeWindowToEphemeralWindows.get(other);
-      if (otherEphemeralWindows != null) {
-        for (W otherEphemeral : otherEphemeralWindows) {
-          // Since otherEphemeral equiv other AND other equiv mergeResult
-          // THEN otherEphemeral equiv mergeResult.
-          newEphemeralWindows.add(otherEphemeral);
-          windowToActiveWindow.put(otherEphemeral, mergeResult);
-        }
-      }
-      activeWindowToEphemeralWindows.remove(other);
-
       // Now other equiv mergeResult.
-      if (otherStateAddressWindows.contains(other)) {
-        // Other was ACTIVE and is now known to be MERGED.
-      } else if (otherStateAddressWindows.isEmpty()) {
-        // Other was NEW thus has no state. It is now EPHEMERAL.
-        newEphemeralWindows.add(other);
-      } else if (other.equals(mergeResult)) {
-        // Other was ACTIVE, was never used to store elements, but is still ACTIVE.
-        // Leave it as active.
-      } else {
-        // Other was ACTIVE, was never used to store element, as is no longer considered ACTIVE.
-        // It is now EPHEMERAL.
-        newEphemeralWindows.add(other);
-      }
-      windowToActiveWindow.put(other, mergeResult);
     }
 
     if (newStateAddressWindows.isEmpty()) {
       // If stateAddressWindows is empty then toBeMerged must have only contained EPHEMERAL windows.
-      // Promote mergeResult to be active now.
+      // Promote mergeResult to be ACTIVE now.
       newStateAddressWindows.add(mergeResult);
     }
-    windowToActiveWindow.put(mergeResult, mergeResult);
 
     activeWindowToStateAddressWindows.put(mergeResult, newStateAddressWindows);
-    if (!newEphemeralWindows.isEmpty()) {
-      activeWindowToEphemeralWindows.put(mergeResult, newEphemeralWindows);
-    }
 
     merged(mergeResult);
   }
 
   @Override
   public void merged(W window) {
+    // Take just the first state address window.
     Set<W> stateAddressWindows = activeWindowToStateAddressWindows.get(window);
     Preconditions.checkState(stateAddressWindows != null, "Window %s is not ACTIVE", window);
     W first = Iterables.getFirst(stateAddressWindows, null);
@@ -410,8 +303,7 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
 
   /**
    * Return the state address windows for ACTIVE {@code window} from which all state associated
-   * should
-   * be read and merged.
+   * should be read and merged.
    */
   @Override
   public Set<W> readStateAddresses(W window) {
@@ -454,35 +346,13 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
     for (Map.Entry<W, Set<W>> entry : activeWindowToStateAddressWindows.entrySet()) {
       W active = entry.getKey();
       Preconditions.checkState(!entry.getValue().isEmpty(),
-          "Unexpected empty state address window set for ACTIVE window %s",
-          active);
+                               "Unexpected empty state address window set for ACTIVE window %s",
+                               active);
       for (W stateAddressWindow : entry.getValue()) {
         Preconditions.checkState(knownStateAddressWindows.add(stateAddressWindow),
-            "%s is in more than one state address window set",
-            stateAddressWindow);
-        Preconditions.checkState(active.equals(windowToActiveWindow.get(stateAddressWindow)),
-            "%s should have %s as its ACTIVE window", stateAddressWindow,
-            active);
+                                 "%s is in more than one state address window set",
+                                 stateAddressWindow);
       }
-    }
-    for (Map.Entry<W, Set<W>> entry : activeWindowToEphemeralWindows.entrySet()) {
-      W active = entry.getKey();
-      Preconditions.checkState(activeWindowToStateAddressWindows.containsKey(active),
-          "%s must be ACTIVE window", active);
-      Preconditions.checkState(
-          !entry.getValue().isEmpty(), "Unexpected empty EPHEMERAL set for %s", active);
-      for (W ephemeralWindow : entry.getValue()) {
-        Preconditions.checkState(knownStateAddressWindows.add(ephemeralWindow),
-            "%s is EPHEMERAL/state address of more than one ACTIVE window",
-            ephemeralWindow);
-        Preconditions.checkState(active.equals(windowToActiveWindow.get(ephemeralWindow)),
-            "%s should have %s as its ACTIVE window", ephemeralWindow, active);
-      }
-    }
-    for (Map.Entry<W, W> entry : windowToActiveWindow.entrySet()) {
-      Preconditions.checkState(activeWindowToStateAddressWindows.containsKey(entry.getValue()),
-          "%s should be ACTIVE since mergeResultWindow for %s",
-          entry.getValue(), entry.getKey());
     }
   }
 
@@ -502,23 +372,9 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
         sb.append(active);
         sb.append(":\n");
         for (W stateAddressWindow : stateAddressWindows) {
-          if (stateAddressWindow.equals(active)) {
-            sb.append("    ACTIVE ");
-          } else {
-            sb.append("    MERGED ");
-          }
+          sb.append("    ");
           sb.append(stateAddressWindow);
           sb.append("\n");
-          W active2 = windowToActiveWindow.get(stateAddressWindow);
-          Preconditions.checkState(active2.equals(active));
-        }
-        Set<W> ephemeralWindows = activeWindowToEphemeralWindows.get(active);
-        if (ephemeralWindows != null) {
-          for (W ephemeralWindow : ephemeralWindows) {
-            sb.append("    EPHEMERAL ");
-            sb.append(ephemeralWindow);
-            sb.append('\n');
-          }
         }
       }
     }
@@ -526,10 +382,26 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
     return sb.toString();
   }
 
-  // ======================================================================
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof MergingActiveWindowSet)) {
+      return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    MergingActiveWindowSet<W> other = (MergingActiveWindowSet<W>) o;
+
+    return activeWindowToStateAddressWindows.equals(other.activeWindowToStateAddressWindows);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(activeWindowToStateAddressWindows);
+  }
 
   /**
-   * Replace null {@code multimap} with empty map, and replace null entries in {@code multimap} with
+   * Replace null {@code multimap} with empty map, and replace null entries in {@code multimap}
+   * with
    * empty sets.
    */
   private static <W> Map<W, Set<W>> emptyIfNull(@Nullable Map<W, Set<W>> multimap) {
@@ -554,23 +426,5 @@ public class MergingActiveWindowSet<W extends BoundedWindow> implements ActiveWi
       newMultimap.put(entry.getKey(), new LinkedHashSet<>(entry.getValue()));
     }
     return newMultimap;
-  }
-
-  /**
-   * Return inversion of {@code multimap}, which must be invertible.
-   */
-  private static <W> Map<W, W> invert(Map<W, Set<W>> multimap) {
-    Map<W, W> result = new HashMap<>();
-    for (Map.Entry<W, Set<W>> entry : multimap.entrySet()) {
-      W active = entry.getKey();
-      for (W target : entry.getValue()) {
-        W previous = result.put(target, active);
-        Preconditions.checkState(
-            previous == null,
-            "Multimap is not invertible: Window %s has both %s and %s as representatives",
-            target, previous, active);
-      }
-    }
-    return result;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NonMergingActiveWindowSet.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NonMergingActiveWindowSet.java
@@ -27,7 +27,8 @@ import java.util.Collection;
 import java.util.Set;
 
 /**
- * Implementation of {@link ActiveWindowSet} used with {@link WindowFn WindowFns} that don't support
+ * Implementation of {@link ActiveWindowSet} used with {@link WindowFn WindowFns} that don't
+ * support
  * merging.
  *
  * @param <W> the types of windows being managed
@@ -40,13 +41,7 @@ public class NonMergingActiveWindowSet<W extends BoundedWindow> implements Activ
   public void persist() {}
 
   @Override
-  public W mergeResultWindow(W window) {
-    // Always represented by itself.
-    return window;
-  }
-
-  @Override
-  public Set<W> getActiveWindows() {
+  public Set<W> getActiveAndNewWindows() {
     // Only supported when merging.
     throw new java.lang.UnsupportedOperationException();
   }
@@ -58,6 +53,11 @@ public class NonMergingActiveWindowSet<W extends BoundedWindow> implements Activ
   }
 
   @Override
+  public boolean isActiveOrNew(W window) {
+    return true;
+  }
+
+  @Override
   public void ensureWindowExists(W window) {}
 
   @Override
@@ -65,7 +65,7 @@ public class NonMergingActiveWindowSet<W extends BoundedWindow> implements Activ
 
   @Override
   @VisibleForTesting
-  public void addActive(W window) {}
+  public void addActiveForTesting(W window) {}
 
   @Override
   public void remove(W window) {}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/TriggerTester.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/TriggerTester.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Maps;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -104,6 +105,7 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
   private final TriggerContextFactory<W> contextFactory;
   private final WindowFn<Object, W> windowFn;
   private final ActiveWindowSet<W> activeWindows;
+  private final Map<W, W> windowToMergeResult;
 
   /**
    * An {@link ExecutableTrigger} built from the {@link Trigger} or {@link TriggerBuilder}
@@ -155,6 +157,7 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
         windowFn.isNonMerging()
             ? new NonMergingActiveWindowSet<W>()
             : new MergingActiveWindowSet<W>(windowFn, stateInternals);
+    this.windowToMergeResult = new HashMap<>();
 
     this.contextFactory =
         new TriggerContextFactory<>(windowingStrategy, stateInternals, activeWindows);
@@ -245,7 +248,7 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
             windowFn, value, timestamp, Arrays.asList(GlobalWindow.INSTANCE)));
 
         for (W window : assignedWindows) {
-          activeWindows.addActive(window);
+          activeWindows.addActiveForTesting(window);
 
           // Today, triggers assume onTimer firing at the watermark time, whether or not they
           // explicitly set the timer themselves. So this tester must set it.
@@ -263,7 +266,7 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
       for (BoundedWindow untypedWindow : windowedValue.getWindows()) {
         // SDK is responsible for type safety
         @SuppressWarnings("unchecked")
-        W window = activeWindows.mergeResultWindow((W) untypedWindow);
+        W window = mergeResult((W) untypedWindow);
 
         Trigger.OnElementContext context = contextFactory.createOnElementContext(window,
             new TestTimers(windowNamespace(window)), windowedValue.getTimestamp(),
@@ -312,14 +315,20 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
    * since it is just to test the trigger's {@code OnMerge} method.
    */
   public final void mergeWindows() throws Exception {
+    windowToMergeResult.clear();
     activeWindows.merge(new MergeCallback<W>() {
       @Override
-      public void prefetchOnMerge(Collection<W> toBeMerged, Collection<W> activeToBeMerged,
-          W mergeResult) throws Exception {}
+      public void prefetchOnMerge(Collection<W> toBeMerged, W mergeResult) throws Exception {}
 
       @Override
-      public void onMerge(Collection<W> toBeMerged, Collection<W> activeToBeMerged, W mergeResult)
-          throws Exception {
+      public void onMerge(Collection<W> toBeMerged, W mergeResult) throws Exception {
+        List<W> activeToBeMerged = new ArrayList<W>();
+        for (W window : toBeMerged) {
+          windowToMergeResult.put(window, mergeResult);
+          if (activeWindows.isActive(window)) {
+            activeToBeMerged.add(window);
+          }
+        }
         Map<W, FinishedTriggers> mergingFinishedSets =
             Maps.newHashMapWithExpectedSize(activeToBeMerged.size());
         for (W oldWindow : activeToBeMerged) {
@@ -332,6 +341,11 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
             windowNamespace(mergeResult), mergeResult.maxTimestamp(), TimeDomain.EVENT_TIME));
       }
     });
+  }
+
+  public  W mergeResult(W window) {
+    W result = windowToMergeResult.get(window);
+    return result == null ? window : result;
   }
 
   private FinishedTriggers getFinishedSet(W window) {


### PR DESCRIPTION
The 'windowToActiveWindow' map in MergingActiveWindowSet had a confused invariant. It was partially tracking the window-to-merged-window map needed while processing a single bundle in ReduceFnRunner. But it was also tracking which 'state address windows' correspond to which active windows. The invariants were written for the second use, which was no longer correct.

This  PR factors out the window-to-merged-window map into the  ReduceFnRunner and simplifies what's left.