### PR TITLE
[BEAM-292] Write: always produce at least 1 WriteT

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.values.PDone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.UUID;
 
 /**
@@ -230,6 +231,14 @@ public class Write {
               LOG.info("Finalizing write operation {}", writeOperation);
               Iterable<WriteT> results = c.sideInput(resultsView);
               LOG.debug("Side input initialized to finalize write operation {}", writeOperation);
+              if (!results.iterator().hasNext()) {
+                LOG.info("No write results, creating a single empty output.");
+                Writer<T, WriteT> writer = writeOperation.createWriter(c.getPipelineOptions());
+                writer.open(UUID.randomUUID().toString());
+                WriteT emptyWrite = writer.close();
+                results = Collections.singleton(emptyWrite);
+                LOG.debug("Done creating a single empty output.");
+              }
               writeOperation.finalize(results, c.getPipelineOptions());
               LOG.debug("Done finalizing write operation {}", writeOperation);
             }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -202,15 +202,17 @@ public class TextIOTest {
     }
     if (numShards == 1) {
       write = write.withoutSharding();
-    } else {
+    } else if (numShards > 0) {
       write = write.withNumShards(numShards).withShardNameTemplate(ShardNameTemplate.INDEX_OF_MAX);
     }
+    int numOutputShards = (numShards > 0) ? numShards : 1;
 
     input.apply(write);
 
     p.run();
 
-    assertOutputFiles(elems, coder, numShards, tmpFolder, outputName, write.getShardNameTemplate());
+    assertOutputFiles(elems, coder, numOutputShards, tmpFolder, outputName,
+        write.getShardNameTemplate());
   }
 
   public static <T> void assertOutputFiles(
@@ -257,6 +259,12 @@ public class TextIOTest {
   @Category(NeedsRunner.class)
   public void testWriteStrings() throws Exception {
     runTestWrite(LINES_ARRAY, StringUtf8Coder.of());
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testWriteEmptyStringsNoSharding() throws Exception {
+    runTestWrite(NO_LINES_ARRAY, StringUtf8Coder.of(), 0);
   }
 
   @Test


### PR DESCRIPTION
Write has a degenerate case wherein, if no elements were in the written PCollection,
the finalize step will get produced with nothing to finalize. This often prevents
correct operation, for example when a FileBasedSink produces no files instead of one
empty file.

Catch and handle this case in Write by opening and closing an empty Writer to
produce a single WriteT.