### PR TITLE
[BEAM-439] Remove optional args from start/finish bundle methods

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -62,13 +62,13 @@ class DoFnRunner(object):
       class CurriedFn(core.DoFn):
 
         def start_bundle(self, context):
-          return fn.start_bundle(context, *args, **kwargs)
+          return fn.start_bundle(context)
 
         def process(self, context):
           return fn.process(context, *args, **kwargs)
 
         def finish_bundle(self, context):
-          return fn.finish_bundle(context, *args, **kwargs)
+          return fn.finish_bundle(context)
       self.dofn = CurriedFn()
     self.window_fn = windowing.windowfn
     self.context = context

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -51,8 +51,13 @@ K = typehints.TypeVariable('K')
 V = typehints.TypeVariable('V')
 
 
-class DoFnProcessContext(object):
-  """A processing context passed to DoFn methods during execution.
+class DoFnContext(object):
+  """A context available to all methods of DoFn instance."""
+  pass
+
+
+class DoFnProcessContext(DoFnContext):
+  """A processing context passed to DoFn process() during execution.
 
   Most importantly, a DoFn.process method will access context.element
   to get the element it is supposed to process.
@@ -132,7 +137,7 @@ class DoFn(WithTypeHints):
     return self._strip_output_annotations(
         trivial_inference.infer_return_type(self.process, [input_type]))
 
-  def start_bundle(self, context, *args, **kwargs):
+  def start_bundle(self, context):
     """Called before a bundle of elements is processed on a worker.
 
     Elements to be processed are split into bundles and distributed
@@ -140,20 +145,15 @@ class DoFn(WithTypeHints):
     of its bundle, it calls this method.
 
     Args:
-      context: a DoFnProcessContext object
-      *args: side inputs
-      **kwargs: keyword side inputs
-
+      context: a DoFnContext object
     """
     pass
 
-  def finish_bundle(self, context, *args, **kwargs):
+  def finish_bundle(self, context):
     """Called after a bundle of elements is processed on a worker.
 
     Args:
-      context: a DoFnProcessContext object
-      *args: side inputs
-      **kwargs: keyword side inputs
+      context: a DoFnContext object
     """
     pass
 

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -54,13 +54,13 @@ class TypeCheckWrapperDoFn(DoFn):
     # TODO(robertwb): Multi-output.
     self._output_type_hint = type_hints.simple_output_type(label)
 
-  def start_bundle(self, context, *args, **kwargs):
+  def start_bundle(self, context):
     return self._type_check_result(
-        self._dofn.start_bundle(context, *args, **kwargs))
+        self._dofn.start_bundle(context))
 
-  def finish_bundle(self, context, *args, **kwargs):
+  def finish_bundle(self, context):
     return self._type_check_result(
-        self._dofn.finish_bundle(context, *args, **kwargs))
+        self._dofn.finish_bundle(context))
 
   def process(self, context, *args, **kwargs):
     if self._input_hints:
@@ -139,11 +139,11 @@ class OutputCheckWrapperDoFn(DoFn):
     else:
       return self._check_type(result)
 
-  def start_bundle(self, context, *args, **kwargs):
-    return self.run(self.dofn.start_bundle, context, args, kwargs)
+  def start_bundle(self, context):
+    return self.run(self.dofn.start_bundle, context, [], {})
 
-  def finish_bundle(self, context, *args, **kwargs):
-    return self.run(self.dofn.finish_bundle, context, args, kwargs)
+  def finish_bundle(self, context):
+    return self.run(self.dofn.finish_bundle, context, [], {})
 
   def process(self, context, *args, **kwargs):
     return self.run(self.dofn.process, context, args, kwargs)


### PR DESCRIPTION
@robertwb can you please take a look? 
(take II -- I abandoned previous PR due to bad merge on my part) 

Technically we do not want to allow deferred side inputs but it is much simple conceptually to remove
extra arguments altogether.