### PR TITLE
[BEAM-155] Use custom Assertions in Spark Streaming Tests

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/AssertContains.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/AssertContains.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.spark.translation.streaming;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.runners.spark.translation.streaming.utils.PAssertStreaming;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.PAssert.IterableAssert;
+import org.apache.beam.sdk.transforms.Aggregator;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A version of {@link PAssert}, more specifically
+ * {@link IterableAssert#containsInAnyOrder(Iterable)} that does not use side inputs, suitable for
+ * use when the input {@link PCollection} conforms to certain restrictions.
+ *
+ * <p>Specifically, if the input {@link PCollection} will only ever produce one pane per key, and
+ * all windows contain the same elements, this will succeed.
+ *
+ * <p>Compatible with {@link PAssertStreaming}.
+ */
+public class AssertContains<InputT> extends PTransform<PCollection<InputT>, PDone> {
+  private final Collection<InputT> expected;
+
+  public AssertContains(Collection<InputT> expected) {
+    this.expected = expected;
+  }
+
+  public PDone apply(PCollection<InputT> input) {
+    input
+        .apply(WithKeys.<Long, InputT>of(0L))
+        .apply(GroupByKey.<Long, InputT>create())
+        .apply(Values.<Iterable<InputT>>create())
+        .apply(ParDo.of(new AssertContentsEqualFn<InputT>(input.getCoder(), expected)));
+
+    return PDone.in(input.getPipeline());
+  }
+
+  private static class AssertContentsEqualFn<InputT> extends DoFn<Iterable<InputT>, Long> {
+    /** For compatibility with {@link PAssert}. */
+    private final Aggregator<Integer, Integer> successes =
+        createAggregator(PAssertStreaming.SUCCESS_COUNTER, new Sum.SumIntegerFn());
+    /** For compatibility with {@link PAssert}. */
+    private final Aggregator<Integer, Integer> failures =
+        createAggregator(PAssertStreaming.FAILURE_COUNTER, new Sum.SumIntegerFn());
+
+    private final Coder<InputT> coder;
+    private final Collection<byte[]> encodedExpected;
+
+    private AssertContentsEqualFn(Coder<InputT> coder, Collection<InputT> expected) {
+      this.coder = coder;
+      ImmutableList.Builder<byte[]> encodedBuilder = ImmutableList.builder();
+      for (InputT elem : expected) {
+        try {
+          encodedBuilder.add(CoderUtils.encodeToByteArray(coder, elem));
+        } catch (CoderException e) {
+          throw new IllegalArgumentException(
+              "Could not encode expected elements with provided coder",
+              e);
+        }
+      }
+      encodedExpected = encodedBuilder.build();
+    }
+
+    @Override
+    public void processElement(ProcessContext c) throws Exception {
+      List<InputT> expected = new ArrayList<>();
+      for (byte[] encoded : encodedExpected) {
+        expected.add(CoderUtils.decodeFromByteArray(coder, encoded));
+      }
+      Iterable<InputT> elems = c.element();
+      try {
+        assertThat(elems, containsInAnyOrder(expected.toArray()));
+        successes.addValue(1);
+      } catch (AssertionError e) {
+        failures.addValue(1);
+        throw e;
+      }
+    }
+  }
+}

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/KafkaStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/KafkaStreamingTest.java
@@ -27,10 +27,8 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
@@ -116,8 +114,7 @@ public class KafkaStreamingTest {
 
     PCollection<String> formattedKV = windowedWords.apply(ParDo.of(new FormatKVFn()));
 
-    PAssert.thatIterable(formattedKV.apply(View.<String>asIterable()))
-        .containsInAnyOrder(EXPECTED);
+    formattedKV.apply(new AssertContains<>(EXPECTED));
 
     EvaluationResult res = SparkPipelineRunner.create(options).run(p);
     res.close();
@@ -137,5 +134,4 @@ public class KafkaStreamingTest {
       c.output(c.element().getKey() + "," + c.element().getValue());
     }
   }
-
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/SimpleStreamingWordCountTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/SimpleStreamingWordCountTest.java
@@ -26,8 +26,6 @@ import org.apache.beam.runners.spark.translation.streaming.utils.PAssertStreamin
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.testing.PAssert;
-import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.PCollection;
@@ -71,8 +69,7 @@ public class SimpleStreamingWordCountTest {
 
     PCollection<String> output = windowedWords.apply(new SimpleWordCountTest.CountWords());
 
-    PAssert.thatIterable(output.apply(View.<String>asIterable()))
-        .containsInAnyOrder(EXPECTED_COUNT_SET);
+    output.apply(new AssertContains<>(EXPECTED_COUNT_SET));
 
     EvaluationResult res = SparkPipelineRunner.create(options).run(p);
     res.close();

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/utils/PAssertStreaming.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/utils/PAssertStreaming.java
@@ -30,8 +30,8 @@ public final class PAssertStreaming {
   /**
    * Copied aggregator names from {@link org.apache.beam.sdk.testing.PAssert}.
    */
-  static final String SUCCESS_COUNTER = "PAssertSuccess";
-  static final String FAILURE_COUNTER = "PAssertFailure";
+  public static final String SUCCESS_COUNTER = "PAssertSuccess";
+  public static final String FAILURE_COUNTER = "PAssertFailure";
 
   private PAssertStreaming() {
   }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Spark Streaming Side Inputs behave differently than the Beam Model. As
the underlying implementation of PAssert is based on side inputs, this
means that Streaming Spark Tests that use SideInputs as the actuals are
non-portable.

More specifically, this enables pipeline-construction time enforcement
that a Preexisting Side Input must be in a window compatible with the
Global Window (otherwise the side input WindowFn should throw an
exception, e.g. in [PartitioningWindowFn](https://github.com/apache/incubator-beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java#L46)

Modify FlattenStreamingTest, KafkaStreamingTest, and
SimpleStreamingWordCountTest to group all of the contents of the
asserted PCollection into a single key, and assert the contents of that
concatenation, rather than doing so via PAssert and Side Input.