### PR TITLE
BEAM-405 - Fixes inefficient use of keySet iterator instead of entrySet iterator

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -122,12 +122,6 @@
     <!--May expose internal representation by incorporating reference to mutable object-->
   </Match>
   <Match>
-    <Class name="org.apache.beam.sdk.io.BigQueryIO$StreamingWriteFn"/>
-    <Method name="finishBundle"/>
-    <Bug pattern="WMI_WRONG_MAP_ITERATOR"/>
-    <!--Inefficient use of keySet iterator instead of entrySet iterator-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.io.PubsubIO$Read$Bound$PubsubBoundedReader"/>
     <Method name="processElement"/>
     <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BigQueryIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BigQueryIO.java
@@ -2063,10 +2063,10 @@ public class BigQueryIO {
       BigQueryOptions options = context.getPipelineOptions().as(BigQueryOptions.class);
       Bigquery client = Transport.newBigQueryClient(options).build();
 
-      for (String tableSpec : tableRows.keySet()) {
-        TableReference tableReference = getOrCreateTable(options, tableSpec);
-        flushRows(client, tableReference, tableRows.get(tableSpec),
-            uniqueIdsForTableRows.get(tableSpec), options);
+      for (Map.Entry<String, List<TableRow>> entry : tableRows.entrySet()) {
+        TableReference tableReference = getOrCreateTable(options, entry.getKey());
+        flushRows(client, tableReference, entry.getValue(),
+                uniqueIdsForTableRows.get(entry.getKey()), options);
       }
       tableRows.clear();
       uniqueIdsForTableRows.clear();


### PR DESCRIPTION
`BiggQueryIO$StreamingWriteFn.finishBundle`: Fixes inefficient use of keySet iterator instead of entrySet iterator.

More info: https://issues.apache.org/jira/browse/BEAM-405