### PR TITLE
[BEAM-145] Fix timestamps in GroupAlsoByWindowsProperties

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/sdk/util/GroupAlsoByWindowsProperties.java
+++ b/runners/core-java/src/test/java/org/apache/beam/sdk/util/GroupAlsoByWindowsProperties.java
@@ -165,11 +165,13 @@ public class GroupAlsoByWindowsProperties {
     TimestampedValue<KV<String, Iterable<String>>> item1 =
         Iterables.getOnlyElement(result.peekOutputElementsInWindow(window(0, 20)));
     assertThat(item1.getValue().getValue(), containsInAnyOrder("v1", "v2"));
+    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
     assertThat(item1.getTimestamp(), equalTo(new Instant(10)));
 
     TimestampedValue<KV<String, Iterable<String>>> item2 =
         Iterables.getOnlyElement(result.peekOutputElementsInWindow(window(10, 30)));
     assertThat(item2.getValue().getValue(), contains("v2"));
+    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
     assertThat(item2.getTimestamp(), equalTo(new Instant(20)));
   }
 
@@ -218,13 +220,15 @@ public class GroupAlsoByWindowsProperties {
         Iterables.getOnlyElement(result.peekOutputElementsInWindow(window(0, 20)));
     assertThat(item1.getValue().getKey(), equalTo("k"));
     assertThat(item1.getValue().getValue(), equalTo(combineFn.apply(ImmutableList.of(1L, 2L, 4L))));
-    assertThat(item1.getTimestamp(), equalTo(new Instant(5L)));
+    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
+    assertThat(item1.getTimestamp(), equalTo(new Instant(10L)));
 
     TimestampedValue<KV<String, Long>> item2 =
         Iterables.getOnlyElement(result.peekOutputElementsInWindow(window(10, 30)));
     assertThat(item2.getValue().getKey(), equalTo("k"));
     assertThat(item2.getValue().getValue(), equalTo(combineFn.apply(ImmutableList.of(2L, 4L))));
-    assertThat(item2.getTimestamp(), equalTo(new Instant(15L)));
+    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
+    assertThat(item2.getTimestamp(), equalTo(new Instant(20L)));
   }
 
   /**


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Some of the timestamps were not adjusted when [BEAM-145](https://issues.apache.org/jira/browse/BEAM-145) was fixed to respect the `WindowFn`'s timestamps.