### PR TITLE
[BEAM-381] BoundedReader: update the range last of all

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -370,13 +370,13 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
       LOG.debug(
           "Proposing to split OffsetBasedReader {} at fraction {} (offset {})",
           rangeTracker, fraction, splitOffset);
-      if (!rangeTracker.trySplitAtPosition(splitOffset)) {
-        return null;
-      }
       long start = source.getStartOffset();
       long end = source.getEndOffset();
       OffsetBasedSource<T> primary = source.createSourceForSubrange(start, splitOffset);
       OffsetBasedSource<T> residual = source.createSourceForSubrange(splitOffset, end);
+      if (!rangeTracker.trySplitAtPosition(splitOffset)) {
+        return null;
+      }
       this.source = primary;
       return residual;
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -834,11 +834,11 @@ public class BigtableIO {
       }
       logger.debug(
           "Proposing to split {} at fraction {} (key {})", rangeTracker, fraction, splitKey);
+      BigtableSource primary = source.withEndKey(splitKey);
+      BigtableSource residual = source.withStartKey(splitKey);
       if (!rangeTracker.trySplitAtPosition(splitKey)) {
         return null;
       }
-      BigtableSource primary = source.withEndKey(splitKey);
-      BigtableSource residual = source.withStartKey(splitKey);
       this.source = primary;
       return residual;
     }


### PR DESCRIPTION
Reorders the code in some splitAtFraction calls so that the rangeTracker update
is the last thing (besides assignment) in the function. This avoids a potential
issue if creating the primary or residual sources happens to throw an exception.