### PR TITLE
Shade everything but a whitelist in core Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
     <protobuf.version>3.0.0-beta-1</protobuf.version>
     <pubsub.version>v1-rev10-1.22.0</pubsub.version>
     <slf4j.version>1.7.14</slf4j.version>
+    <snappy.version>1.1.2.6</snappy.version>
     <stax2.version>3.1.4</stax2.version>
     <storage.version>v1-rev71-1.22.0</storage.version>
     <woodstox.version>4.4.1</woodstox.version>
@@ -616,6 +617,12 @@
         <artifactId>hamcrest-all</artifactId>
         <version>${hamcrest.version}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
       </dependency>
 
       <dependency>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -119,10 +119,6 @@
               <location>${basedir}/../../sdks/java/javadoc/hamcrest-docs</location>
             </offlineLink>
             <offlineLink>
-              <url>http://fasterxml.github.io/jackson-annotations/javadoc/2.7/</url>
-              <location>${basedir}/../../sdks/java/javadoc/jackson-annotations-docs</location>
-            </offlineLink>
-            <offlineLink>
               <url>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</url>
               <location>${basedir}/../../sdks/java/javadoc/jackson-databind-docs</location>
             </offlineLink>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -79,10 +79,6 @@
                 <location>${basedir}/../javadoc/bq-docs</location>
               </offlineLink>
               <offlineLink>
-                <url>https://cloud.google.com/datastore/docs/apis/javadoc/</url>
-                <location>${basedir}/../javadoc/datastore-docs</location>
-              </offlineLink>
-              <offlineLink>
                 <url>http://docs.guava-libraries.googlecode.com/git-history/release19/javadoc/</url>
                 <location>${basedir}/../javadoc/guava-docs</location>
               </offlineLink>
@@ -204,12 +200,9 @@
                   <exclude>com.google.api-client:google-api-client</exclude>
                   <exclude>com.google.apis:google-api-services-bigquery</exclude>
                   <exclude>com.google.apis:google-api-services-dataflow</exclude>
-                  <exclude>com.google.apis:google-api-services-datastore-protobuf</exclude>
                   <exclude>com.google.apis:google-api-services-pubsub</exclude>
                   <exclude>com.google.apis:google-api-services-storage</exclude>
                   <exclude>com.google.auto.service:auto-service</exclude>
-                  <exclude>com.google.cloud.bigtable:bigtable-client-core</exclude>
-                  <exclude>com.google.cloud.bigtable:bigtable-protos</exclude>
                   <exclude>com.google.code.findbugs:jsr305</exclude>
                   <exclude>com.google.http-client:google-http-client</exclude>
                   <exclude>com.google.http-client:google-http-client-jackson2</exclude>
@@ -258,11 +251,9 @@
                     <exclude>com.google.api.client.**</exclude>
                     <exclude>com.google.api.services.bigquery.**</exclude>
                     <exclude>com.google.api.services.dataflow.**</exclude>
-                    <exclude>com.google.api.services.datastore.**</exclude>
                     <exclude>com.google.api.services.pubsub.**</exclude>
                     <exclude>com.google.api.services.storage.**</exclude>
                     <exclude>com.google.cloud.dataflow.**</exclude>
-                    <exclude>com.google.bigtable.**</exclude>
                     <exclude>com.google.protobuf.**</exclude>
                     <exclude>com.fasterxml.jackson.**</exclude>
                   </excludes>
@@ -319,12 +310,9 @@
                   <include>com.google.api-client:google-api-client</include>
                   <include>com.google.apis:google-api-services-bigquery</include>
                   <include>com.google.apis:google-api-services-dataflow</include>
-                  <include>com.google.apis:google-api-services-datastore-protobuf</include>
                   <include>com.google.apis:google-api-services-pubsub</include>
                   <include>com.google.apis:google-api-services-storage</include>
                   <include>com.google.auto.service:auto-service</include>
-                  <include>com.google.cloud.bigtable:bigtable-client-core</include>
-                  <include>com.google.cloud.bigtable:bigtable-protos</include>
                   <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.http-client:google-http-client</include>
                   <include>com.google.http-client:google-http-client-jackson2</include>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -163,8 +163,31 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+
