### PR TITLE
[BEAM-468] NullableCoder should not ask valueCoder isRegisterByteSizeObserverCheap when value is null

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/NullableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/NullableCoder.java
@@ -175,6 +175,9 @@ public class NullableCoder<T> extends StandardCoder<T> {
    */
   @Override
   public boolean isRegisterByteSizeObserverCheap(@Nullable T value, Context context) {
+    if (value == null) {
+      return true;
+    }
     return valueCoder.isRegisterByteSizeObserverCheap(value, context.nested());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/NullableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/NullableCoderTest.java
@@ -90,29 +90,33 @@ public class NullableCoderTest {
 
   @Test
   public void testWireFormatEncode() throws Exception {
-      CoderProperties.coderEncodesBase64(TEST_CODER, TEST_VALUES, TEST_ENCODINGS);
+    CoderProperties.coderEncodesBase64(TEST_CODER, TEST_VALUES, TEST_ENCODINGS);
   }
 
   @Test
   public void testEncodedSize() throws Exception {
-      NullableCoder<Double> coder = NullableCoder.of(DoubleCoder.of());
-      assertEquals(1, coder.getEncodedElementByteSize(null, Coder.Context.OUTER));
-      assertEquals(9, coder.getEncodedElementByteSize(5.0, Coder.Context.OUTER));
+    NullableCoder<Double> coder = NullableCoder.of(DoubleCoder.of());
+    assertEquals(1, coder.getEncodedElementByteSize(null, Coder.Context.OUTER));
+    assertEquals(9, coder.getEncodedElementByteSize(5.0, Coder.Context.OUTER));
   }
 
   @Test
   public void testObserverIsCheap() throws Exception {
-      NullableCoder<Double> coder = NullableCoder.of(DoubleCoder.of());
-      assertTrue(coder.isRegisterByteSizeObserverCheap(null, Coder.Context.OUTER));
-      assertTrue(coder.isRegisterByteSizeObserverCheap(5.0, Coder.Context.OUTER));
+    NullableCoder<Double> coder = NullableCoder.of(DoubleCoder.of());
+    assertTrue(coder.isRegisterByteSizeObserverCheap(5.0, Coder.Context.OUTER));
   }
 
   @Test
   public void testObserverIsNotCheap() throws Exception {
-      NullableCoder<List<String>> coder = NullableCoder.of(ListCoder.of(StringUtf8Coder.of()));
-      assertFalse(coder.isRegisterByteSizeObserverCheap(null, Coder.Context.OUTER));
-      assertFalse(coder.isRegisterByteSizeObserverCheap(
-          ImmutableList.of("hi", "test"), Coder.Context.OUTER));
+    NullableCoder<List<String>> coder = NullableCoder.of(ListCoder.of(StringUtf8Coder.of()));
+    assertFalse(coder.isRegisterByteSizeObserverCheap(
+        ImmutableList.of("hi", "test"), Coder.Context.OUTER));
+  }
+
+  @Test
+  public void testObserverIsAlwaysCheapForNullValues() throws Exception {
+    NullableCoder<List<String>> coder = NullableCoder.of(ListCoder.of(StringUtf8Coder.of()));
+    assertTrue(coder.isRegisterByteSizeObserverCheap(null, Coder.Context.OUTER));
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---