### PR TITLE
Disable Java specific Travis tests for python-sdk branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,17 @@ addons:
 
 matrix:
   include:
-    # On OSX, run with default JDK only.
-    - os: osx
-      env: MAVEN_OVERRIDE=""
-    # On Linux, run with specific JDKs only.
-    - os: linux
-      env: CUSTOM_JDK="oraclejdk8" MAVEN_OVERRIDE="-DforkCount=0"
-    - os: linux
-      env: CUSTOM_JDK="oraclejdk7" MAVEN_OVERRIDE="-DforkCount=0"
-    - os: linux
-      env: CUSTOM_JDK="openjdk7" MAVEN_OVERRIDE="-DforkCount=0"
+    # TODO(altay): Re-enable Java tests before merging python-sdk branch to master.
+    ## On OSX, run with default JDK only.
+    #- os: osx
+    #  env: MAVEN_OVERRIDE=""
+    ## On Linux, run with specific JDKs only.
+    #- os: linux
+    #  env: CUSTOM_JDK="oraclejdk8" MAVEN_OVERRIDE="-DforkCount=0"
+    #- os: linux
+    #  env: CUSTOM_JDK="oraclejdk7" MAVEN_OVERRIDE="-DforkCount=0"
+    #- os: linux
+    #  env: CUSTOM_JDK="openjdk7" MAVEN_OVERRIDE="-DforkCount=0"
     # Python SDK environments.
     - os: osx
       env: TEST_PYTHON="1"


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

python-sdk branch is exclusively used for Python SDK development. This
change disables the Java tests to reduce testing time (~ 1-2 hrs).

Jenkins will continue to verify Java tests so this should not result in
accidental breakages. (Jenkins tests are considerably faster).

And we will revert these changes before python-sdk branch graduates
and merged to master.