### PR TITLE
CompressedSourceTest: simplify

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -384,9 +384,7 @@ public class CompressedSourceTest {
     // Arbitrary but fixed seed
     Random random = new Random(285930);
     byte[] buff = new byte[size];
-    for (int i = 0; i < size; i++) {
-      buff[i] = (byte) (random.nextInt() % Byte.MAX_VALUE);
-    }
+    random.nextBytes(buff);
     return buff;
   }
 


### PR DESCRIPTION
We should use random.nextBytes(buff) instead of making the array in a loop.

The code we now point to is the same as the for loop, so the test continues to pass.