### PR TITLE
Allow custom timestamp/watermark function for UnboundedFlinkSource

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
@@ -49,6 +49,11 @@ public class UnboundedFlinkSource<T> extends UnboundedSource<T, UnboundedSource.
     flinkSource = checkNotNull(source);
   }
 
+  public UnboundedFlinkSource(SourceFunction<T> source, AssignerWithPeriodicWatermarks<T> timestampAssigner) {
+    flinkSource = checkNotNull(source);
+    flinkTimestampAssigner = checkNotNull(timestampAssigner);
+  }
+
   public SourceFunction<T> getFlinkSource() {
     return this.flinkSource;
   }
@@ -100,5 +105,10 @@ public class UnboundedFlinkSource<T> extends UnboundedSource<T, UnboundedSource.
    */
   public static <T> UnboundedSource<T, UnboundedSource.CheckpointMark> of(SourceFunction<T> flinkSource) {
     return new UnboundedFlinkSource<>(flinkSource);
+  }
+
+  public static <T> UnboundedSource<T, UnboundedSource.CheckpointMark> of(
+          SourceFunction<T> flinkSource, AssignerWithPeriodicWatermarks<T> flinkTimestampAssigner) {
+    return new UnboundedFlinkSource<>(flinkSource, flinkTimestampAssigner);
   }
 }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
@@ -23,6 +23,8 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
 
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.IngestionTimeExtractor;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 import java.util.List;
@@ -40,12 +42,19 @@ public class UnboundedFlinkSource<T> extends UnboundedSource<T, UnboundedSource.
   /** Coder set during translation */
   private Coder<T> coder;
 
+  /** Timestamp / watermark assigner for source; defaults to ingestion time */
+  private AssignerWithPeriodicWatermarks<T> flinkTimestampAssigner = new IngestionTimeExtractor<T>();
+
   public UnboundedFlinkSource(SourceFunction<T> source) {
     flinkSource = checkNotNull(source);
   }
 
   public SourceFunction<T> getFlinkSource() {
     return this.flinkSource;
+  }
+
+  public AssignerWithPeriodicWatermarks<T> getFlinkTimestampAssigner() {
+    return flinkTimestampAssigner;
   }
 
   @Override
@@ -77,6 +86,10 @@ public class UnboundedFlinkSource<T> extends UnboundedSource<T, UnboundedSource.
 
   public void setCoder(Coder<T> coder) {
     this.coder = coder;
+  }
+
+  public void setFlinkTimestampAssigner(AssignerWithPeriodicWatermarks<T> flinkTimestampAssigner) {
+    this.flinkTimestampAssigner = flinkTimestampAssigner;
   }
 
   /**


### PR DESCRIPTION
So, using an `UnboundedFlinkSource` seems to force the timestamp applied to each element of the incoming stream to the ingestion time, rather than allowing for proper event timestamping. This PR  adds the ability to created an `UnboundedFlinkSource` with a custom TimestampAssigner, which should alleviate that issue. Note that this is particularly useful, as currently the only means of consuming from Kafka 0.8 using Beam/Flink Runner is to wrap Flink's Kafka 0.8 consumer.