### PR TITLE
[BEAM-408] - Fixes ProxyInvocationHandler uses inefficient Math.random() for random int

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -206,12 +206,6 @@
     <!--Parameter must be non-null but is marked as nullable-->
   </Match>
   <Match>
-    <Class name="org.apache.beam.sdk.options.ProxyInvocationHandler"/>
-    <Method name="&lt;init&gt;"/>
-    <Bug pattern="DM_NEXTINT_VIA_NEXTDOUBLE"/>
-    <!--Use the nextInt method of Random rather than nextDouble to generate a random integer-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.runners.DirectPipelineRunner"/>
     <Method name="&lt;init&gt;"/>
     <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -66,10 +66,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -94,8 +94,8 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
    * No two instances of this class are considered equivalent hence we generate a random hash code
    * between 0 and {@link Integer#MAX_VALUE}.
    */
-  private final int hashCode = (RANDOM.nextInt() * Integer.MAX_VALUE);
-  private static final Random RANDOM = new Random();
+  private final int hashCode =  ThreadLocalRandom.current().nextInt(
+          Integer.MIN_VALUE, Integer.MAX_VALUE);
   private final Set<Class<? extends PipelineOptions>> knownInterfaces;
   private final ClassToInstanceMap<PipelineOptions> interfaceToProxyCache;
   private final Map<String, BoundValue> options;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -66,6 +66,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -93,7 +94,8 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
    * No two instances of this class are considered equivalent hence we generate a random hash code
    * between 0 and {@link Integer#MAX_VALUE}.
    */
-  private final int hashCode = (int) (Math.random() * Integer.MAX_VALUE);
+  private final int hashCode = (RANDOM.nextInt() * Integer.MAX_VALUE);
+  private static final Random RANDOM = new Random();
   private final Set<Class<? extends PipelineOptions>> knownInterfaces;
   private final ClassToInstanceMap<PipelineOptions> interfaceToProxyCache;
   private final Map<String, BoundValue> options;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -94,7 +94,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
    * No two instances of this class are considered equivalent hence we generate a random hash code
    * between 0 and {@link Integer#MAX_VALUE}.
    */
-  private final int hashCode =  ThreadLocalRandom.current().nextInt(
+  private final int hashCode = ThreadLocalRandom.current().nextInt(
           Integer.MIN_VALUE, Integer.MAX_VALUE);
   private final Set<Class<? extends PipelineOptions>> knownInterfaces;
   private final ClassToInstanceMap<PipelineOptions> interfaceToProxyCache;


### PR DESCRIPTION
For more information: https://issues.apache.org/jira/browse/BEAM-408