+        <!--
+        This configuration bundles the SDK with all of its
+        dependencies, as follows:
+
+         - If a dependency makes up part of the SDK's API surface (for
+           examples, joda-time and BigQuery's TableRow) then the
+           class is included in the bundled SDK.
+         - If a dependency is merely used by the SDK as an implementation
+           detail, the class is included in a repackaged form so it will
+           never cause a conflict with any other user or library's
+           dependencies.
+
+        In the first execution, all of the repackaged dependencies are
+        bundled in a minimized jar. Because they are an implementation
+        detail, this should not be observable.
+
+        In the second execution, all of the dependencies that are part of
+        the SDK's API surface are included fully. This ensures that if any
+        class overrides something on the class path, all of the other classes
+        from that version of its library are also overridden.
+        -->
         <executions>
-          <!-- In the first phase, we pick dependencies and relocate them. -->
+
+          <!-- Bundle all repackaged implementation detail dependencies -->
           <execution>
             <id>bundle-and-repackage</id>
             <phase>package</phase>
@@ -174,9 +197,33 @@
             <configuration>
               <shadeTestJar>true</shadeTestJar>
               <artifactSet>
-                <includes>
-                  <include>com.google.guava:guava</include>
-                </includes>
+                <!-- This excludes all API surface libraries from repackaging.
+                     The list should be complete, even if some of the entries
+                     do not match a relocation pattern. -->
+                <excludes>
+                  <exclude>com.google.api-client:google-api-client</exclude>
+                  <exclude>com.google.apis:google-api-services-bigquery</exclude>
+                  <exclude>com.google.apis:google-api-services-dataflow</exclude>
+                  <exclude>com.google.apis:google-api-services-datastore-protobuf</exclude>
+                  <exclude>com.google.apis:google-api-services-pubsub</exclude>
+                  <exclude>com.google.apis:google-api-services-storage</exclude>
+                  <exclude>com.google.auto.service:auto-service</exclude>
+                  <exclude>com.google.cloud.bigtable:bigtable-client-core</exclude>
+                  <exclude>com.google.cloud.bigtable:bigtable-protos</exclude>
+                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                  <exclude>com.google.http-client:google-http-client</exclude>
+                  <exclude>com.google.http-client:google-http-client-jackson2</exclude>
+                  <exclude>com.google.oauth-client:google-oauth-client</exclude>
+                  <exclude>com.google.protobuf:protobuf-java</exclude>
+                  <exclude>com.fasterxml.jackson.core:jackson-annotation</exclude>
+                  <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+                  <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+                  <exclude>joda-time:joda-time</exclude>
+                  <exclude>junit:junit</exclude>
+                  <exclude>org.apache.avro:avro</exclude>
+                  <exclude>org.hamcrest:hamcrest-all</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                </excludes>
               </artifactSet>
               <filters>
                 <filter>
@@ -188,23 +235,70 @@
                   </excludes>
                 </filter>
               </filters>
+              <!--
+              What we really want is to repackage "" to
+              "org.apache.beam.sdk.repackaged" but the
+              implementation of the shade plugin the relocates
+              non-class files as well (and fails to join directory
+              names witha "/").
+
+              Instead, we have a separate toplevel relocation for
+              every root package prefix in our dependencies.
+
+              Additionally, inclusion/exclusion in the jar is independent of
+              the rewriting of other class files, so we must still exclude
+              the packages from all of the API surface dependencies here.
+              -->
               <relocations>
-                <!-- TODO: Once ready, change the following pattern to 'com' only, 
-                  exclude 'org.apache.beam.**', and remove the second relocation. -->
                 <relocation>
-                  <pattern>com.google.common</pattern>
-                  <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
+                  <pattern>com.</pattern>
+                  <shadedPattern>org.apache.beam.sdk.repackaged.com.</shadedPattern>
+                  <excludes>
+                    <exclude>com.google.api.client.**</exclude>
+                    <exclude>com.google.api.services.bigquery.**</exclude>
+                    <exclude>com.google.api.services.dataflow.**</exclude>
+                    <exclude>com.google.api.services.datastore.**</exclude>
+                    <exclude>com.google.api.services.pubsub.**</exclude>
+                    <exclude>com.google.api.services.storage.**</exclude>
+                    <exclude>com.google.cloud.dataflow.**</exclude>
+                    <exclude>com.google.bigtable.**</exclude>
+                    <exclude>com.google.protobuf.**</exclude>
+                    <exclude>com.fasterxml.jackson.**</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.thirdparty</pattern>
-                  <shadedPattern>org.apache.beam.sdk.repackaged.com.google.thirdparty</shadedPattern>
+                  <pattern>io.</pattern>
+                  <shadedPattern>org.apache.beam.sdk.repackaged.io.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>okio.</pattern>
+                  <shadedPattern>org.apache.beam.sdk.repackaged.okio.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.</pattern>
+                  <shadedPattern>org.apache.beam.sdk.repackaged.org.</shadedPattern>
+                  <excludes>
+                    <exclude>org.apache.avro.**</exclude>
+                    <exclude>org.apache.beam.**</exclude>
+                    <exclude>org.hamcrest.**</exclude>
+                    <exclude>org.joda.time.**</exclude>
+                    <exclude>org.junit.**</exclude>
+                    <exclude>org.slf4j.**</exclude>
+                    <exclude>org.w3c.dom.**</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>javax.</pattern>
+                  <shadedPattern>org.apache.beam.sdk.repackaged.javax.</shadedPattern>
+                  <excludes>
+                    <exclude>javax.annotion</exclude>
+                  </excludes>
                 </relocation>
               </relocations>
             </configuration>
           </execution>
 
