### PR TITLE
Making the dataflow temp_location argument optional

### DIFF
--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -339,16 +339,18 @@ class Job(object):
   def __init__(self, options):
     self.options = options
     self.google_cloud_options = options.view_as(GoogleCloudOptions)
-    required_google_cloud_options = ['project',
-                                     'job_name',
-                                     'staging_location',
-                                     'temp_location']
+    required_google_cloud_options = ['project', 'job_name', 'staging_location']
     missing = [
         option for option in required_google_cloud_options
         if not getattr(self.google_cloud_options, option)]
     if missing:
       raise ValueError(
           'Missing required configuration parameters: %s' % missing)
+
+    if not self.google_cloud_options.temp_location:
+      (self.google_cloud_options
+       .temp_location) = self.google_cloud_options.staging_location
+
     # Make the staging and temp locations job name and time specific. This is
     # needed to avoid clashes between job submissions using the same staging
     # area or team members using same job names. This method is not entirely

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -348,6 +348,8 @@ class Job(object):
           'Missing required configuration parameters: %s' % missing)
 
     if not self.google_cloud_options.temp_location:
+      logging.info('Defaulting to the staging_location as temp_location: %s',
+                   self.google_cloud_options.staging_location)
       (self.google_cloud_options
        .temp_location) = self.google_cloud_options.staging_location
 

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -255,7 +255,8 @@ class GoogleCloudOptions(PipelineOptions):
     if validator.is_service_runner():
       errors.extend(validator.validate_cloud_options(self))
       errors.extend(validator.validate_gcs_path(self, 'staging_location'))
-      if getattr(self, 'temp_location', None):
+      if getattr(self, 'temp_location',
+                 None) or getattr(self, 'staging_location', None) is None:
         errors.extend(validator.validate_gcs_path(self, 'temp_location'))
     return errors
 

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -235,8 +235,8 @@ class GoogleCloudOptions(PipelineOptions):
                         default=None,
                         help='GCS path for staging code packages needed by '
                         'workers.')
-    # If this option is None then the Dataflow pipeline defaults to using
-    # staging_location.
+    # Remote execution must check that this option is not None.
+    # If temp_location is not set, it defaults to staging_location.
     parser.add_argument('--temp_location',
                         default=None,
                         help='GCS path for saving temporary workflow jobs.')

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -235,7 +235,8 @@ class GoogleCloudOptions(PipelineOptions):
                         default=None,
                         help='GCS path for staging code packages needed by '
                         'workers.')
-    # Remote execution must check that this option is not None.
+    # If this option is None then the Dataflow pipeline defaults to using
+    # staging_location.
     parser.add_argument('--temp_location',
                         default=None,
                         help='GCS path for saving temporary workflow jobs.')
@@ -254,7 +255,8 @@ class GoogleCloudOptions(PipelineOptions):
     if validator.is_service_runner():
       errors.extend(validator.validate_cloud_options(self))
       errors.extend(validator.validate_gcs_path(self, 'staging_location'))
-      errors.extend(validator.validate_gcs_path(self, 'temp_location'))
+      if getattr(self, 'temp_location', None):
+        errors.extend(validator.validate_gcs_path(self, 'temp_location'))
     return errors
 
 

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -70,16 +70,18 @@ class SetupTest(unittest.TestCase):
     self.assertEqual(
         self.check_errors_for_arguments(
             errors,
-            ['project', 'job_name', 'staging_location']),
+            ['project', 'job_name', 'staging_location', 'temp_location']),
         [])
 
   def test_gcs_path(self):
-    def get_validator(temp_location):
-      options = ['--project=example:example', '--job_name=job',
-                 '--staging_location=gs://foo/bar']
+    def get_validator(temp_location, staging_location):
+      options = ['--project=example:example', '--job_name=job']
 
       if temp_location is not None:
         options.append('--temp_location=' + temp_location)
+
+      if staging_location is not None:
+        options.append('--staging_location=' + staging_location)
 
       pipeline_options = PipelineOptions(options)
       runner = MockRunners.DataflowPipelineRunner()
@@ -87,18 +89,44 @@ class SetupTest(unittest.TestCase):
       return validator
 
     test_cases = [
-        {'temp_location': None, 'errors': []},
-        {'temp_location': 'gcs:/foo/bar', 'errors': ['temp_location']},
-        {'temp_location': 'gs:/foo/bar', 'errors': ['temp_location']},
-        {'temp_location': 'gs://ABC/bar', 'errors': ['temp_location']},
-        {'temp_location': 'gs://ABC/bar', 'errors': ['temp_location']},
-        {'temp_location': 'gs://foo', 'errors': ['temp_location']},
-        {'temp_location': 'gs://foo/', 'errors': []},
-        {'temp_location': 'gs://foo/bar', 'errors': []},
+        {'temp_location': None,
+         'staging_location': 'gs://foo/bar',
+         'errors': []},
+        {'temp_location': None,
+         'staging_location': None,
+         'errors': ['staging_location', 'temp_location']},
+        {'temp_location': 'gs://foo/bar',
+         'staging_location': None,
+         'errors': ['staging_location']},
+        {'temp_location': 'gs://foo/bar',
+         'staging_location': 'gs://ABC/bar',
+         'errors': ['staging_location']},
+        {'temp_location': 'gcs:/foo/bar',
+         'staging_location': 'gs://foo/bar',
+         'errors': ['temp_location']},
+        {'temp_location': 'gs:/foo/bar',
+         'staging_location': 'gs://foo/bar',
+         'errors': ['temp_location']},
+        {'temp_location': 'gs://ABC/bar',
+         'staging_location': 'gs://foo/bar',
+         'errors': ['temp_location']},
+        {'temp_location': 'gs://ABC/bar',
+         'staging_location': 'gs://foo/bar',
+         'errors': ['temp_location']},
+        {'temp_location': 'gs://foo',
+         'staging_location': 'gs://foo/bar',
+         'errors': ['temp_location']},
+        {'temp_location': 'gs://foo/',
+         'staging_location': 'gs://foo/bar',
+         'errors': []},
+        {'temp_location': 'gs://foo/bar',
+         'staging_location': 'gs://foo/bar',
+         'errors': []},
     ]
 
     for case in test_cases:
-      errors = get_validator(case['temp_location']).validate()
+      errors = get_validator(case['temp_location'],
+                             case['staging_location']).validate()
       self.assertEqual(
           self.check_errors_for_arguments(errors, case['errors']), [])
 

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -70,7 +70,7 @@ class SetupTest(unittest.TestCase):
     self.assertEqual(
         self.check_errors_for_arguments(
             errors,
-            ['project', 'job_name', 'staging_location', 'temp_location']),
+            ['project', 'job_name', 'staging_location']),
         [])
 
   def test_gcs_path(self):
@@ -87,7 +87,7 @@ class SetupTest(unittest.TestCase):
       return validator
 
     test_cases = [
-        {'temp_location': None, 'errors': ['temp_location']},
+        {'temp_location': None, 'errors': []},
         {'temp_location': 'gcs:/foo/bar', 'errors': ['temp_location']},
         {'temp_location': 'gs:/foo/bar', 'errors': ['temp_location']},
         {'temp_location': 'gs://ABC/bar', 'errors': ['temp_location']},


### PR DESCRIPTION
Making the dataflow temp_location argument optional in the python SDK to match the java SDK.