### PR TITLE
Add Travis config for Python SDK tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ notifications:
     on_success: change
     on_failure: always
 
+addons:
+  apt:
+    packages:
+    - python2.7
+
 matrix:
   include:
     # On OSX, run with default JDK only.
@@ -40,15 +45,26 @@ matrix:
       env: CUSTOM_JDK="oraclejdk7" MAVEN_OVERRIDE="-DforkCount=0"
     - os: linux
       env: CUSTOM_JDK="openjdk7" MAVEN_OVERRIDE="-DforkCount=0"
+    # Python SDK environments.
+    - os: osx
+      env: TEST_PYTHON="1"
+    - os: linux
+      env: TEST_PYTHON="1"
 
 before_install:
   - echo "MAVEN_OPTS='-Xmx2048m -XX:MaxPermSize=512m'" > ~/.mavenrc
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
+  # Python SDK environment settings.
+  - export TOX_ENV=py27
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export TOX_HOME=$HOME/Library/Python/2.7/bin; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export TOX_HOME=$HOME/.local/bin; fi
 
 install:
-  - travis_retry mvn -B install clean -U -DskipTests=true
+  - if [ ! "$TEST_PYTHON" ]; then travis_retry mvn -B install clean -U -DskipTests=true; fi
+  - if [ "$TEST_PYTHON" ]; then travis_retry pip install tox --user `whoami`; fi
 
 script:
-  - travis_retry mvn -B $MAVEN_OVERRIDE install -U
-  - travis_retry testing/travis/test_wordcount.sh
+  - if [ "$TEST_PYTHON" ]; then travis_retry $TOX_HOME/tox -e $TOX_ENV -c sdks/python/tox.ini; fi
+  - if [ ! "$TEST_PYTHON" ]; then travis_retry mvn -B $MAVEN_OVERRIDE install -U; fi
+  - if [ ! "$TEST_PYTHON" ]; then travis_retry testing/travis/test_wordcount.sh; fi

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -1,0 +1,24 @@
+;
+;    Licensed to the Apache Software Foundation (ASF) under one or more
+;    contributor license agreements.  See the NOTICE file distributed with
+;    this work for additional information regarding copyright ownership.
+;    The ASF licenses this file to You under the Apache License, Version 2.0
+;    (the "License"); you may not use this file except in compliance with
+;    the License.  You may obtain a copy of the License at
+;
+;       http://www.apache.org/licenses/LICENSE-2.0
+;
+;    Unless required by applicable law or agreed to in writing, software
+;    distributed under the License is distributed on an "AS IS" BASIS,
+;    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;    See the License for the specific language governing permissions and
+;    limitations under the License.
+;
+
+[tox]
+envlist = py27
+
+[testenv:py27]
+commands =
+  python setup.py test
+passenv = TRAVIS*


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Adds a basic Travis config for installing and running tests with tox. tox is only configured to setup.py test. This will provide a basic level of presubmit coverage.