### PR TITLE
[BEAM-434] Control the number of output shards in the Direct Runner

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.io.Write;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.AggregatorPipelineExtractor;
 import org.apache.beam.sdk.runners.AggregatorRetrievalException;
@@ -78,6 +79,7 @@ public class DirectRunner
           ImmutableMap.<Class<? extends PTransform>, PTransformOverrideFactory>builder()
               .put(GroupByKey.class, new DirectGroupByKeyOverrideFactory())
               .put(CreatePCollectionView.class, new ViewOverrideFactory())
+              .put(Write.Bound.class, new WriteWithShardingFactory())
               .build();
 
   /**

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.direct;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.apache.beam.sdk.io.Write;
+import org.apache.beam.sdk.io.Write.Bound;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.PInput;
+import org.apache.beam.sdk.values.POutput;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import org.joda.time.Duration;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A {@link PTransformOverrideFactory} that overrides {@link Write} {@link PTransform PTransforms}
+ * with an unspecified number of shards with a write with a specified number of shards. The number
+ * of shards is the log base 10 of the number of input records, with up to 2 additional shards.
+ */
+class WriteWithShardingFactory implements PTransformOverrideFactory {
+  static final int MAX_RANDOM_EXTRA_SHARDS = 3;
+
+  @Override
+  public <InputT extends PInput, OutputT extends POutput> PTransform<InputT, OutputT> override(
+      PTransform<InputT, OutputT> transform) {
+    if (transform instanceof Write.Bound) {
+      Write.Bound<InputT> that = (Write.Bound<InputT>) transform;
+      if (that.getNumShards() == 0) {
+        return (PTransform<InputT, OutputT>) new DynamicallyReshardedWrite<InputT>(that);
+      }
+    }
+    return transform;
+  }
+
+  private static class DynamicallyReshardedWrite <T> extends PTransform<PCollection<T>, PDone> {
+    private final transient Write.Bound<T> original;
+
+    private DynamicallyReshardedWrite(Bound<T> original) {
+      this.original = original;
+    }
+
+    @Override
+    public PDone apply(PCollection<T> input) {
+      PCollection<T> records = input.apply("RewindowInputs",
+          Window.<T>into(new GlobalWindows()).triggering(DefaultTrigger.of())
+              .withAllowedLateness(Duration.ZERO)
+              .discardingFiredPanes());
+      final PCollectionView<Long> numRecords = records.apply(Count.<T>globally().asSingletonView());
+      PCollection<T> resharded =
+          records
+              .apply(
+                  "ApplySharding",
+                  ParDo.withSideInputs(numRecords)
+                      .of(
+                          new KeyBasedOnCountFn<T>(
+                              numRecords,
+                              ThreadLocalRandom.current().nextInt(MAX_RANDOM_EXTRA_SHARDS))))
+              .apply("GroupIntoShards", GroupByKey.<Integer, T>create())
+              .apply("DropShardingKeys", Values.<Iterable<T>>create())
+              .apply("FlattenShardIterables", Flatten.<T>iterables());
+      // This is an inverted application to apply the expansion of the original Write PTransform
+      // without adding a new Write Transform Node, which would be overwritten the same way, leading
+      // to an infinite recursion. We cannot modify the number of shards, because that is determined
+      // at runtime.
+      return original.apply(resharded);
+    }
+  }
+
+  @VisibleForTesting
+  static class KeyBasedOnCountFn<T> extends DoFn<T, KV<Integer, T>> {
+    @VisibleForTesting
+    static final int MIN_SHARDS_FOR_LOG = 3;
+
+    private final PCollectionView<Long> numRecords;
+    private final int randomExtraShards;
+    private int currentShard;
+    private int maxShards;
+
+    KeyBasedOnCountFn(PCollectionView<Long> numRecords, int extraShards) {
+      this.numRecords = numRecords;
+      this.randomExtraShards = extraShards;
+    }
+
+    @Override
+    public void processElement(ProcessContext c) throws Exception {
+      if (maxShards == 0L) {
+        maxShards = calculateShards(c.sideInput(numRecords));
+        currentShard = ThreadLocalRandom.current().nextInt(maxShards);
+      }
+      int shard = currentShard;
+      currentShard = (currentShard + 1) % maxShards;
+      c.output(KV.of(shard, c.element()));
+    }
+
+    private int calculateShards(long totalRecords) {
+      checkArgument(
+          totalRecords > 0,
+          "KeyBasedOnCountFn cannot be invoked on an element if there are no elements");
+      if (totalRecords < MIN_SHARDS_FOR_LOG + randomExtraShards) {
+        return (int) totalRecords;
+      }
+      // 100mil records before >7 output files
+      int floorLogRecs = Double.valueOf(Math.log10(totalRecords)).intValue();
+      int shards = Math.max(floorLogRecs, MIN_SHARDS_FOR_LOG) + randomExtraShards;
+      return shards;
+    }
+  }
+}

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.direct;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.runners.direct.WriteWithShardingFactory.KeyBasedOnCountFn;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.io.Sink;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.Write;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFnTester;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.util.IOChannelUtils;
+import org.apache.beam.sdk.util.PCollectionViews;
+import org.apache.beam.sdk.util.WindowingStrategy;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PDone;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.nio.CharBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Tests for {@link WriteWithShardingFactory}.
+ */
+public class WriteWithShardingFactoryTest {
+  public static final int INPUT_SIZE = 10000;
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+  private WriteWithShardingFactory factory = new WriteWithShardingFactory();
+
+  @Test
+  public void dynamicallyReshardedWrite() throws Exception {
+    List<String> strs = new ArrayList<>(INPUT_SIZE);
+    for (int i = 0; i < INPUT_SIZE; i++) {
+      strs.add(UUID.randomUUID().toString());
+    }
+    Collections.shuffle(strs);
+
+    String fileName = "resharded_write";
+    String outputPath = tmp.getRoot().getAbsolutePath();
+    String targetLocation = IOChannelUtils.resolve(outputPath, fileName);
+    TestPipeline p = TestPipeline.create();
+    // TextIO is implemented in terms of the Write PTransform. When sharding is not specified,
+    // resharding should be automatically applied
+    p.apply(Create.of(strs)).apply(TextIO.Write.to(targetLocation));
+
+    p.run();
+
+    Collection<String> files = IOChannelUtils.getFactory(outputPath).match(targetLocation + "*");
+    List<String> actuals = new ArrayList(strs.size());
+    for (String file : files) {
+      CharBuffer buf = CharBuffer.allocate((int) new File(file).length());
+      try (Reader reader = new FileReader(file)) {
+        reader.read(buf);
+        buf.flip();
+      }
+
+      String[] readStrs = buf.toString().split("\n");
+      for (String read : readStrs) {
+        if (read.length() > 0) {
+          actuals.add(read);
+        }
+      }
+    }
+
+    assertThat(actuals, containsInAnyOrder(strs.toArray()));
+    assertThat(
+        files,
+        hasSize(
+            allOf(
+                greaterThan(1),
+                lessThan(
+                    (int)
+                        (Math.log10(INPUT_SIZE)
+                            + WriteWithShardingFactory.MAX_RANDOM_EXTRA_SHARDS)))));
+  }
+
+  @Test
+  public void withShardingSpecifiesOriginalTransform() {
+    PTransform<PCollection<Object>, PDone> original = Write.to(new TestSink()).withNumShards(3);
+
+    assertThat(factory.override(original), equalTo(original));
+  }
+
+  @Test
+  public void withNonWriteReturnsOriginalTransform() {
+    PTransform<PCollection<Object>, PDone> original =
+        new PTransform<PCollection<Object>, PDone>() {
+          @Override
+          public PDone apply(PCollection<Object> input) {
+            return PDone.in(input.getPipeline());
+          }
+        };
+
+    assertThat(factory.override(original), equalTo(original));
+  }
+
+  @Test
+  public void withNoShardingSpecifiedReturnsNewTransform() {
+    PTransform<PCollection<Object>, PDone> original = Write.to(new TestSink());
+    assertThat(factory.override(original), not(equalTo(original)));
+  }
+
+  @Test
+  public void keyBasedOnCountFnWithOneElement() throws Exception {
+    PCollectionView<Long> elementCountView =
+        PCollectionViews.singletonView(
+            TestPipeline.create(), WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+    KeyBasedOnCountFn<String> fn = new KeyBasedOnCountFn<>(elementCountView, 0);
+    DoFnTester<String, KV<Integer, String>> fnTester = DoFnTester.of(fn);
+
+    fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, 1L);
+
+    List<KV<Integer, String>> outputs = fnTester.processBundle("foo", "bar", "bazbar");
+    assertThat(
+        outputs, containsInAnyOrder(KV.of(0, "foo"), KV.of(0, "bar"), KV.of(0, "bazbar")));
+  }
+
+  @Test
+  public void keyBasedOnCountFnWithTwoElements() throws Exception {
+    PCollectionView<Long> elementCountView =
+        PCollectionViews.singletonView(
+            TestPipeline.create(), WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+    KeyBasedOnCountFn<String> fn = new KeyBasedOnCountFn<>(elementCountView, 0);
+    DoFnTester<String, KV<Integer, String>> fnTester = DoFnTester.of(fn);
+
+    fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, 2L);
+
+    List<KV<Integer, String>> outputs = fnTester.processBundle("foo", "bar");
+    assertThat(
+        outputs,
+        anyOf(
+            containsInAnyOrder(KV.of(0, "foo"), KV.of(1, "bar")),
+            containsInAnyOrder(KV.of(1, "foo"), KV.of(0, "bar"))));
+  }
+
+  @Test
+  public void keyBasedOnCountFnFewElementsThreeShards() throws Exception {
+    PCollectionView<Long> elementCountView =
+        PCollectionViews.singletonView(
+            TestPipeline.create(), WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+    KeyBasedOnCountFn<String> fn = new KeyBasedOnCountFn<>(elementCountView, 0);
+    DoFnTester<String, KV<Integer, String>> fnTester = DoFnTester.of(fn);
+
+    fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, 100L);
+
+    List<KV<Integer, String>> outputs =
+        fnTester.processBundle("foo", "bar", "baz", "foobar", "foobaz", "barbaz");
+    assertThat(
+        Iterables.transform(
+            outputs,
+            new Function<KV<Integer, String>, Integer>() {
+              @Override
+              public Integer apply(KV<Integer, String> input) {
+                return input.getKey();
+              }
+            }),
+        containsInAnyOrder(0, 0, 1, 1, 2, 2));
+  }
+
+  @Test
+  public void keyBasedOnCountFnManyElements() throws Exception {
+    PCollectionView<Long> elementCountView =
+        PCollectionViews.singletonView(
+            TestPipeline.create(), WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+    KeyBasedOnCountFn<String> fn = new KeyBasedOnCountFn<>(elementCountView, 0);
+    DoFnTester<String, KV<Integer, String>> fnTester = DoFnTester.of(fn);
+
+    double count = Math.pow(10, 10);
+    fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, (long) count);
+
+    List<String> strings = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      strings.add(Long.toHexString(ThreadLocalRandom.current().nextLong()));
+    }
+    List<KV<Integer, String>> kvs = fnTester.processBundle(strings);
+    long maxKey = -1L;
+    for (KV<Integer, String> kv : kvs) {
+      maxKey = Math.max(maxKey, kv.getKey());
+    }
+    assertThat(maxKey, equalTo(9L));
+  }
+
+  @Test
+  public void keyBasedOnCountFnFewElementsExtraShards() throws Exception {
+    PCollectionView<Long> elementCountView =
+        PCollectionViews.singletonView(
+            TestPipeline.create(), WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+    KeyBasedOnCountFn<String> fn = new KeyBasedOnCountFn<>(elementCountView, 10);
+    DoFnTester<String, KV<Integer, String>> fnTester = DoFnTester.of(fn);
+
+    long countValue = (long) KeyBasedOnCountFn.MIN_SHARDS_FOR_LOG + 3;
+    fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, countValue);
+
+    List<String> strings = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      strings.add(Long.toHexString(ThreadLocalRandom.current().nextLong()));
+    }
+    List<KV<Integer, String>> kvs = fnTester.processBundle(strings);
+    long maxKey = -1L;
+    for (KV<Integer, String> kv : kvs) {
+      maxKey = Math.max(maxKey, kv.getKey());
+    }
+    // 0 to n-1 shard ids.
+    assertThat(maxKey, equalTo(countValue - 1));
+  }
+
+  @Test
+  public void keyBasedOnCountFnManyElementsExtraShards() throws Exception {
+    PCollectionView<Long> elementCountView =
+        PCollectionViews.singletonView(
+            TestPipeline.create(), WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+    KeyBasedOnCountFn<String> fn = new KeyBasedOnCountFn<>(elementCountView, 3);
+    DoFnTester<String, KV<Integer, String>> fnTester = DoFnTester.of(fn);
+
+    double count = Math.pow(10, 10);
+    fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, (long) count);
+
+    List<String> strings = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      strings.add(Long.toHexString(ThreadLocalRandom.current().nextLong()));
+    }
+    List<KV<Integer, String>> kvs = fnTester.processBundle(strings);
+    long maxKey = -1L;
+    for (KV<Integer, String> kv : kvs) {
+      maxKey = Math.max(maxKey, kv.getKey());
+    }
+    assertThat(maxKey, equalTo(12L));
+  }
+
+  private static class TestSink extends Sink<Object> {
+    @Override
+    public void validate(PipelineOptions options) {}
+
+    @Override
+    public WriteOperation<Object, ?> createWriteOperation(PipelineOptions options) {
+      throw new IllegalArgumentException("Should not be used");
+    }
+  }
+}

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/TransformTranslatorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/TransformTranslatorTest.java
@@ -32,23 +32,27 @@ import org.apache.beam.sdk.values.PCollection;
 
 import com.google.common.base.Charsets;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * A test for the transforms registered in TransformTranslator.
