### PR TITLE
[BEAM-343] Fix NullPointerException in AfterWatermark display data

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
@@ -236,7 +236,7 @@ public class AfterWatermark {
             .append(")");
       }
 
-      if (lateTrigger != null) {
+      if (lateTrigger != null && !(lateTrigger instanceof Never.NeverTrigger)) {
         builder
             .append(".withLateFirings(")
             .append(lateTrigger)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
@@ -31,6 +31,8 @@ import org.joda.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>{@code AfterWatermark} triggers fire based on progress of the system watermark. This time is a
  * lower-bound, sometimes heuristically established, on event times that have been fully processed
@@ -106,6 +108,7 @@ public class AfterWatermark {
     private static final int LATE_INDEX = 1;
 
     private final OnceTrigger earlyTrigger;
+    @Nullable
     private final OnceTrigger lateTrigger;
 
     @SuppressWarnings("unchecked")
@@ -226,7 +229,6 @@ public class AfterWatermark {
     public String toString() {
       StringBuilder builder = new StringBuilder(TO_STRING);
 
-      Trigger earlyTrigger = subTriggers.get(EARLY_INDEX);
       if (!(earlyTrigger instanceof Never.NeverTrigger)) {
         builder
             .append(".withEarlyFirings(")
@@ -234,10 +236,12 @@ public class AfterWatermark {
             .append(")");
       }
 
-      builder
-          .append(".withLateFirings(")
-          .append(subTriggers.get(LATE_INDEX))
-          .append(")");
+      if (lateTrigger != null) {
+        builder
+            .append(".withLateFirings(")
+            .append(lateTrigger)
+            .append(")");
+      }
 
       return builder.toString();
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/AfterWatermarkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/AfterWatermarkTest.java
@@ -372,4 +372,14 @@ public class AfterWatermarkTest {
     assertEquals("AfterWatermark.pastEndOfWindow().withEarlyFirings(t1).withLateFirings(t2)",
         trigger.toString());
   }
+
+  @Test
+  public void testToStringExcludesNeverTrigger() {
+    Trigger trigger = AfterWatermark.pastEndOfWindow()
+        .withEarlyFirings(Never.ever())
+        .withLateFirings(Never.ever())
+        .buildTrigger();
+
+    assertEquals("AfterWatermark.pastEndOfWindow()", trigger.toString());
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/AfterWatermarkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/AfterWatermarkTest.java
@@ -345,6 +345,15 @@ public class AfterWatermarkTest {
   }
 
   @Test
+  public void testEarlyFiringsToString() {
+    Trigger trigger = AfterWatermark.pastEndOfWindow()
+        .withEarlyFirings(StubTrigger.named("t1"))
+        .buildTrigger();
+
+    assertEquals("AfterWatermark.pastEndOfWindow().withEarlyFirings(t1)", trigger.toString());
+  }
+
+  @Test
   public void testLateFiringsToString() {
     Trigger trigger = AfterWatermark.pastEndOfWindow()
         .withLateFirings(StubTrigger.named("t1"))


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Window transforms register display data for the associated trigger
function by calling its .toString() method. The AfterWatermark
trigger .toString() method was not properly handling cases where
there is no late firings registered.