### PR TITLE
Reorganization of Maven coordinates

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -20,14 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
+    <groupId>org.apache.beam.examples</groupId>
     <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-examples-all</artifactId>
-  <name>Apache Beam :: Examples :: Java All</name>
+  <artifactId>java</artifactId>
+  <name>Apache Beam :: Examples :: Java</name>
   <description>Apache Beam SDK provides a simple, Java-based
   interface for processing virtually any size data. This
   artifact includes all Apache Beam Java SDK examples.</description>
@@ -207,8 +207,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -20,14 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
+    <groupId>org.apache.beam.examples</groupId>
     <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java8examples-all</artifactId>
-  <name>Apache Beam :: Examples :: Java 8 All</name>
+  <artifactId>java8</artifactId>
+  <name>Apache Beam :: Examples :: Java 8</name>
   <description>Apache Beam Java SDK provides a simple, Java-based
     interface for processing virtually any size data.
     This artifact includes examples of the SDK from a Java 8
@@ -106,13 +106,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-examples-all</artifactId>
+      <groupId>org.apache.beam.examples</groupId>
+      <artifactId>java</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,8 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>examples-parent</artifactId>
+  <groupId>org.apache.beam.examples</groupId>
+  <artifactId>parent</artifactId>
 
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,8 @@
     <dependencies>
 
       <dependency>
-        <groupId>org.apache.beam</groupId>
-        <artifactId>java-sdk-all</artifactId>
+        <groupId>org.apache.beam.sdks.java</groupId>
+        <artifactId>core</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -276,8 +276,8 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.beam</groupId>
-        <artifactId>java-examples-all</artifactId>
+        <groupId>org.apache.beam.examples</groupId>
+        <artifactId>java</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -584,16 +584,16 @@
       <!-- Testing -->
 
       <dependency>
-        <groupId>org.apache.beam</groupId>
-        <artifactId>java-sdk-all</artifactId>
+        <groupId>org.apache.beam.sdks.java</groupId>
+        <artifactId>core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.beam</groupId>
-        <artifactId>java-sdk-all</artifactId>
+        <groupId>org.apache.beam.sdks.java</groupId>
+        <artifactId>core</artifactId>
         <version>${project.version}</version>
         <classifier>tests</classifier>
         <scope>test</scope>
@@ -658,8 +658,8 @@
               <version>6.17</version>
             </dependency>
             <dependency>
-              <groupId>org.apache.beam</groupId>
-              <artifactId>java-build-tools</artifactId>
+              <groupId>org.apache.beam.sdks.java</groupId>
+              <artifactId>build-tools</artifactId>
               <version>${project.version}</version>
             </dependency>
           </dependencies>

--- a/runners/core-java/pom.xml
+++ b/runners/core-java/pom.xml
@@ -178,8 +178,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <!-- build dependencies -->

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -90,7 +90,7 @@
               <parallel>none</parallel>
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
-                <dependency>org.apache.beam:java-sdk-all</dependency>
+                <dependency>org.apache.beam.sdks.java:core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>
                 <beamTestPipelineOptions>
@@ -246,8 +246,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>
@@ -331,8 +331,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/runners/flink/examples/pom.xml
+++ b/runners/flink/examples/pom.xml
@@ -20,8 +20,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>flink-parent</artifactId>
+    <groupId>org.apache.beam.runners.flink</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -68,7 +68,7 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
+      <groupId>org.apache.beam.runners.flink</groupId>
       <artifactId>flink_2.10</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -26,8 +26,8 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>flink-parent</artifactId>
-  <version>0.2.0-incubating-SNAPSHOT</version>
+  <groupId>org.apache.beam.runners.flink</groupId>
+  <artifactId>parent</artifactId>
 
   <name>Apache Beam :: Runners :: Flink</name>
 

--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -20,8 +20,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>flink-parent</artifactId>
+    <groupId>org.apache.beam.runners.flink</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -52,8 +52,8 @@
 
     <!-- Beam -->
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -93,8 +93,8 @@
 
     <!-- Depend on test jar to scan for RunnableOnService tests -->
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
       <exclusions>
@@ -106,8 +106,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-examples-all</artifactId>
+      <groupId>org.apache.beam.examples</groupId>
+      <artifactId>java</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -179,7 +179,7 @@
               <parallel>none</parallel>
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
-                <dependency>org.apache.beam:java-sdk-all</dependency>
+                <dependency>org.apache.beam.sdks.java:core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>
                 <beamTestPipelineOptions>
@@ -203,7 +203,7 @@
               <parallel>none</parallel>
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
-                <dependency>org.apache.beam:java-sdk-all</dependency>
+                <dependency>org.apache.beam.sdks.java:core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>
                 <beamTestPipelineOptions>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -281,8 +281,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>
@@ -431,8 +431,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -72,8 +72,8 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <exclusions>
         <!-- Use Hadoop/Spark's backend logger -->
         <exclusion>
@@ -83,8 +83,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-examples-all</artifactId>
+      <groupId>org.apache.beam.examples</groupId>
+      <artifactId>java</artifactId>
       <exclusions>
         <!-- Use Hadoop/Spark's backend logger -->
         <exclusion>

--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -227,28 +227,6 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <reportSets>
-          <reportSet>
-            <id>aggregate</id>
-            <reports>
-              <report>aggregate</report>
-              <report>test-aggregate</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <profiles>
     <profile>
       <id>jacoco</id>

