### PR TITLE
[BEAM-397] - Fixes Format string - it should use %n instead of \n

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -69,12 +69,6 @@
     <!--Class is not derived from an Exception, even though it is named as such-->
   </Match>
   <Match>
-    <Class name="org.apache.beam.sdk.coders.Coder$NonDeterministicException"/>
-    <Method name="getMessage"/>
-    <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
-    <!--Format string should use %n rather than \n-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.coders.EntityCoder"/>
     <Method name="decode"/>
     <Bug pattern="RR_NOT_CHECKED"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -293,8 +293,8 @@ public interface Coder<T> extends Serializable {
 
     @Override
     public String getMessage() {
-      return String.format("%s is not deterministic because:\n  %s",
-          coder, Joiner.on("\n  ").join(reasons));
+      return String.format("%s is not deterministic because:%n  %s",
+          coder, Joiner.on("%n  ").join(reasons));
     }
   }
 }


### PR DESCRIPTION
For more information: https://issues.apache.org/jira/browse/BEAM-397