### PR TITLE
[BEAM-38] Allow DoFns to be Reused

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -121,7 +121,8 @@ public class ParDoTest implements Serializable {
 
     @Override
     public void startBundle(Context c) {
-      assertEquals(State.UNSTARTED, state);
+      // The Fn can be reused, but only if FinishBundle has been called.
+      assertThat(state, anyOf(equalTo(State.UNSTARTED), equalTo(State.FINISHED)));
       state = State.STARTED;
       outputToAll(c, "started");
     }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Modify the documentation of ParDo to allow DoFns to be reused for
multiple bundles in the general case. This allows DoFns which implement
start and finish bundle to be reused.

Update ParDoTest.TestDoFn to succeed if reused.