-          <!-- In the second phase, we pick remaining dependencies and bundle them 
-            without repackaging. -->
+          <!-- Bundle all remaining dependencies without repackaging -->
           <execution>
             <id>bundle-rest-without-repackaging</id>
             <phase>package</phase>
@@ -215,9 +309,32 @@
               <shadeTestJar>true</shadeTestJar>
               <finalName>${project.artifactId}-bundled-${project.version}</finalName>
               <artifactSet>
-                <excludes>
-                  <exclude>com.google.guava:guava</exclude>
-                </excludes>
+                <!-- This includes all API surface libraries, which were
+                     excluded from repackaging. The list should be complete,
+                     identical to the exclusions from the prior execution.
+                -->
+                <includes>
+                  <include>com.google.api-client:google-api-client</include>
+                  <include>com.google.apis:google-api-services-bigquery</include>
+                  <include>com.google.apis:google-api-services-dataflow</include>
+                  <include>com.google.apis:google-api-services-datastore-protobuf</include>
+                  <include>com.google.apis:google-api-services-pubsub</include>
+                  <include>com.google.apis:google-api-services-storage</include>
+                  <include>com.google.auto.service:auto-service</include>
+                  <include>com.google.cloud.bigtable:bigtable-client-core</include>
+                  <include>com.google.cloud.bigtable:bigtable-protos</include>
+                  <include>com.google.code.findbugs:jsr305</include>
+                  <include>com.google.http-client:google-http-client</include>
+                  <include>com.google.http-client:google-http-client-jackson2</include>
+                  <include>com.google.oauth-client:google-oauth-client</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                  <include>com.fasterxml.jackson.core:jackson-annotation</include>
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  <include>joda-time:joda-time</include>
+                  <include>org.apache.avro:avro</include>
+                  <include>org.slf4j:slf4j-api</include>
+                </includes>
               </artifactSet>
               <filters>
                 <filter>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -223,6 +223,7 @@
                   <exclude>org.apache.avro:avro</exclude>
                   <exclude>org.hamcrest:hamcrest-all</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
+                  <exclude>org.xerial:snappy-java</exclude>
                 </excludes>
               </artifactSet>
               <filters>
@@ -285,6 +286,7 @@
                     <exclude>org.junit.**</exclude>
                     <exclude>org.slf4j.**</exclude>
                     <exclude>org.w3c.dom.**</exclude>
+                    <exclude>org.xerial.snappy.**</exclude>
                   </excludes>
                 </relocation>
                 <relocation>
@@ -334,6 +336,7 @@
                   <include>joda-time:joda-time</include>
                   <include>org.apache.avro:avro</include>
                   <include>org.slf4j:slf4j-api</include>
+                  <include>org.xerial:snappy-java</include>
                 </includes>
               </artifactSet>
               <filters>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -577,7 +577,6 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.2.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).

---

Some of our dependencies are part of our API surface and thus must be public and retain their original names; they are channels of interchange between the SDK and its users/peer libraries. All of the rest are implementation details and it should be essentially unobservable that they are in use.

Previously, we selected a few of the most problematic private dependencies to shade, which got the job done. This PR changes the paradigm to defaulting to shading all dependencies unless we explicitly declare that they are part of the public API surface.

Due to the design of jars/maven/shading, the whitelisted artifacts that are listed twice, and namespace exclusions are separate, too (the improvement here might be if shade plugin scraped the jars, which would in turn be easier if split packages weren't a thing).