### PR TITLE
[BEAM-155] Use only WindowFn in TriggerTester

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/sdk/util/ReduceFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/sdk/util/ReduceFnRunner.java
@@ -236,7 +236,8 @@ public class ReduceFnRunner<K, InputT, OutputT, W extends BoundedWindow> {
     this.triggerRunner =
         new TriggerRunner<>(
             windowingStrategy.getTrigger(),
-            new TriggerContextFactory<>(windowingStrategy, stateInternals, activeWindows));
+            new TriggerContextFactory<>(
+                windowingStrategy.getWindowFn(), stateInternals, activeWindows));
   }
 
   private ActiveWindowSet<W> createActiveWindowSet() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TriggerContextFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TriggerContextFactory.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.Trigger;
 import org.apache.beam.sdk.transforms.windowing.Trigger.MergingTriggerInfo;
 import org.apache.beam.sdk.transforms.windowing.Trigger.TriggerInfo;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.util.state.MergingStateAccessor;
 import org.apache.beam.sdk.util.state.State;
 import org.apache.beam.sdk.util.state.StateAccessor;
@@ -50,19 +51,19 @@ import javax.annotation.Nullable;
  */
 public class TriggerContextFactory<W extends BoundedWindow> {
 
-  private final WindowingStrategy<?, W> windowingStrategy;
+  private final WindowFn<?, W> windowFn;
   private StateInternals<?> stateInternals;
   // Future triggers may be able to exploit the active window to state address window mapping.
   @SuppressWarnings("unused")
   private ActiveWindowSet<W> activeWindows;
   private final Coder<W> windowCoder;
 
-  public TriggerContextFactory(WindowingStrategy<?, W> windowingStrategy,
+  public TriggerContextFactory(WindowFn<?, W> windowFn,
       StateInternals<?> stateInternals, ActiveWindowSet<W> activeWindows) {
-    this.windowingStrategy = windowingStrategy;
+    this.windowFn = windowFn;
     this.stateInternals = stateInternals;
     this.activeWindows = activeWindows;
-    this.windowCoder = windowingStrategy.getWindowFn().windowCoder();
+    this.windowCoder = windowFn.windowCoder();
   }
 
   public Trigger.TriggerContext base(W window, Timers timers,
@@ -106,7 +107,7 @@ public class TriggerContextFactory<W extends BoundedWindow> {
 
     @Override
     public boolean isMerging() {
-      return !windowingStrategy.getWindowFn().isNonMerging();
+      return !windowFn.isNonMerging();
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/TriggerTester.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/TriggerTester.java
@@ -160,7 +160,7 @@ public class TriggerTester<InputT, W extends BoundedWindow> {
     this.windowToMergeResult = new HashMap<>();
 
     this.contextFactory =
-        new TriggerContextFactory<>(windowingStrategy, stateInternals, activeWindows);
+        new TriggerContextFactory<>(windowingStrategy.getWindowFn(), stateInternals, activeWindows);
   }
 
   /**


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This change is preparatory for separating trigger syntax from implementation.

Previously, the whole `WindowingStrategy` was passed in, but not used. Since the tester is really a test of the state machine, it will be moved to runners-core alongside the trigger implementation. The requirement to provide a `WindowingStrategy` with the original syntax is extraneous.