### PR TITLE
[BEAM-287] Use flat groupId structure and fully qualified artifactIds

### DIFF
--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -21,7 +21,7 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>beam-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -21,13 +21,13 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>beam-examples-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-examples-all</artifactId>
-  <name>Apache Beam :: Examples :: Java All</name>
+  <artifactId>beam-examples-java</artifactId>
+  <name>Apache Beam :: Examples :: Java</name>
   <description>Apache Beam SDK provides a simple, Java-based
   interface for processing virtually any size data. This
   artifact includes all Apache Beam Java SDK examples.</description>
@@ -208,12 +208,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>google-cloud-dataflow-java</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -21,13 +21,13 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>beam-examples-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java8examples-all</artifactId>
-  <name>Apache Beam :: Examples :: Java 8 All</name>
+  <artifactId>beam-examples-java8</artifactId>
+  <name>Apache Beam :: Examples :: Java 8</name>
   <description>Apache Beam Java SDK provides a simple, Java-based
     interface for processing virtually any size data.
     This artifact includes examples of the SDK from a Java 8
@@ -107,18 +107,18 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-examples-all</artifactId>
+      <artifactId>beam-examples-java</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>google-cloud-dataflow-java</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>beam-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>examples-parent</artifactId>
+  <artifactId>beam-examples-parent</artifactId>
 
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>org.apache.beam</groupId>
-  <artifactId>parent</artifactId>
+  <artifactId>beam-parent</artifactId>
   <name>Apache Beam :: Parent</name>
   <description>Apache Beam provides a simple, Java-based interface
   for processing virtually any size data. This artifact includes the parent POM
@@ -259,25 +259,25 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>java-sdk-all</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.beam.runners</groupId>
-        <artifactId>core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.beam.runners</groupId>
-        <artifactId>google-cloud-dataflow-java</artifactId>
+        <artifactId>beam-sdks-java-core</artifactId>
         <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>java-examples-all</artifactId>
+        <artifactId>beam-runners-core-java</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.beam</groupId>
+        <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.beam</groupId>
+        <artifactId>beam-examples-java</artifactId>
         <version>${project.version}</version>
       </dependency>
 
@@ -585,7 +585,7 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>java-sdk-all</artifactId>
+        <artifactId>beam-sdks-java-core</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
@@ -593,7 +593,7 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>java-sdk-all</artifactId>
+        <artifactId>beam-sdks-java-core</artifactId>
         <version>${project.version}</version>
         <classifier>tests</classifier>
         <scope>test</scope>
@@ -659,7 +659,7 @@
             </dependency>
             <dependency>
               <groupId>org.apache.beam</groupId>
-              <artifactId>java-build-tools</artifactId>
+              <artifactId>beam-sdks-java-build-tools</artifactId>
               <version>${project.version}</version>
             </dependency>
           </dependencies>

--- a/runners/core-java/pom.xml
+++ b/runners/core-java/pom.xml
@@ -20,14 +20,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>core</artifactId>
-  <name>Apache Beam :: Runners :: Core</name>
+  <artifactId>beam-runners-core-java</artifactId>
+  <name>Apache Beam :: Runners :: Core Java</name>
   <description>Beam Runners Core provides utilities to aid runner authors.</description>
 
   <packaging>jar</packaging>
@@ -179,7 +179,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <!-- build dependencies -->

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -20,15 +20,15 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>direct</artifactId>
+  <artifactId>beam-runners-direct-java</artifactId>
 
-  <name>Apache Beam :: Runners :: Direct</name>
+  <name>Apache Beam :: Runners :: Direct Java</name>
 
   <packaging>jar</packaging>
 
@@ -90,7 +90,7 @@
               <parallel>none</parallel>
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
-                <dependency>org.apache.beam:java-sdk-all</dependency>
+                <dependency>org.apache.beam:beam-sdks-java-core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>
                 <beamTestPipelineOptions>
@@ -247,12 +247,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>core</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-core-java</artifactId>
     </dependency>
 
     <dependency>
@@ -332,7 +332,7 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/runners/flink/examples/pom.xml
+++ b/runners/flink/examples/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>flink-parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-flink-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>flink_2.10-examples</artifactId>
+  <artifactId>beam-runners-flink_2.10-examples</artifactId>
 
   <name>Apache Beam :: Runners :: Flink :: Examples</name>
 
@@ -68,8 +68,8 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>flink_2.10</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-flink_2.10</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>flink-parent</artifactId>
+  <artifactId>beam-runners-flink-parent</artifactId>
   <version>0.2.0-incubating-SNAPSHOT</version>
 
   <name>Apache Beam :: Runners :: Flink</name>

--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>flink-parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-flink-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>flink_2.10</artifactId>
+  <artifactId>beam-runners-flink_2.10</artifactId>
 
   <name>Apache Beam :: Runners :: Flink :: Core</name>
 
