### PR TITLE
[BEAM-431] Move example dependency on runners into a profile

### DIFF
--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -35,6 +35,53 @@
 
   <packaging>jar</packaging>
 
+  <profiles>
+
+    <!--
+      A default profile that includes optional dependencies
+      on all of our runners. This is aimed at making it very
+      easy for users to run examples with any runner without
+      any configuration. It is not needed or desirable when
+      testing the examples with a particular runner.
+
+      This profile can be disabled on the command line
+      by specifying -P !include-runners.
+
+      This profile cannot be lifted to examples-parent because
+      it would be automatically deactivated when the Java 8
+      profile were activated.
+    -->
+    <profile>
+      <id>include-runners</id>
+      <activation><activeByDefault>true</activeByDefault></activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-direct-java</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+          <optional>true</optional>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-flink_2.10</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+          <optional>true</optional>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-spark</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
@@ -163,22 +210,6 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-direct-java</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-flink_2.10</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Even an optional runtime dependency, such as from the examples
to a runner, does get pulled in for testing. This meant that
all the dependencies for all runners had to be resolvable in an
integration testing context. It is quite inconvenient.

Explicitly excluding runners via flags such as `-pl !runners/spark`
does not work since it causes errors in dependency resolution.

This change adds a profile, active by default, that can be
explicitly disabled to avoid pulling in dependencies.