### PR TITLE
[BEAM-37] DoFnReflector: Add invoker interface and generate code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,12 @@
         <version>${slf4j.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>1.4.3</version>
+      </dependency>
+
       <!-- Testing -->
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -899,6 +899,22 @@
           </configuration>
         </plugin>
 
+        <!-- Ignore runtime-only dependencies in analysis -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.10</version>
+          <configuration>
+            <ignoreNonCompile>true</ignoreNonCompile>
+
+            <!-- This dependency is only used for an annotation which doesn't
+                 show up in bytecode, so doesn't show up as used. -->
+            <ignoredUnusedDeclaredDependencies>
+              <ignoredUnusedDeclaredDependency>com.google.code.findbugs:findbugs-annotations</ignoredUnusedDeclaredDependency>
+            </ignoredUnusedDeclaredDependencies>
+          </configuration>
+        </plugin>
+
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -905,22 +905,6 @@
           </configuration>
         </plugin>
 
-        <!-- Ignore runtime-only dependencies in analysis -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.10</version>
-          <configuration>
-            <ignoreNonCompile>true</ignoreNonCompile>
-
-            <!-- This dependency is only used for an annotation which doesn't
-                 show up in bytecode, so doesn't show up as used. -->
-            <ignoredUnusedDeclaredDependencies>
-              <ignoredUnusedDeclaredDependency>com.google.code.findbugs:findbugs-annotations</ignoredUnusedDeclaredDependency>
-            </ignoredUnusedDeclaredDependencies>
-          </configuration>
-        </plugin>
-
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -414,6 +414,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -431,6 +437,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.4.3</version>
     </dependency>
 
     <dependency>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -442,7 +442,6 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.4.3</version>
     </dependency>
 
     <dependency>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -414,12 +414,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>findbugs-annotations</artifactId>
-      <version>3.0.1</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnReflector.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnReflector.java
@@ -722,7 +722,7 @@ public abstract class DoFnReflector {
         @Nullable final Method target, boolean isStartBundle, ExtraContextInfo[] args) {
       if (target == null && !isStartBundle) {
         // There is no target to call, and this is not a startBundle method (which needs to call
-        // prepareForProcessing no matter whaht). There is nothing to do, so just produce a stub:
+        // prepareForProcessing no matter what). There is nothing to do, so just produce a stub:
         return StubMethod.INSTANCE;
       } else {
         // We need to generate a non-empty method implementation.
@@ -732,7 +732,7 @@ public abstract class DoFnReflector {
 
     @Override
     public InstrumentedType prepare(InstrumentedType instrumentedType) {
-      // Remember the filed description of the instrumented type.
+      // Remember the field description of the instrumented type.
       field = instrumentedType.getDeclaredFields()
           .filter(ElementMatchers.named(FN_DELEGATE_FIELD_NAME)).getOnly();
 
@@ -761,9 +761,11 @@ public abstract class DoFnReflector {
     /**
      * Stack manipulation to call the {@code prepareForProcessing} method.
      *
-     * Precondition: Stack has the delegate target on top of the stack
-     * Postcondition: If finalStep is true, then we've returned from the method. Otherwise, the
+     * <ul>
+     * <li>Precondition: Stack has the delegate target on top of the stack
+     * <li>Postcondition: If finalStep is true, then we've returned from the method. Otherwise, the
      * stack still has the delegate target on top of the stack.
+     * </ul>
      *
      * @param finalStep If true, return from the {@code invokeStartBundle} method after invoking
      * {@code prepareForProcessing} on the delegate.
@@ -901,7 +903,7 @@ public abstract class DoFnReflector {
               // No local variables
               0, new Object[] {},
               // No new stack variables
-              0, new Object[] { });
+              0, new Object[] {});
 
           return new Size(
               trySize.getSizeImpact(),

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnReflector.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnReflector.java
@@ -999,8 +999,8 @@ public abstract class DoFnReflector {
   }
 
   /**
-   * A byte-buddy {@link Implementation} for the constructor of a {@link DoFnInvoker}. The generated
-   * constructor takes a single argument and assigns it to the delegate field.
+   * A constructor {@link Implementation} for a {@link DoFnInvoker class}. Produces the byte code
+   * for a constructor that takes a single argument and assigns it to the delegate field.
    * {@link AdditionalParameter} to the given {@link DoFnWithContext} method.
    */
   private final class InvokerConstructor implements Implementation {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnReflectorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnReflectorTest.java
@@ -152,6 +152,20 @@ public class DoFnReflectorTest {
     checkInvokeProcessElementWorks(reflector, invocations);
   }
 
+  @Test
+  public void testDoFnInvokersReused() throws Exception {
+    // Ensures that we don't create a new Invoker class for every instance of the DoFn.
+    IdentityParent fn1 = new IdentityParent();
+    IdentityParent fn2 = new IdentityParent();
+    DoFnReflector reflector1 = underTest(fn1);
+    DoFnReflector reflector2 = underTest(fn2);
+    assertSame("DoFnReflector instances should be cached and reused for identical types",
+        reflector1, reflector2);
+    assertSame("Invoker classes should only be generated once for each type",
+        reflector1.bindInvoker(fn1).getClass(),
+        reflector2.bindInvoker(fn2).getClass());
+  }
+
   interface InterfaceWithProcessElement {
     @ProcessElement
     void processElement(DoFnWithContext<String, String>.ProcessContext c);

--- a/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnReflectorBenchmark.java
+++ b/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnReflectorBenchmark.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnReflector;
+import org.apache.beam.sdk.transforms.DoFnReflector.DoFnInvoker;
 import org.apache.beam.sdk.transforms.DoFnWithContext;
 import org.apache.beam.sdk.transforms.DoFnWithContext.ExtraContextFactory;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -72,10 +73,13 @@ public class DoFnReflectorBenchmark {
   private DoFnReflector doFnReflector;
   private DoFn<String, String> adaptedDoFnWithContext;
 
+  private DoFnInvoker<String, String> invoker;
+
   @Setup
   public void setUp() {
     doFnReflector = DoFnReflector.of(doFnWithContext.getClass());
     adaptedDoFnWithContext = doFnReflector.toDoFn(doFnWithContext);
+    invoker = doFnReflector.bindInvoker(doFnWithContext);
   }
 
   @Benchmark
@@ -92,8 +96,7 @@ public class DoFnReflectorBenchmark {
 
   @Benchmark
   public String invokeDoFnWithContext() throws Exception {
-    doFnReflector.invokeProcessElement(
-        doFnWithContext, stubDoFnWithContextContext, extraContextFactory);
+    invoker.invokeProcessElement(stubDoFnWithContextContext, extraContextFactory);
     return stubDoFnWithContextContext.output;
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [*] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [*] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [*] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [*] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The method to call for a DoFnWithContext requires reflection since the
shape of the parameters may change. Doing so in each processElement call
puts this refelection in the hot path.

This PR introduces a DoFnInvoker interface which is bound to a specific
DoFnWithContext and delegates the three important methods (startBundle,
processElement, finishBundle).

It uses byte-buddy to generate a simple trampoline implementation of
the DoFnInvoker class for each type of DoFnWithContext.

This leads to 2-3x better performance in micro-benchmarks of method
dispatching.