### PR TITLE
[BEAM-394] Updated the AvroCoder class to set unserializable fields as transient

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -30,42 +30,6 @@
           the issue.
         -->
   <Match>
-    <Class name="org.apache.beam.sdk.coders.AvroCoder"/>
-    <Field name="decoder"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-    <!--[BEAM-394] Non-transient non-serializable instance field in serializable class-->
-  </Match>
-  <Match>
-    <Class name="org.apache.beam.sdk.coders.AvroCoder"/>
-    <Field name="encoder"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-    <!--[BEAM-394] Non-transient non-serializable instance field in serializable class-->
-  </Match>
-  <Match>
-    <Class name="org.apache.beam.sdk.coders.AvroCoder"/>
-    <Field name="reader"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-    <!--[BEAM-394] Non-transient non-serializable instance field in serializable class-->
-  </Match>
-  <Match>
-    <Class name="org.apache.beam.sdk.coders.AvroCoder"/>
-    <Field name="writer"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-    <!--[BEAM-394] Non-transient non-serializable instance field in serializable class-->
-  </Match>
-  <Match>
-    <Class name="org.apache.beam.sdk.coders.AvroCoder"/>
-    <Field name="reader"/>
-    <Bug pattern="SE_BAD_FIELD_STORE"/>
-    <!--[BEAM-394] Non-serializable value stored into instance field of a serializable class-->
-  </Match>
-  <Match>
-    <Class name="org.apache.beam.sdk.coders.AvroCoder"/>
-    <Field name="writer"/>
-    <Bug pattern="SE_BAD_FIELD_STORE"/>
-    <!--[BEAM-394] Non-serializable value stored into instance field of a serializable class-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.coders.Coder$NonDeterministicException"/>
     <Bug pattern="NM_CLASS_NOT_EXCEPTION"/>
     <!--[BEAM-396] Class is not derived from an Exception, even though it is named as such-->

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -168,7 +168,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
   };
 
   private final Class<T> type;
-  private final Schema schema;
+  private transient final Schema schema;
 
   private final List<String> nonDeterministicReasons;
 
@@ -178,10 +178,10 @@ public class AvroCoder<T> extends StandardCoder<T> {
   // Cache the old encoder/decoder and let the factories reuse them when possible. To be threadsafe,
   // these are ThreadLocal. This code does not need to be re-entrant as AvroCoder does not use
   // an inner coder.
-  private final ThreadLocal<BinaryDecoder> decoder;
-  private final ThreadLocal<BinaryEncoder> encoder;
-  private final ThreadLocal<DatumWriter<T>> writer;
-  private final ThreadLocal<DatumReader<T>> reader;
+  private transient final ThreadLocal<BinaryDecoder> decoder;
+  private transient final ThreadLocal<BinaryEncoder> encoder;
+  private transient final ThreadLocal<DatumWriter<T>> writer;
+  private transient final ThreadLocal<DatumReader<T>> reader;
 
   protected AvroCoder(Class<T> type, Schema schema) {
     this.type = type;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -178,7 +178,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
   // Cache the old encoder/decoder and let the factories reuse them when possible. To be threadsafe,
   // these are ThreadLocal. This code does not need to be re-entrant as AvroCoder does not use
   // an inner coder.
-  private final transient  ThreadLocal<BinaryDecoder> decoder;
+  private final transient ThreadLocal<BinaryDecoder> decoder;
   private final transient ThreadLocal<BinaryEncoder> encoder;
   private final transient ThreadLocal<DatumWriter<T>> writer;
   private final transient ThreadLocal<DatumReader<T>> reader;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -168,7 +168,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
   };
 
   private final Class<T> type;
-  private transient final Schema schema;
+  private final transient Schema schema;
 
   private final List<String> nonDeterministicReasons;
 
@@ -178,10 +178,10 @@ public class AvroCoder<T> extends StandardCoder<T> {
   // Cache the old encoder/decoder and let the factories reuse them when possible. To be threadsafe,
   // these are ThreadLocal. This code does not need to be re-entrant as AvroCoder does not use
   // an inner coder.
-  private transient final ThreadLocal<BinaryDecoder> decoder;
-  private transient final ThreadLocal<BinaryEncoder> encoder;
-  private transient final ThreadLocal<DatumWriter<T>> writer;
-  private transient final ThreadLocal<DatumReader<T>> reader;
+  private final transient  ThreadLocal<BinaryDecoder> decoder;
+  private final transient ThreadLocal<BinaryEncoder> encoder;
+  private final transient ThreadLocal<DatumWriter<T>> writer;
+  private final transient ThreadLocal<DatumReader<T>> reader;
 
   protected AvroCoder(Class<T> type, Schema schema) {
     this.type = type;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/AvroCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/AvroCoderTest.java
@@ -62,10 +62,8 @@ import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -153,13 +151,13 @@ public class AvroCoderTest {
   }
 
   /**
-   * Confirm that we can serialize and deserialize an AvroCoder object and then still successfully decode after
-   * (BEAM-349)
+   * Confirm that we can serialize and deserialize an AvroCoder object and still decode after.
+   * (BEAM-349).
+   *
    * @throws Exception
    */
   @Test
-  public void testTransientFieldInitialization() throws Exception
-  {
+  public void testTransientFieldInitialization() throws Exception {
     Pojo value = new Pojo("Hello", 42);
     AvroCoder<Pojo> coder = AvroCoder.of(Pojo.class);
 


### PR DESCRIPTION
* Updated AvroCoder to mark non-serializable fields as transient.
* Updated the findbugs_filter to remove ignored errors.