### PR TITLE
[BEAM-429] remove an obsolete comment in KafkaIOTest.java

### DIFF
--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -126,7 +126,6 @@ public class KafkaIOTest {
         records.put(tp, new ArrayList<ConsumerRecord<byte[], byte[]>>());
       }
       records.get(tp).add(
-          // Note: this interface has changed in 0.10. may get fixed before the release.
           new ConsumerRecord<byte[], byte[]>(
               tp.topic(),
               tp.partition(),


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Kafka 10.0 added compatible constructor for ConsumerRecord. It was not present when I wrote this test. https://github.com/apache/kafka/commit/4e557f8ef60d46a8870704655c9a35092f74d125