### PR TITLE
Allow ".tar" files in extra_packages

### DIFF
--- a/sdks/python/apache_beam/utils/dependency.py
+++ b/sdks/python/apache_beam/utils/dependency.py
@@ -461,4 +461,3 @@ def _download_pypi_sdk_package(temp_dir):
       'Failed to download a source distribution for the running SDK. Expected '
       'either %s or %s to be found in the download folder.' % (
           zip_expected, tgz_expected))
-

--- a/sdks/python/apache_beam/utils/dependency.py
+++ b/sdks/python/apache_beam/utils/dependency.py
@@ -29,7 +29,7 @@ and a --setup_file option.
 If --setup_file is present then it is assumed that the folder containing the
 file specified by the option has the typical layout required by setuptools and
 it will run 'python setup.py sdist' to produce a source distribution. The
-resulting tarball (a file ending in .tar.gz) will be staged at the GCS staging
+resulting tarball (a .tar or .tar.gz file) will be staged at the GCS staging
 location specified as job option. When a worker starts it will check for the
 presence of this file and will run 'easy_install tarball' to install the
 package in the worker.
@@ -137,10 +137,11 @@ def _stage_extra_packages(extra_packages, staging_location, temp_dir,
   staging_temp_dir = None
   local_packages = []
   for package in extra_packages:
-    if not os.path.basename(package).endswith('.tar.gz'):
+    if not (os.path.basename(package).endswith('.tar') or
+            os.path.basename(package).endswith('.tar.gz')):
       raise RuntimeError(
           'The --extra_packages option expects a full path ending with '
-          '\'.tar.gz\' instead of %s' % package)
+          '\'.tar\' or \'.tar.gz\' instead of %s' % package)
 
     if not os.path.isfile(package):
       if package.startswith('gs://'):

--- a/sdks/python/apache_beam/utils/dependency_test.py
+++ b/sdks/python/apache_beam/utils/dependency_test.py
@@ -333,6 +333,8 @@ class SetupTest(unittest.TestCase):
     self.create_temp_file(
         os.path.join(source_dir, 'xyz.tar.gz'), 'nothing')
     self.create_temp_file(
+        os.path.join(source_dir, 'xyz2.tar'), 'nothing')
+    self.create_temp_file(
         os.path.join(source_dir, dependency.EXTRA_PACKAGES_FILE), 'nothing')
 
     options = PipelineOptions()
@@ -341,6 +343,7 @@ class SetupTest(unittest.TestCase):
     options.view_as(SetupOptions).extra_packages = [
         os.path.join(source_dir, 'abc.tar.gz'),
         os.path.join(source_dir, 'xyz.tar.gz'),
+        os.path.join(source_dir, 'xyz2.tar'),
         'gs://my-gcs-bucket/gcs.tar.gz']
 
     gcs_copied_files = []
@@ -359,13 +362,13 @@ class SetupTest(unittest.TestCase):
     dependency._dependency_file_copy = file_copy
 
     self.assertEqual(
-        ['abc.tar.gz', 'xyz.tar.gz', 'gcs.tar.gz',
+        ['abc.tar.gz', 'xyz.tar.gz', 'xyz2.tar', 'gcs.tar.gz',
          dependency.EXTRA_PACKAGES_FILE,
          names.PICKLED_MAIN_SESSION_FILE],
         dependency.stage_job_resources(options))
     with open(os.path.join(staging_dir, dependency.EXTRA_PACKAGES_FILE)) as f:
-      self.assertEqual(['abc.tar.gz\n', 'xyz.tar.gz\n', 'gcs.tar.gz\n'],
-                       f.readlines())
+      self.assertEqual(['abc.tar.gz\n', 'xyz.tar.gz\n', 'xyz2.tar\n',
+                        'gcs.tar.gz\n'], f.readlines())
     self.assertEqual(['gs://my-gcs-bucket/gcs.tar.gz'], gcs_copied_files)
 
   def test_with_extra_packages_missing_files(self):
@@ -398,7 +401,8 @@ class SetupTest(unittest.TestCase):
     self.assertEqual(
         cm.exception.message,
         'The --extra_packages option expects a full path ending with '
-        '\'.tar.gz\' instead of %s' % os.path.join(source_dir, 'abc.tgz'))
+        '\'.tar\' or \'.tar.gz\' instead of %s' % os.path.join(source_dir,
+                                                               'abc.tgz'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change allows uncompressed ".tar" package tarballs to be staged and installed on worker startup.
