### PR TITLE
[BEAM-413] - Improves test for floating point equality.

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -296,12 +296,6 @@
     <!--Unread field-->
   </Match>
   <Match>
-    <Class name="org.apache.beam.sdk.transforms.Mean$CountSum"/>
-    <Method name="equals"/>
-    <Bug pattern="FE_FLOATING_POINT_EQUALITY"/>
-    <!--Test for floating point equality-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.transforms.display.DisplayData"/>
     <Field name="entries"/>
     <Bug pattern="SE_BAD_FIELD"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Mean.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Mean.java
@@ -161,8 +161,8 @@ public class Mean {
       }
       @SuppressWarnings("unchecked")
       CountSum<?> otherCountSum = (CountSum<?>) other;
-      return (count == otherCountSum.count)
-          && (sum == otherCountSum.sum);
+      return (Math.abs(count - otherCountSum.count) < .0000001)
+              && Math.abs(sum - otherCountSum.sum) < .0000001;
     }
 
     @Override


### PR DESCRIPTION
This operation compares two floating point values for equality. Because
floating point calculations may involve rounding, calculated float and
double values may not be accurate. For values that must be precise, such
as monetary values, consider using a fixed-precision type such as
BigDecimal. For values that need not be precise, consider comparing for
equality within some range, for example: if ( Math.abs(x - y) < .0000001
).

For more information: https://issues.apache.org/jira/browse/BEAM-413