### PR TITLE
Fix pom shading of Guava

### DIFF
--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -201,6 +201,10 @@
                   <pattern>com.google.common</pattern>
                   <shadedPattern>org.apache.beam.runners.direct.repackaged.com.google.common</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.google.thirdparty</pattern>
+                  <shadedPattern>org.apache.beam.runners.direct.repackaged.com.google.thirdparty</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -187,6 +187,10 @@
                     <pattern>com.google.common</pattern>
                     <shadedPattern>org.apache.beam.spark.relocated.com.google.common</shadedPattern>
                   </relocation>
+                  <relocation>
+                    <pattern>com.google.thirdparty</pattern>
+                    <shadedPattern>org.apache.beam.spark.relocated.com.google.thirdparty</shadedPattern>
+                  </relocation>
                 </relocations>
                 <shadedArtifactAttached>true</shadedArtifactAttached>
                 <shadedClassifierName>spark-app</shadedClassifierName>


### PR DESCRIPTION
There are two packages: com.google.common and com.google.thirdparty.
Both need to be repackaged/relocated, but we only had com.google.common
in a few places.