### PR TITLE
BEAM-379: Add support for source Ptransform in DisplayDataEvaluator

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
@@ -99,6 +99,7 @@ public class DisplayDataEvaluator {
   /**
    * Traverse the specified source {@link PTransform}, collecting {@link DisplayData} registered
    * on the inner primitive {@link PTransform PTransforms}.
+   *
    * @param root The source root {@link PTransform} to traverse
    * @return the set of {@link DisplayData} for primitive source {@link PTransform PTransforms}.
    */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
@@ -116,8 +116,7 @@ public class DisplayDataEvaluator {
     pipeline.traverseTopologically(visitor);
     return visitor.getPrimitivesDisplayData();
   }
-
-
+  
   /**
    * Visits {@link PTransform PTransforms} in a pipeline, and collects {@link DisplayData} for
    * each primitive transform under a given composite root.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
@@ -116,7 +116,7 @@ public class DisplayDataEvaluator {
     pipeline.traverseTopologically(visitor);
     return visitor.getPrimitivesDisplayData();
   }
-  
+
   /**
    * Visits {@link PTransform PTransforms} in a pipeline, and collects {@link DisplayData} for
    * each primitive transform under a given composite root.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluator.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.runners.TransformTreeNode;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 
@@ -79,8 +80,8 @@ public class DisplayDataEvaluator {
    * @return the set of {@link DisplayData} for primitive {@link PTransform PTransforms}.
    */
   public <InputT> Set<DisplayData> displayDataForPrimitiveTransforms(
-    final PTransform<? super PCollection<InputT>, ? extends POutput> root,
-    Coder<InputT> inputCoder) {
+      final PTransform<? super PCollection<InputT>, ? extends POutput> root,
+      Coder<InputT> inputCoder) {
 
     Create.Values<InputT> input = Create.of();
     if (inputCoder != null) {
@@ -89,13 +90,33 @@ public class DisplayDataEvaluator {
 
     Pipeline pipeline = Pipeline.create(options);
     pipeline
-      .apply(input)
-      .apply(root);
+        .apply(input)
+        .apply(root);
 
+    return displayDataForPipeline(pipeline, root);
+  }
+
+  /**
+   * Traverse the specified source {@link PTransform}, collecting {@link DisplayData} registered
+   * on the inner primitive {@link PTransform PTransforms}.
+   * @param root The source root {@link PTransform} to traverse
+   * @return the set of {@link DisplayData} for primitive source {@link PTransform PTransforms}.
+   */
+  public Set<DisplayData> displayDataForPrimitiveSourceTransforms(
+      final PTransform<? super PBegin, ? extends POutput> root) {
+    Pipeline pipeline = Pipeline.create(options);
+    pipeline
+        .apply(root);
+
+    return displayDataForPipeline(pipeline, root);
+  }
+
+  private static Set<DisplayData> displayDataForPipeline(Pipeline pipeline, PTransform root) {
     PrimitiveDisplayDataPTransformVisitor visitor = new PrimitiveDisplayDataPTransformVisitor(root);
     pipeline.traverseTopologically(visitor);
     return visitor.getPrimitivesDisplayData();
   }
+
 
   /**
    * Visits {@link PTransform PTransforms} in a pipeline, and collects {@link DisplayData} for

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluatorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataEvaluatorTest.java
@@ -23,9 +23,11 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 
@@ -91,5 +93,17 @@ public class DisplayDataEvaluatorTest implements Serializable {
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(myTransform);
 
     assertThat(displayData, hasItem(hasDisplayItem("foo")));
+  }
+
+  @Test
+  public void testSourceTransform() {
+    PTransform<? super PBegin, ? extends POutput> myTransform = TextIO.Read
+        .from("foo.*")
+        .withoutValidation();
+
+    DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
+    Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(myTransform);
+
+    assertThat(displayData, hasItem(hasDisplayItem("filePattern", "foo.*")));
   }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

DisplayDataEvaluator takes PTranform<? extends PCollection<InputT>, ? extends POutput>, but this doesn't work for source transforms of the form PTransform<PBegin, PCollection<T>>. Add a new method that works for source PTransforms.