- * Builds a regular Dataflow pipeline with each of the mapped
+ * Builds a regular Beam pipeline with each of the mapped
  * transforms, and makes sure that they work when the pipeline is
  * executed in Spark.
  */
 public class TransformTranslatorTest {
+  private static final Logger LOG = LoggerFactory.getLogger(TransformTranslatorTest.class);
   @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
   /**
@@ -61,11 +65,13 @@ public class TransformTranslatorTest {
     String directOut = runPipeline(DirectRunner.class);
     String sparkOut = runPipeline(SparkRunner.class);
 
+    File directOutFile = new File(directOut);
     List<String> directOutput =
-        Files.readAllLines(Paths.get(directOut + "-00000-of-00001"), Charsets.UTF_8);
+            readFromOutputFiles(directOutFile.getParentFile(), directOutFile.getName());
 
+    File sparkOutFile = new File(sparkOut);
     List<String> sparkOutput =
-        Files.readAllLines(Paths.get(sparkOut + "-00000-of-00001"), Charsets.UTF_8);
+            readFromOutputFiles(sparkOutFile.getParentFile(), sparkOutFile.getName());
 
     // sort output to get a stable result (PCollections are not ordered)
     assertThat(sparkOutput, containsInAnyOrder(directOutput.toArray()));
@@ -80,5 +86,21 @@ public class TransformTranslatorTest {
     lines.apply(TextIO.Write.to(outFile.getAbsolutePath()));
     p.run();
     return outFile.getAbsolutePath();
+  }
+
+  private List<String> readFromOutputFiles(File parent, String outPattern) throws IOException {
+    // example pattern: outprefix-00000-of-00001
+    Pattern pattern = Pattern.compile(String.format("%s-[0-9]{5}-of-[0-9]{5}", outPattern));
+    List<String> lines = new ArrayList<>();
+    if (parent.exists() && parent.isDirectory()) {
+      //noinspection ConstantConditions
+      for (File f : parent.listFiles()) {
+        if (pattern.matcher(f.getName()).matches()) {
+          LOG.info("For " + outPattern + " reading file " + f.getName());
+          lines.addAll(FileUtils.readLines(f, Charsets.UTF_8));
+        }
+      }
+    }
+    return lines;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FileIOChannelFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FileIOChannelFactory.java
@@ -108,7 +108,8 @@ public class FileIOChannelFactory implements IOChannelFactory {
     File file = new File(spec);
     if (file.getAbsoluteFile().getParentFile() != null
         && !file.getAbsoluteFile().getParentFile().exists()
-        && !file.getAbsoluteFile().getParentFile().mkdirs()) {
+        && !file.getAbsoluteFile().getParentFile().mkdirs()
+        && !file.getAbsoluteFile().getParentFile().exists()) {
       throw new IOException("Unable to create parent directories for '" + spec + "'");
     }
     return Channels.newChannel(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -19,10 +19,10 @@ package org.apache.beam.sdk.io;
 
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.includesDisplayDataFrom;
-
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -146,7 +146,7 @@ public class WriteTest {
   public void testEmptyWrite() {
     runWrite(Collections.<String>emptyList(), IDENTITY_MAP);
     // Note we did not request a sharded write, so runWrite will not validate the number of shards.
-    assertEquals(1, numShards.intValue());
+    assertThat(numShards.intValue(), greaterThan(0));
   }
 
   /**


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Add a Write Override Factory that limits the number of shards is
unspecified. This ensures that we will not write an output file per-key
due to bundling.