--- a/sdks/java/build-tools/pom.xml
+++ b/sdks/java/build-tools/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
   
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-build-tools</artifactId>
+  <artifactId>build-tools</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Build Tools</name>
   
 </project>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-sdk-all</artifactId>
+  <artifactId>core</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Core</name>
   <description>Beam SDK Java All provides a simple, Java-based
   interface for processing virtually any size data. This

--- a/sdks/java/extensions/join-library/pom.xml
+++ b/sdks/java/extensions/join-library/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.extensions</groupId>
+    <groupId>org.apache.beam.sdks.java.extensions</groupId>
     <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -52,8 +52,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/extensions/pom.xml
+++ b/sdks/java/extensions/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam.extensions</groupId>
+  <groupId>org.apache.beam.sdks.java.extensions</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
 

--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.io</groupId>
+    <groupId>org.apache.beam.sdks.java.io</groupId>
     <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -58,8 +58,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>
@@ -81,8 +81,8 @@
 
     <!-- test -->
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/sdks/java/io/hdfs/pom.xml
+++ b/sdks/java/io/hdfs/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.io</groupId>
+    <groupId>org.apache.beam.sdks.java.io</groupId>
     <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -53,8 +53,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/kafka/pom.xml
+++ b/sdks/java/io/kafka/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.io</groupId>
+    <groupId>org.apache.beam.sdks.java.io</groupId>
     <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
@@ -52,8 +52,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/pom.xml
+++ b/sdks/java/io/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam.io</groupId>
+  <groupId>org.apache.beam.sdks.java.io</groupId>
   <artifactId>parent</artifactId>
   <packaging>pom</packaging>
   <name>Apache Beam :: SDKs :: Java :: IO</name>

--- a/sdks/java/java8tests/pom.xml
+++ b/sdks/java/java8tests/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java8tests-all</artifactId>
+  <artifactId>java8tests</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Tests</name>
   <description>Apache Beam Java SDK provides a simple, Java-based
     interface for processing virtually any size data.
@@ -90,8 +90,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/sdks/java/maven-archetypes/examples/pom.xml
+++ b/sdks/java/maven-archetypes/examples/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>maven-archetypes-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java.archetypes</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>maven-archetypes-examples</artifactId>
+  <artifactId>examples</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Maven Archetypes :: Examples</name>
   <description>A Maven Archetype to create a project containing all the
     example pipelines from the Apache Beam Java SDK.</description>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -93,8 +93,8 @@
   <dependencies>
     <!-- Adds a dependency on a specific version of the Beam SDK. -->
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <version>[0-incubating, 2-incubating)</version>
     </dependency>
 

--- a/sdks/java/maven-archetypes/pom.xml
+++ b/sdks/java/maven-archetypes/pom.xml
@@ -20,13 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>maven-archetypes-parent</artifactId>
+  <groupId>org.apache.beam.sdks.java.archetypes</groupId>
+  <artifactId>parent</artifactId>
   <packaging>pom</packaging>
 
   <name>Apache Beam :: SDKs :: Java :: Maven Archetypes</name>

--- a/sdks/java/maven-archetypes/starter/pom.xml
+++ b/sdks/java/maven-archetypes/starter/pom.xml
@@ -20,14 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>maven-archetypes-parent</artifactId>
+    <groupId>org.apache.beam.sdks.java.archetypes</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam</groupId>
-  <artifactId>maven-archetypes-starter</artifactId>
+  <artifactId>starter</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Maven Archetypes :: Starter</name>
   <description>A Maven archetype to create a simple starter pipeline to
     get started using the Apache Beam Java SDK. </description>

--- a/sdks/java/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
@@ -40,8 +40,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <version>[0-incubating, 1-incubating)</version>
     </dependency>
 

--- a/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
@@ -40,8 +40,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <groupId>org.apache.beam.sdks.java</groupId>
+      <artifactId>core</artifactId>
       <version>[0-incubating, 1-incubating)</version>
     </dependency>
 

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -20,13 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam</groupId>
-    <artifactId>sdks-parent</artifactId>
+    <groupId>org.apache.beam.sdks</groupId>
+    <artifactId>parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-sdk-parent</artifactId>
+  <groupId>org.apache.beam.sdks.java</groupId>
+  <artifactId>parent</artifactId>
 
   <packaging>pom</packaging>
 

--- a/sdks/pom.xml
+++ b/sdks/pom.xml
@@ -26,7 +26,8 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>sdks-parent</artifactId>
+  <groupId>org.apache.beam.sdks</groupId>
+  <artifactId>parent</artifactId>
 
   <packaging>pom</packaging>
 

--- a/testing/travis/test_wordcount.sh
+++ b/testing/travis/test_wordcount.sh
@@ -35,7 +35,7 @@ set -o pipefail
 
 PASS=1
 VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\[')
-JAR_FILE=examples/java/target/java-examples-all-bundled-${VERSION}.jar
+JAR_FILE=examples/java/target/java-bundled-${VERSION}.jar
 
 function check_result_hash {
   local name=$1


### PR DESCRIPTION
This makes the Maven coordinates in line with our module structure. Specifically, Maven groups are applied to all parent poms.

R: @dhalperi 
CC: @jbonofre, @amitsela for the removal of `<reporting>` section in the Spark runner