### PR TITLE
[BEAM-445] Switch to netty-tcnative uber-jar dependency

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -195,6 +195,17 @@
         </executions>
       </plugin>
     </plugins>
+
+    <extensions>
+      <!-- Use os-maven-plugin to initialize the "os.detected" properties for Bigtable
+           in beam-sdks-java-io-google-cloud-platform.
+           See: https://cloud.google.com/bigtable/docs/using-maven#encryption -->
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${os-maven-plugin.version}</version>
+      </extension>
+    </extensions>
   </build>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
     <joda.version>2.4</joda.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.9.5</mockito.version>
+    <os-maven-plugin.version>1.4.0.Final</os-maven-plugin.version>
     <protobuf.version>3.0.0-beta-1</protobuf.version>
     <pubsub.version>v1-rev10-1.22.0</pubsub.version>
     <slf4j.version>1.7.14</slf4j.version>

--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -88,11 +88,12 @@
     </plugins>
 
     <extensions>
-      <!-- Use os-maven-plugin to initialize the "os.detected" properties -->
+      <!-- Use os-maven-plugin to initialize the "os.detected" properties for Bigtable.
+           See: https://cloud.google.com/bigtable/docs/using-maven#encryption -->
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
+        <version>${os-maven-plugin.version}</version>
       </extension>
     </extensions>
   </build>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Currently, we are using the os-maven-plugin extension to compute the platform-specific version of the netty-tcnative dependency to use in gcp-io. Unfortunately, netty-tcnative is a transitive dependency and all pom's which depend on gcp-io (directly or transitively) also need to declare the os-maven-plugin dependency.

This PR removes os-maven-plugin and it's dynamic resolution. We instead depend on the "uber jar" version of netty-tcnative, which includes all platform-native versions.
