### PR TITLE
Check type of coder for step feeding into GroupByKey in Dataflow runner

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -938,6 +938,12 @@ class Read(ptransform.PTransform):
   def get_windowing(self, unused_inputs):
     return core.Windowing(window.GlobalWindows())
 
+  def _infer_output_coder(self, input_type=None, input_coder=None):
+    if isinstance(self.source, BoundedSource):
+      return self.source.default_output_coder()
+    else:
+      return self.source.coder
+
 
 class Write(ptransform.PTransform):
   """A ``PTransform`` that writes to a sink.

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -24,6 +24,8 @@ caching and clearing values that are not tested elsewhere.
 
 import unittest
 
+import apache_beam as beam
+
 from apache_beam.internal import apiclient
 from apache_beam.pipeline import Pipeline
 from apache_beam.runners import create_runner
@@ -63,6 +65,25 @@ class RunnerTest(unittest.TestCase):
      | ptransform.GroupByKey('gbk'))
     remote_runner.job = apiclient.Job(p.options)
     super(DataflowPipelineRunner, remote_runner).run(p)
+
+  def test_no_group_by_key_directly_after_bigquery(self):
+    remote_runner = DataflowPipelineRunner()
+    p = Pipeline(remote_runner,
+                 options=PipelineOptions([
+                     '--dataflow_endpoint=ignored',
+                     '--job_name=test-job',
+                     '--project=test-project',
+                     '--staging_location=ignored',
+                     '--temp_location=/dev/null',
+                     '--no_auth=True'
+                 ]))
+    rows = p | beam.io.Read('read',
+                            beam.io.BigQuerySource('dataset.faketable'))
+    with self.assertRaises(ValueError,
+                           msg=('Coder for the GroupByKey operation'
+                                '"GroupByKey" is not a key-value coder: '
+                                'RowAsDictJsonCoder')):
+      unused_invalid = rows | beam.GroupByKey()
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -330,6 +330,27 @@ class PTransform(WithTypeHints):
                 input_or_output.title(), self.label, at_context, hint,
                 pvalue_.element_type))
 
+  def _infer_output_coder(self, input_type=None, input_coder=None):
+    """Returns the output coder to use for output of this transform.
+
+    Note: this API is experimental and is subject to change; please do not rely
+    on behavior induced by this method.
+
+    The Coder returned here should not be wrapped in a WindowedValueCoder
+    wrapper.
+
+    Args:
+      input_type: An instance of an allowed built-in type, a custom class, or a
+        typehints.TypeConstraint for the input type, or None if not available.
+      input_coder: Coder object for encoding input to this PTransform, or None
+        if not available.
+
+    Returns:
+      Coder object for encoding output of this PTransform or None if unknown.
+    """
+    # TODO(ccy): further refine this API.
+    return None
+
   def clone(self, new_label):
     """Clones the current transform instance under a new label."""
     transform = copy.copy(self)


### PR DESCRIPTION
This prevents submission of invalid pipelines, such as one where a GroupByKey operation happens directly after a BigQuery Read.