### PR TITLE
[BEAM-124] WordCountIT: Add outputs verification

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -18,17 +18,39 @@
 
 package org.apache.beam.examples;
 
+import static org.junit.Assert.fail;
+
 import org.apache.beam.examples.WordCount.WordCountOptions;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.SerializableMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
-import com.google.common.base.Joiner;
+import org.apache.beam.sdk.util.IOChannelFactory;
+import org.apache.beam.sdk.util.IOChannelUtils;
 
+import com.google.common.base.Joiner;
+import com.google.common.io.LineReader;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 /**
  * End-to-end tests of WordCount.
@@ -46,9 +68,121 @@ public class WordCountIT {
   public void testE2EWordCount() throws Exception {
     PipelineOptionsFactory.register(WordCountITOptions.class);
     WordCountITOptions options = TestPipeline.testingPipelineOptions().as(WordCountITOptions.class);
-    options.setOutput(Joiner.on("/").join(new String[]{options.getTempRoot(),
-        String.format("WordCountIT-%tF-%<tH-%<tM-%<tS-%<tL", new Date()), "output", "results"}));
+    options.setOutput(
+        Joiner.on("/")
+            .join(
+                new String[] {
+                  options.getTempRoot(),
+                  String.format("WordCountIT-%tF-%<tH-%<tM-%<tS-%<tL", new Date()),
+                  "output",
+                  "results"
+                }));
+    options.setOnSuccessMatcher(new WordCountOnSuccessMatcher(options.getOutput() + "*"));
 
     WordCount.main(TestPipeline.convertToArgs(options));
+  }
+
+  /**
+   * Matcher for verifying WordCount output data.
+   */
+  static class WordCountOnSuccessMatcher extends BaseMatcher<PipelineResult>
+      implements SerializableMatcher<PipelineResult> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WordCountOnSuccessMatcher.class);
+
+    private static final String EXPECTED_CHECKSUM = "C780E9466B8635AF1D11B74BBD35233A82908A02";
+
+    private final String outputPath;
+
+    WordCountOnSuccessMatcher(String outputPath) {
+      this.outputPath = outputPath;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      if (o == null || !(o instanceof PipelineResult)) {
+        fail(String.format("Expected PipelineResult but received %s", o));
+      }
+
+      if (outputPath == null || outputPath.isEmpty()) {
+        fail(String.format("Expected valid output path, but received %s", outputPath));
+      }
+
+      //Load output data
+      LOG.info("Loading actual from path: {}", outputPath);
+      List<String> outputs = read(outputPath);
+
+      // Verify checksum of outputs
+      Collections.sort(outputs);
+      try {
+        String checksum = generateChecksum(outputs);
+        LOG.info("Generate checksum for output data: {}", checksum);
+
+        return checksum.equals(EXPECTED_CHECKSUM);
+      } catch (NoSuchAlgorithmException e) {
+        e.printStackTrace();
+      }
+
+      return false;
+    }
+
+    private List<String> read(String path) {
+      List<String> readData = new ArrayList<>();
+
+      try {
+        IOChannelFactory factory = IOChannelUtils.getFactory(path);
+
+        // Match inputPath which may contains glob
+        Collection<String> files = factory.match(path);
+
+        // Read data from file paths
+        for (String file : files) {
+          Reader reader = Channels.newReader(factory.open(file), StandardCharsets.UTF_8.name());
+          LineReader lineReader = new LineReader(reader);
+
+          String line;
+          while ((line = lineReader.readLine()) != null) {
+            readData.add(line);
+          }
+
+          reader.close();
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+      return readData;
+    }
+
+    /**
+     * Generate checksum of a string collection using SHA-1 algorithm.
+     */
+    private String generateChecksum(List<String> lines) throws NoSuchAlgorithmException {
+      MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+
+      for (String line : lines) {
+        messageDigest.update(line.getBytes(StandardCharsets.UTF_8));
+      }
+
+      return convertDecimalToHex(messageDigest.digest());
+    }
+
+    private String convertDecimalToHex(byte[] numbers) {
+      char[] digits = "0123456789ABCDEF".toCharArray();
+      StringBuilder hexNum = new StringBuilder();
+
+      for (int i = 0; i < numbers.length; i++) {
+        int num = numbers[i] & 0xFF;
+        hexNum.append(digits[num >>> 4]);
+        hexNum.append(digits[num & 0xF]);
+      }
+
+      return hexNum.toString();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("Expect output checksum should be ").appendValue(EXPECTED_CHECKSUM);
+    }
   }
 }

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -93,7 +93,7 @@ public class WordCountIT {
 
     WordCountOnSuccessMatcher(String outputPath) {
       checkArgument(
-          Strings.isNullOrEmpty(outputPath),
+          !Strings.isNullOrEmpty(outputPath),
           "Expected valid output path, but received %s", outputPath);
 
       this.outputPath = outputPath;

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.testing.TestPipelineOptions;
 import org.apache.beam.sdk.util.IOChannelFactory;
 import org.apache.beam.sdk.util.IOChannelUtils;
 
+import com.google.common.base.Strings;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.CharStreams;
@@ -92,7 +93,7 @@ public class WordCountIT {
 
     WordCountOnSuccessMatcher(String outputPath) {
       checkArgument(
-          outputPath != null && !outputPath.isEmpty(),
+          Strings.isNullOrEmpty(outputPath),
           "Expected valid output path, but received %s", outputPath);
 
       this.outputPath = outputPath;
@@ -131,7 +132,7 @@ public class WordCountIT {
           List<String> lines = CharStreams.readLines(reader);
           readData.addAll(lines);
           LOG.info(
-              "[{} of {}] Read {} lines from file: ", i, files.size() - 1, lines.size(), file);
+              "[{} of {}] Read {} lines from file: {}", i, files.size() - 1, lines.size(), file);
         }
         i++;
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.PipelineRunner;
+import org.apache.beam.sdk.util.IOChannelUtils;
 import org.apache.beam.sdk.util.TestCredential;
 
 import com.google.common.base.Optional;
@@ -155,6 +156,8 @@ public class TestPipeline extends Pipeline {
         options.as(GcpOptions.class).setGcpCredential(new TestCredential());
       }
       options.setStableUniqueNames(CheckEnabled.ERROR);
+
+      IOChannelUtils.registerStandardIOFactories(options);
       return options;
     } catch (IOException e) {
       throw new RuntimeException("Unable to instantiate test options from system property "


### PR DESCRIPTION
+R: @jasonkuster @dhalperi @lukecwik 

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Implement onSuccessMatcher for WordCount Integration Test to verify checksum of WordCount output. 

Using IOChannelUtils which dynamically creates IOChannelFactory and avoids the dependence on specific storage type.