### PR TITLE
[BEAM-439] Remove optional args from start/finish bundle methods

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -62,13 +62,13 @@ class DoFnRunner(object):
       class CurriedFn(core.DoFn):
 
         def start_bundle(self, context):
-          return fn.start_bundle(context, *args, **kwargs)
+          return fn.start_bundle(context)
 
         def process(self, context):
           return fn.process(context, *args, **kwargs)
 
         def finish_bundle(self, context):
-          return fn.finish_bundle(context, *args, **kwargs)
+          return fn.finish_bundle(context)
       self.dofn = CurriedFn()
     self.window_fn = windowing.windowfn
     self.context = context

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -54,13 +54,13 @@ class TypeCheckWrapperDoFn(DoFn):
     # TODO(robertwb): Multi-output.
     self._output_type_hint = type_hints.simple_output_type(label)
 
-  def start_bundle(self, context, *args, **kwargs):
+  def start_bundle(self, context):
     return self._type_check_result(
-        self._dofn.start_bundle(context, *args, **kwargs))
+        self._dofn.start_bundle(context))
 
-  def finish_bundle(self, context, *args, **kwargs):
+  def finish_bundle(self, context):
     return self._type_check_result(
-        self._dofn.finish_bundle(context, *args, **kwargs))
+        self._dofn.finish_bundle(context))
 
   def process(self, context, *args, **kwargs):
     if self._input_hints:
@@ -139,11 +139,11 @@ class OutputCheckWrapperDoFn(DoFn):
     else:
       return self._check_type(result)
 
-  def start_bundle(self, context, *args, **kwargs):
-    return self.run(self.dofn.start_bundle, context, args, kwargs)
+  def start_bundle(self, context):
+    return self.run(self.dofn.start_bundle, context, [], {})
 
-  def finish_bundle(self, context, *args, **kwargs):
-    return self.run(self.dofn.finish_bundle, context, args, kwargs)
+  def finish_bundle(self, context):
+    return self.run(self.dofn.finish_bundle, context, [], {})
 
   def process(self, context, *args, **kwargs):
     return self.run(self.dofn.process, context, args, kwargs)


### PR DESCRIPTION
@robertwb can you please take a look?
Technically we do not want to allow deferred side inputs but it is much simple conceptually to remove
extra arguments altogether. 
