### PR TITLE
Return from awaitCompletion if Already Done

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -204,7 +204,11 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
       if (executorService.isShutdown() && visibleUpdates.isEmpty()) {
         return;
       }
-      update = visibleUpdates.take();
+      // Get an update; don't block forever if another thread has handled it
+      update = visibleUpdates.poll(2L, TimeUnit.SECONDS);
+      if (update == null) {
+        continue;
+      }
       if (update.throwable.isPresent()) {
         throw update.throwable.get();
       }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -212,7 +212,7 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
       if (update.throwable.isPresent()) {
         throw update.throwable.get();
       }
-    } while (!update.isDone());
+    } while (update == null || !update.isDone());
     executorService.shutdown();
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -200,7 +200,8 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
   public void awaitCompletion() throws Throwable {
     VisibleExecutorUpdate update;
     do {
-      // Return immediately if there no updates will ever be published
+      // Return immediately if there no updates will ever be published because the executor is
+      // completed, and there is are no updates to process
       if (executorService.isShutdown() && visibleUpdates.isEmpty()) {
         return;
       }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -200,6 +200,10 @@ final class ExecutorServiceParallelExecutor implements InProcessExecutor {
   public void awaitCompletion() throws Throwable {
     VisibleExecutorUpdate update;
     do {
+      // Return immediately if there no updates will ever be published
+      if (executorService.isShutdown() && visibleUpdates.isEmpty()) {
+        return;
+      }
       update = visibleUpdates.take();
       if (update.throwable.isPresent()) {
         throw update.throwable.get();


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This ensures that a call to ExecutorService#awaitCompletion returns immediately
if there are no visible updates and the executor has completed. If the executor is
in this state, no additional visible updates will be published and the call will hang.

This sequence generally will not happen, as calls via InProcessPipelineResult
return if the state is already terminal, but this ensures that parallel calls to
awaitCompletion do not hang one calling thread.