@@ -53,7 +53,7 @@
     <!-- Beam -->
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -63,8 +63,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>core</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-core-java</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -94,7 +94,7 @@
     <!-- Depend on test jar to scan for RunnableOnService tests -->
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
       <exclusions>
@@ -107,7 +107,7 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-examples-all</artifactId>
+      <artifactId>beam-examples-java</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -179,7 +179,7 @@
               <parallel>none</parallel>
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
-                <dependency>org.apache.beam:java-sdk-all</dependency>
+                <dependency>org.apache.beam:beam-sdks-java-core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>
                 <beamTestPipelineOptions>
@@ -203,7 +203,7 @@
               <parallel>none</parallel>
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
-                <dependency>org.apache.beam:java-sdk-all</dependency>
+                <dependency>org.apache.beam:beam-sdks-java-core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>
                 <beamTestPipelineOptions>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>google-cloud-dataflow-java</artifactId>
+  <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
 
   <name>Apache Beam :: Runners :: Google Cloud Dataflow</name>
 
@@ -282,12 +282,12 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>core</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-core-java</artifactId>
     </dependency>
 
     <dependency>
@@ -432,7 +432,7 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/runners/pom.xml
+++ b/runners/pom.xml
@@ -21,13 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>beam-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam.runners</groupId>
-  <artifactId>parent</artifactId>
+  <artifactId>beam-runners-parent</artifactId>
 
   <packaging>pom</packaging>
 
@@ -58,7 +57,7 @@
                 <parallel>all</parallel>
                 <threadCount>4</threadCount>
                 <dependenciesToScan>
-                  <dependency>org.apache.beam:java-sdk-all</dependency>
+                  <dependency>org.apache.beam:beam-sdks-java-core</dependency>
                 </dependenciesToScan>
                 <systemPropertyVariables>
                   <beamTestPipelineOptions>${runnableOnServicePipelineOptions}</beamTestPipelineOptions>

--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -227,28 +227,6 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <reportSets>
-          <reportSet>
-            <id>aggregate</id>
-            <reports>
-              <report>aggregate</report>
-              <report>test-aggregate</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <profiles>
     <profile>
       <id>jacoco</id>

--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.runners</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-runners-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>spark</artifactId>
+  <artifactId>beam-runners-spark</artifactId>
 
   <name>Apache Beam :: Runners :: Spark</name>
   <packaging>jar</packaging>
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <exclusions>
         <!-- Use Hadoop/Spark's backend logger -->
         <exclusion>
@@ -84,7 +84,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-examples-all</artifactId>
+      <artifactId>beam-examples-java</artifactId>
       <exclusions>
         <!-- Use Hadoop/Spark's backend logger -->
         <exclusion>

--- a/sdks/java/build-tools/pom.xml
+++ b/sdks/java/build-tools/pom.xml
@@ -21,12 +21,12 @@
   
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <artifactId>beam-sdks-java-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-build-tools</artifactId>
+  <artifactId>beam-sdks-java-build-tools</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Build Tools</name>
   
 </project>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <artifactId>beam-sdks-java-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-sdk-all</artifactId>
+  <artifactId>beam-sdks-java-core</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Core</name>
   <description>Beam SDK Java All provides a simple, Java-based
   interface for processing virtually any size data. This

--- a/sdks/java/extensions/join-library/pom.xml
+++ b/sdks/java/extensions/join-library/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.extensions</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-extensions-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>join-library</artifactId>
+  <artifactId>beam-sdks-java-extensions-join-library</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Extensions :: Join library</name>
 
   <build>
@@ -53,7 +53,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/extensions/pom.xml
+++ b/sdks/java/extensions/pom.xml
@@ -21,13 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <artifactId>beam-sdks-java-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam.extensions</groupId>
-  <artifactId>parent</artifactId>
+  <artifactId>beam-sdks-java-extensions-parent</artifactId>
   <packaging>pom</packaging>
 
   <name>Apache Beam :: SDKs :: Java :: Extensions</name>

--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.io</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-io-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>google-cloud-platform</artifactId>
+  <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
   <name>Apache Beam :: SDKs :: Java :: IO :: Google Cloud Platform</name>
   <description>IO library to read and write Google Cloud Platform systems from Beam.</description>
   <packaging>jar</packaging>
@@ -59,7 +59,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>
@@ -82,7 +82,7 @@
     <!-- test -->
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/sdks/java/io/hdfs/pom.xml
+++ b/sdks/java/io/hdfs/pom.xml
@@ -20,13 +20,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.io</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-io-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>hdfs</artifactId>
+  <artifactId>beam-sdks-java-io-hdfs</artifactId>
   <name>Apache Beam :: SDKs :: Java :: IO :: HDFS</name>
   <description>Library to read and write Hadoop/HDFS file formats from Beam.</description>
 
@@ -54,7 +54,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/kafka/pom.xml
+++ b/sdks/java/io/kafka/pom.xml
@@ -19,13 +19,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.beam.io</groupId>
-    <artifactId>parent</artifactId>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-io-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>kafka</artifactId>
+  <artifactId>beam-sdks-java-io-kafka</artifactId>
   <name>Apache Beam :: SDKs :: Java :: IO :: Kafka</name>
   <description>Library to read Kafka topics.</description>
 
