### PR TITLE
Clean up Aggregator javadoc

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Aggregator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Aggregator.java
@@ -23,7 +23,7 @@ import org.apache.beam.sdk.transforms.Combine.CombineFn;
  * An {@code Aggregator<InputT>} enables monitoring of values of type {@code InputT},
  * to be combined across all bundles.
  *
- * <p>Aggregators are created by calling {@link DoFn#createAggregator},
+ * <p>Aggregators are created by calling {@link DoFn#createAggregator DoFn.createAggregator()},
  * typically from the {@link DoFn} constructor. Elements can be added to the
  * {@code Aggregator} by calling {@link Aggregator#addValue}.
  *


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
The [current javadoc for `Aggregator`](http://beam.incubator.apache.org/javadoc/0.1.0-incubating/org/apache/beam/sdk/transforms/Aggregator.html) is difficult to read:

> Aggregators are created by calling `DoFn.createAggregator(java.lang.String, org.apache.beam.sdk.transforms.Combine.CombineFn<? super AggInputT, ?, AggOutputT>)`, typically from the `DoFn` constructor. Elements can be added to the Aggregator by calling `addValue(InputT)`.

This simply takes the function parameters out of `createAggregator`:

> Aggregators are created by calling `DoFn.createAggregator()`, typically from the `DoFn` constructor. Elements can be added to the Aggregator by calling `addValue(InputT)`.
