### PR TITLE
[BEAM-132] pom.xml: skip source-release assembly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -921,6 +921,21 @@
             <autoVersionSubmodules>true</autoVersionSubmodules>
           </configuration>
         </plugin>
+
+        <!-- Unconditionally disable invocation of the assembly
+             plugin from the Apache parent. -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>source-release-assembly</id>
+              <configuration>
+                <skipAssembly>true</skipAssembly>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
We do this separately via our own assembly.