### PR TITLE
Move allowsDynamicSplitting to Reader, and set it in CompressedSource.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -396,6 +396,11 @@ public class CompressedSource<T> extends FileBasedSource<T> {
     }
 
     @Override
+    public boolean allowsDynamicSplitting() {
+      return splittable;
+    }
+
+    @Override
     public final long getSplitPointsConsumed() {
       if (splittable) {
         return readerDelegate.getSplitPointsConsumed();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -192,17 +192,6 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
    */
   public abstract OffsetBasedSource<T> createSourceForSubrange(long start, long end);
 
-  /**
-   * Whether this source should allow dynamic splitting of the offset ranges.
-   *
-   * <p>True by default. Override this to return false if the source cannot
-   * support dynamic splitting correctly. If this returns false,
-   * {@link OffsetBasedSource.OffsetBasedReader#splitAtFraction} will refuse all split requests.
-   */
-  public boolean allowsDynamicSplitting() {
-    return true;
-  }
-
   @Override
   public void populateDisplayData(DisplayData.Builder builder) {
     super.populateDisplayData(builder);
@@ -342,7 +331,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
         // Note that even if the current source does not allow splitting, we don't know that
         // it's non-empty so we return UNKNOWN instead of 1.
         return BoundedReader.SPLIT_POINTS_UNKNOWN;
-      } else if (!getCurrentSource().allowsDynamicSplitting()) {
+      } else if (!allowsDynamicSplitting()) {
         // Started (so non-empty) and unsplittable, so only the current task.
         return 1;
       } else if (getCurrentOffset() >= rangeTracker.getStopPosition() - 1) {
@@ -355,9 +344,20 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
       }
     }
 
+    /**
+     * Whether this reader should allow dynamic splitting of the offset ranges.
+     *
+     * <p>True by default. Override this to return false if the reader cannot
+     * support dynamic splitting correctly. If this returns false,
+     * {@link OffsetBasedReader#splitAtFraction} will refuse all split requests.
+     */
+    public boolean allowsDynamicSplitting() {
+      return true;
+    }
+
     @Override
     public final synchronized OffsetBasedSource<T> splitAtFraction(double fraction) {
-      if (!getCurrentSource().allowsDynamicSplitting()) {
+      if (!allowsDynamicSplitting()) {
         return null;
       }
       if (rangeTracker.getStopPosition() == Long.MAX_VALUE) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -608,9 +609,8 @@ public class CompressedSourceTest {
       // checkpoint every 9 elements
       if (actual.size() % 9 == 0) {
         Double fractionConsumed = reader.getFractionConsumed();
-        if (fractionConsumed != null) {
-          assertNull(reader.splitAtFraction(fractionConsumed));
-        }
+        assertNotNull(fractionConsumed);
+        assertNull(reader.splitAtFraction(fractionConsumed));
       }
     }
     assertEquals(expected.size(), actual.size());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -44,6 +45,8 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.common.primitives.Bytes;
 
@@ -580,6 +583,38 @@ public class CompressedSourceTest {
       assertEquals(1, reader.getSplitPointsConsumed());
       assertEquals(0, reader.getSplitPointsRemaining());
     }
+  }
+
+  @Test
+  public void testUnsplittable() throws IOException {
+    String baseName = "test-input";
+    File compressedFile = tmpFolder.newFile(baseName + ".gz");
+    byte[] input = generateInput(10000);
+    writeFile(compressedFile, input, CompressionMode.GZIP);
+
+    CompressedSource<Byte> source =
+        CompressedSource.from(new ByteSource(compressedFile.getPath(), 1));
+    List<Byte> expected = Lists.newArrayList();
+    for (byte i : input) {
+      expected.add(i);
+    }
+
+    PipelineOptions options = PipelineOptionsFactory.create();
+    BoundedReader<Byte> reader = source.createReader(options);
+
+    List<Byte> actual = Lists.newArrayList();
+    for (boolean hasNext = reader.start(); hasNext; hasNext = reader.advance()) {
+      actual.add(reader.getCurrent());
+      // checkpoint every 9 elements
+      if (actual.size() % 9 == 0) {
+        Double fractionConsumed = reader.getFractionConsumed();
+        if (fractionConsumed != null) {
+          assertNull(reader.splitAtFraction(fractionConsumed));
+        }
+      }
+    }
+    assertEquals(expected.size(), actual.size());
+    assertEquals(Sets.newHashSet(expected), Sets.newHashSet(actual));
   }
 
   @Test


### PR DESCRIPTION
Before the change in CompressedSource, testUnsplittable() fails in:
assertNull(reader.splitAtFraction(fractionConsumed));