### PR TITLE
[BEAM-350] DataflowPipelineJob: Retry messages, metrics, and status polls

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineRunner.java
@@ -633,12 +633,12 @@ public class DataflowPipelineRunner extends PipelineRunner<DataflowPipelineJob> 
     // regularly and need not be retried automatically.
     DataflowPipelineJob dataflowPipelineJob =
         new DataflowPipelineJob(options.getProject(), jobResult.getId(),
-            DataflowTransport.newRawDataflowClient(options).build(), aggregatorTransforms);
+            options.getDataflowClient(), aggregatorTransforms);
 
     // If the service returned client request id, the SDK needs to compare it
     // with the original id generated in the request, if they are not the same
     // (i.e., the returned job is not created by this request), throw
-    // DataflowJobAlreadyExistsException or DataflowJobAlreadyUpdatedExcetpion
+    // DataflowJobAlreadyExistsException or DataflowJobAlreadyUpdatedException
     // depending on whether this is a reload or not.
     if (jobResult.getClientRequestId() != null && !jobResult.getClientRequestId().isEmpty()
         && !jobResult.getClientRequestId().equals(requestId)) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DataflowTransport.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DataflowTransport.java
@@ -77,7 +77,7 @@ public class DataflowTransport {
         chainHttpRequestInitializer(
             options.getGcpCredential(),
             // Do not log 404. It clutters the output and is possibly even required by the caller.
-            new RetryHttpRequestInitializer(ImmutableList.of(404, 500))))
+            new RetryHttpRequestInitializer(ImmutableList.of(404))))
         .setApplicationName(options.getAppName())
         .setRootUrl(components.rootUrl)
         .setServicePath(components.servicePath)

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DataflowTransport.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DataflowTransport.java
@@ -77,7 +77,7 @@ public class DataflowTransport {
         chainHttpRequestInitializer(
             options.getGcpCredential(),
             // Do not log 404. It clutters the output and is possibly even required by the caller.
-            new RetryHttpRequestInitializer(ImmutableList.of(404))))
+            new RetryHttpRequestInitializer(ImmutableList.of(404, 500))))
         .setApplicationName(options.getAppName())
         .setRootUrl(components.rootUrl)
         .setServicePath(components.servicePath)
@@ -89,17 +89,6 @@ public class DataflowTransport {
         getJsonFactory(),
         chainHttpRequestInitializer(options.getGcpCredential(), new RetryHttpRequestInitializer()))
         .setApplicationName(options.getAppName())
-        .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
-  }
-
-  /**
-   * Returns a Dataflow client that does not automatically retry failed
-   * requests.
-   */
-  public static Dataflow.Builder
-      newRawDataflowClient(DataflowPipelineOptions options) {
-    return newDataflowClient(options)
-        .setHttpRequestInitializer(options.getGcpCredential())
         .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
   }
 


### PR DESCRIPTION
At some point in the past, we decided to use a rawDataflowClient that
does not do retries when checking job status, because it was best-effort
reporting to users. The purported goal was to not clutter the log with
networking errors.

However, since that time, we have:
* Added the ability to suppress logs (emit only at DEBUG level or not at
  all) when retrying.
* Increased reliability of the job checking status so that these errors
  are less frequent and more indicative of quota or other issues.
* Started using the metrics in tests, where we do need to retry
  transient issues (BEAM-350).

So let's drop the raw transport client and just use the one that
retries.