### PR TITLE
Remove DirectRunner implementations from DoFnTester

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountTest.java
@@ -48,7 +48,7 @@ public class WordCountTest {
 
   /** Example test that tests a specific DoFn. */
   @Test
-  public void testExtractWordsFn() {
+  public void testExtractWordsFn() throws Exception {
     DoFnTester<String, String> extractWordsFn =
         DoFnTester.of(new ExtractWordsFn());
 

--- a/examples/java/src/test/java/org/apache/beam/examples/cookbook/CombinePerKeyExamplesTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/cookbook/CombinePerKeyExamplesTest.java
@@ -72,7 +72,7 @@ public class CombinePerKeyExamplesTest {
       .set("all_plays", "king_lear,macbeth");
 
   @Test
-  public void testExtractLargeWordsFn() {
+  public void testExtractLargeWordsFn() throws Exception {
     DoFnTester<TableRow, KV<String, String>> extractLargeWordsFn =
         DoFnTester.of(new ExtractLargeWordsFn());
     List<KV<String, String>> results = extractLargeWordsFn.processBatch(ROWS_ARRAY);
@@ -82,7 +82,7 @@ public class CombinePerKeyExamplesTest {
   }
 
   @Test
-  public void testFormatShakespeareOutputFn() {
+  public void testFormatShakespeareOutputFn() throws Exception {
     DoFnTester<KV<String, String>, TableRow> formatShakespeareOutputFn =
         DoFnTester.of(new FormatShakespeareOutputFn());
     List<TableRow> results = formatShakespeareOutputFn.processBatch(COMBINED_TUPLES_ARRAY);

--- a/examples/java/src/test/java/org/apache/beam/examples/cookbook/FilterExamplesTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/cookbook/FilterExamplesTest.java
@@ -68,7 +68,7 @@ public class FilterExamplesTest {
 
 
   @Test
-  public void testProjectionFn() {
+  public void testProjectionFn() throws Exception {
     DoFnTester<TableRow, TableRow> projectionFn =
         DoFnTester.of(new ProjectionFn());
     List<TableRow> results = projectionFn.processBatch(ROWS_ARRAY);
@@ -78,7 +78,7 @@ public class FilterExamplesTest {
   }
 
   @Test
-  public void testFilterSingleMonthDataFn() {
+  public void testFilterSingleMonthDataFn() throws Exception {
     DoFnTester<TableRow, TableRow> filterSingleMonthDataFn =
         DoFnTester.of(new FilterSingleMonthDataFn(7));
     List<TableRow> results = filterSingleMonthDataFn.processBatch(PROJROWS_ARRAY);

--- a/examples/java/src/test/java/org/apache/beam/examples/cookbook/JoinExamplesTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/cookbook/JoinExamplesTest.java
@@ -84,7 +84,7 @@ public class JoinExamplesTest {
     };
 
   @Test
-  public void testExtractEventDataFn() {
+  public void testExtractEventDataFn() throws Exception {
     DoFnTester<TableRow, KV<String, String>> extractEventDataFn =
         DoFnTester.of(new ExtractEventDataFn());
     List<KV<String, String>> results = extractEventDataFn.processBatch(EVENTS);
@@ -93,7 +93,7 @@ public class JoinExamplesTest {
   }
 
   @Test
-  public void testExtractCountryInfoFn() {
+  public void testExtractCountryInfoFn() throws Exception {
     DoFnTester<TableRow, KV<String, String>> extractCountryInfoFn =
         DoFnTester.of(new ExtractCountryInfoFn());
     List<KV<String, String>> results = extractCountryInfoFn.processBatch(CCS);

--- a/examples/java/src/test/java/org/apache/beam/examples/cookbook/MaxPerKeyExamplesTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/cookbook/MaxPerKeyExamplesTest.java
@@ -66,7 +66,7 @@ public class MaxPerKeyExamplesTest {
 
 
   @Test
-  public void testExtractTempFn() {
+  public void testExtractTempFn() throws Exception {
     DoFnTester<TableRow, KV<Integer, Double>> extractTempFn =
         DoFnTester.of(new ExtractTempFn());
     List<KV<Integer, Double>> results = extractTempFn.processBatch(TEST_ROWS);
@@ -76,7 +76,7 @@ public class MaxPerKeyExamplesTest {
   }
 
   @Test
-  public void testFormatMaxesFn() {
+  public void testFormatMaxesFn() throws Exception {
     DoFnTester<KV<Integer, Double>, TableRow> formatMaxesFnFn =
         DoFnTester.of(new FormatMaxesFn());
     List<TableRow> results = formatMaxesFnFn.processBatch(TEST_KVS);

--- a/examples/java/src/test/java/org/apache/beam/examples/cookbook/TriggerExampleTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/cookbook/TriggerExampleTest.java
@@ -87,7 +87,7 @@ public class TriggerExampleTest {
       .set("window", "[1970-01-01T00:00:00.000Z..1970-01-01T00:01:00.000Z)");
 
   @Test
-  public void testExtractTotalFlow() {
+  public void testExtractTotalFlow() throws Exception {
     DoFnTester<String, KV<String, Integer>> extractFlowInfow = DoFnTester
         .of(new ExtractFlowInfo());
 

--- a/examples/java8/src/test/java/org/apache/beam/examples/complete/game/UserScoreTest.java
+++ b/examples/java8/src/test/java/org/apache/beam/examples/complete/game/UserScoreTest.java
@@ -85,7 +85,7 @@ public class UserScoreTest implements Serializable {
 
   /** Test the ParseEventFn DoFn. */
   @Test
-  public void testParseEventFn() {
+  public void testParseEventFn() throws Exception {
     DoFnTester<String, GameActionInfo> parseEventFn =
         DoFnTester.of(new ParseEventFn());
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -383,14 +383,13 @@ public class DoFnTester<InputT, OutputT> {
    * Returns the value of the provided {@link Aggregator}.
    */
   public <AggregateT> AggregateT getAggregatorValue(Aggregator<?, AggregateT> agg) {
-    return extractAggregatorValue(agg, agg.getCombineFn());
+    return extractAggregatorValue(agg.getName(), agg.getCombineFn());
   }
 
   private <AccumT, AggregateT> AggregateT extractAggregatorValue(
-      Aggregator<?, AggregateT> agg,
-      CombineFn<?, AccumT, AggregateT> combiner) {
+      String name, CombineFn<?, AccumT, AggregateT> combiner) {
     @SuppressWarnings("unchecked")
-    AccumT accumulator = (AccumT) accumulators.get(agg.getName());
+    AccumT accumulator = (AccumT) accumulators.get(name);
     return combiner.extractOutput(accumulator);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnTesterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnTesterTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.beam.sdk.transforms;
 
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -39,7 +39,7 @@ import java.util.List;
 public class DoFnTesterTest {
 
   @Test
-  public void processElement() {
+  public void processElement() throws Exception {
     CounterDoFn counterDoFn = new CounterDoFn();
     DoFnTester<Long, String> tester = DoFnTester.of(counterDoFn);
 
@@ -61,7 +61,7 @@ public class DoFnTesterTest {
   }
 
   @Test
-  public void processElementsWithPeeks() {
+  public void processElementsWithPeeks() throws Exception {
     CounterDoFn counterDoFn = new CounterDoFn();
     DoFnTester<Long, String> tester = DoFnTester.of(counterDoFn);
 
@@ -119,7 +119,7 @@ public class DoFnTesterTest {
   }
 
   @Test
-  public void processBatch() {
+  public void processBatch() throws Exception {
     CounterDoFn counterDoFn = new CounterDoFn();
     DoFnTester<Long, String> tester = DoFnTester.of(counterDoFn);
 
@@ -138,7 +138,7 @@ public class DoFnTesterTest {
   }
 
   @Test
-  public void processElementWithTimestamp() {
+  public void processElementWithTimestamp() throws Exception {
     CounterDoFn counterDoFn = new CounterDoFn();
     DoFnTester<Long, String> tester = DoFnTester.of(counterDoFn);
 
@@ -175,7 +175,7 @@ public class DoFnTesterTest {
   }
 
   @Test
-  public void getAggregatorValuesShouldGetValueOfCounter() {
+  public void getAggregatorValuesShouldGetValueOfCounter() throws Exception {
     CounterDoFn counterDoFn = new CounterDoFn();
     DoFnTester<Long, String> tester = DoFnTester.of(counterDoFn);
     tester.processBatch(1L, 2L, 4L, 8L);
@@ -186,7 +186,7 @@ public class DoFnTesterTest {
   }
 
   @Test
-  public void getAggregatorValuesWithEmptyCounterShouldSucceed() {
+  public void getAggregatorValuesWithEmptyCounterShouldSucceed() throws Exception {
     CounterDoFn counterDoFn = new CounterDoFn();
     DoFnTester<Long, String> tester = DoFnTester.of(counterDoFn);
     tester.processBatch();
@@ -196,7 +196,7 @@ public class DoFnTesterTest {
   }
 
   @Test
-  public void getAggregatorValuesInStartFinishBundleShouldGetValues() {
+  public void getAggregatorValuesInStartFinishBundleShouldGetValues() throws Exception {
     CounterDoFn fn = new CounterDoFn(1L, 2L);
     DoFnTester<Long, String> tester = DoFnTester.of(fn);
     tester.processBatch(0L, 0L);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/join/CoGroupByKeyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/join/CoGroupByKeyTest.java
@@ -406,7 +406,7 @@ public class CoGroupByKeyTest implements Serializable {
    */
   @SuppressWarnings("unchecked")
   @Test
-  public void testConsumingDoFn() {
+  public void testConsumingDoFn() throws Exception {
     TupleTag<String> purchasesTag = new TupleTag<>();
     TupleTag<String> addressesTag = new TupleTag<>();
     TupleTag<String> namesTag = new TupleTag<>();

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/src/test/java/WordCountTest.java
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/src/test/java/WordCountTest.java
@@ -48,7 +48,7 @@ public class WordCountTest {
 
   /** Example test that tests a specific DoFn. */
   @Test
-  public void testExtractWordsFn() {
+  public void testExtractWordsFn() throws Exception {
     DoFnTester<String, String> extractWordsFn =
         DoFnTester.of(new ExtractWordsFn());
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Part of the removal of runners-core from the Core SDK, and the deletion
of the DirectRunner from the core SDK.

The implementations of DoFn.Context and DoFn.ProcessContext are
a simplified version of the DoFnRunnerBase versions of the same that
use local data structures.