### PR TITLE
[BEAM-270] remove CoGroupByKey translation artifacts

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchPipelineTranslator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchPipelineTranslator.java
@@ -22,8 +22,6 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.TransformTreeNode;
 import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.join.CoGroupByKey;
-import org.apache.beam.sdk.values.PValue;
 
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -134,19 +132,7 @@ public class FlinkBatchPipelineTranslator extends FlinkPipelineTranslator {
       return null;
     }
 
-    BatchTransformTranslator<?> translator = FlinkBatchTransformTranslators.getTranslator(transform);
-
-    // No translator known
-    if (translator == null) {
-      return null;
-    }
-
-    // We actually only specialize CoGroupByKey when exactly 2 inputs
-    if (transform instanceof CoGroupByKey && node.getInput().expand().size() != 2) {
-      return null;
-    }
-
-    return translator;
+    return FlinkBatchTransformTranslators.getTranslator(transform);
   }
 
   private static String formatNodeName(TransformTreeNode node) {


### PR DESCRIPTION
We used to have an optimization for the CoGroupByKey operation with two
inputs. This is no longer the cases after changes to the batch execution
in BEAM-270.

CC @aljoscha