### PR TITLE
[BEAM-376] Python README correction

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -197,7 +197,7 @@ we'll assume you use that one.  With a virtual environment active, paste the
 URL into a ``pip install`` shell command, executing something like this:
 
 ```sh
-pip install https://github.com/GoogleCloudPlatform/DataflowPythonSDK/vX.Y.Z.tar.gz
+pip install https://github.com/GoogleCloudPlatform/DataflowPythonSDK/archive/vX.Y.Z.tar.gz
 ```
 
 #### Notes on installing with ``setup.py install``


### PR DESCRIPTION
correct pip install target to include 'archive/'