### PR TITLE
[BEAM-339] Archetype project version shouldn't be coupled to Beam version

### DIFF
--- a/sdks/java/maven-archetypes/examples/src/test/resources/projects/basic/archetype.properties
+++ b/sdks/java/maven-archetypes/examples/src/test/resources/projects/basic/archetype.properties
@@ -15,7 +15,7 @@
 #    limitations under the License.
 #
 package=it.pkg
-version=0.1-SNAPSHOT
+version=0.1
 groupId=archetype.it
 artifactId=basic
 targetPlatform=1.7

--- a/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/archetype.properties
+++ b/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/archetype.properties
@@ -15,7 +15,7 @@
 #    limitations under the License.
 #
 package=it.pkg
-version=0.1-SNAPSHOT
+version=0.1
 groupId=archetype.it
 artifactId=basic
 targetPlatform=1.7

--- a/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>archetype.it</groupId>
   <artifactId>basic</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>0.1</version>
 
   <build>
    <plugins>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Follow-up from [a previous archetype PR](https://github.com/apache/incubator-beam/pull/444/files/ba55042275bd9b525ee8716e4e1007b7924a647f#r66819150), the maven artifact version for the generated project should not be tied to the version of Beam. The generated module is a new user project, so the version should represent "initial version", i.e. 0.1.

This PR drops the -SNAPSHOT suffix from the version and fixes the version to 0.1 in our tests.