### PR TITLE
[BEAM-330] Disable exec-maven-plugin cleanupDaemonThreads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -754,6 +754,7 @@
             </execution>
           </executions>
           <configuration>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
             <systemProperties>
               <systemProperty>
                 <key>java.util.logging.config.file</key>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

exec-maven-plugin has a bad interaction with DataflowPipelineRunner
when waiting on daemon threads. When running example pipelines,
Maven will emit a warning saying background threads are alive
after being aborted. This looks to users like an error while there's
actually no harm to it. Disabling cleanupDaemonThreads suppresses
this warning.