@@ -53,7 +53,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/pom.xml
+++ b/sdks/java/io/pom.xml
@@ -21,13 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <artifactId>beam-sdks-java-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam.io</groupId>
-  <artifactId>parent</artifactId>
+  <artifactId>beam-sdks-java-io-parent</artifactId>
   <packaging>pom</packaging>
   <name>Apache Beam :: SDKs :: Java :: IO</name>
   <description>Beam SDK Java IO provides different connectivity components

--- a/sdks/java/java8tests/pom.xml
+++ b/sdks/java/java8tests/pom.xml
@@ -21,13 +21,13 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <artifactId>beam-sdks-java-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java8tests-all</artifactId>
-  <name>Apache Beam :: SDKs :: Java :: Tests</name>
+  <artifactId>beam-sdks-java-java8tests</artifactId>
+  <name>Apache Beam :: SDKs :: Java :: Java 8 Tests</name>
   <description>Apache Beam Java SDK provides a simple, Java-based
     interface for processing virtually any size data.
     This artifact includes tests of the SDK from a Java 8
@@ -91,7 +91,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/sdks/java/maven-archetypes/examples/pom.xml
+++ b/sdks/java/maven-archetypes/examples/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>maven-archetypes-parent</artifactId>
+    <artifactId>beam-sdks-java-maven-archetypes-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>maven-archetypes-examples</artifactId>
+  <artifactId>beam-sdks-java-maven-archetypes-examples</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Maven Archetypes :: Examples</name>
   <description>A Maven Archetype to create a project containing all the
     example pipelines from the Apache Beam Java SDK.</description>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -94,14 +94,14 @@
     <!-- Adds a dependency on a specific version of the Beam SDK. -->
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <version>[0-incubating, 2-incubating)</version>
     </dependency>
 
     <!-- Adds a dependency on a specific version of the Dataflow runnner. -->
     <dependency>
-      <groupId>org.apache.beam.runners</groupId>
-      <artifactId>google-cloud-dataflow-java</artifactId>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
       <version>[0-incubating, 2-incubating)</version>
     </dependency>
 

--- a/sdks/java/maven-archetypes/pom.xml
+++ b/sdks/java/maven-archetypes/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>java-sdk-parent</artifactId>
+    <artifactId>beam-sdks-java-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>maven-archetypes-parent</artifactId>
+  <artifactId>beam-sdks-java-maven-archetypes-parent</artifactId>
   <packaging>pom</packaging>
 
   <name>Apache Beam :: SDKs :: Java :: Maven Archetypes</name>

--- a/sdks/java/maven-archetypes/starter/pom.xml
+++ b/sdks/java/maven-archetypes/starter/pom.xml
@@ -21,13 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>maven-archetypes-parent</artifactId>
+    <artifactId>beam-sdks-java-maven-archetypes-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.beam</groupId>
-  <artifactId>maven-archetypes-starter</artifactId>
+  <artifactId>beam-sdks-java-maven-archetypes-starter</artifactId>
   <name>Apache Beam :: SDKs :: Java :: Maven Archetypes :: Starter</name>
   <description>A Maven archetype to create a simple starter pipeline to
     get started using the Apache Beam Java SDK. </description>

--- a/sdks/java/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
@@ -41,7 +41,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <version>[0-incubating, 1-incubating)</version>
     </dependency>
 

--- a/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
@@ -41,7 +41,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>java-sdk-all</artifactId>
+      <artifactId>beam-sdks-java-core</artifactId>
       <version>[0-incubating, 1-incubating)</version>
     </dependency>
 

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>sdks-parent</artifactId>
+    <artifactId>beam-sdks-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>java-sdk-parent</artifactId>
+  <artifactId>beam-sdks-java-parent</artifactId>
 
   <packaging>pom</packaging>
 

--- a/sdks/pom.xml
+++ b/sdks/pom.xml
@@ -21,12 +21,12 @@
 
   <parent>
     <groupId>org.apache.beam</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>beam-parent</artifactId>
     <version>0.2.0-incubating-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>sdks-parent</artifactId>
+  <artifactId>beam-sdks-parent</artifactId>
 
   <packaging>pom</packaging>
 

--- a/testing/travis/test_wordcount.sh
+++ b/testing/travis/test_wordcount.sh
@@ -35,7 +35,7 @@ set -o pipefail
 
 PASS=1
 VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\[')
-JAR_FILE=examples/java/target/java-examples-all-bundled-${VERSION}.jar
+JAR_FILE=examples/java/target/beam-examples-java-bundled-${VERSION}.jar
 
 function check_result_hash {
   local name=$1


### PR DESCRIPTION
R: @jbonofre, @dhalperi 

JB, this is taking your #420 and builds on top of it. In particular, fixed compile errors, both on Travis and Jenkins, and improved consistency in naming.