### PR TITLE
[BEAM-479] Execute RunnableOnService tests only when runner options provided

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -37,37 +37,6 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
   </properties>
 
-  <profiles>
-    <profile>
-      <!-- This profile disables automatic execution of RunnableOnService
-           integration tests on Google Cloud Dataflow service. However,
-           the tests will be executed if runnableOnServicePipelineOptions
-           is specified. -->
-      <id>disable-runnable-on-service-tests</id>
-      <activation>
-        <property>
-          <name>!runnableOnServicePipelineOptions</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>runnable-on-service-tests</id>
-                <configuration>
-                  <skip>true</skip>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <resources>
       <resource>

--- a/runners/pom.xml
+++ b/runners/pom.xml
@@ -39,34 +39,46 @@
     <module>spark</module>
   </modules>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>runnable-on-service-tests</id>
-              <phase>integration-test</phase>
-              <goals>
-                <goal>test</goal>
-              </goals>
-              <configuration>
-                <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
-                <parallel>all</parallel>
-                <threadCount>4</threadCount>
-                <dependenciesToScan>
-                  <dependency>org.apache.beam:beam-sdks-java-core</dependency>
-                </dependenciesToScan>
-                <systemPropertyVariables>
-                  <beamTestPipelineOptions>${runnableOnServicePipelineOptions}</beamTestPipelineOptions>
-                </systemPropertyVariables>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+  <profiles>
+
+    <!-- A profile that adds an integration test phase if and only if
+         the runnableOnServicePipelineOptions maven property has been set.
+         It should be set to a valid PipelineOptions JSON string. -->
+    <profile>
+      <id>runnable-on-service-tests</id>
+      <activation>
+        <property><name>runnableOnServicePipelineOptions</name></property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>runnable-on-service-tests</id>
+                  <phase>integration-test</phase>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
+                    <parallel>all</parallel>
+                    <threadCount>4</threadCount>
+                    <dependenciesToScan>
+                      <dependency>org.apache.beam:beam-sdks-java-core</dependency>
+                    </dependenciesToScan>
+                    <systemPropertyVariables>
+                      <beamTestPipelineOptions>${runnableOnServicePipelineOptions}</beamTestPipelineOptions>
+                    </systemPropertyVariables>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Previously, the situation was this:

 - All runners inherit a RunnableOnService integration-test
   execution referencing runnableOnServicePipelineOptions
   whether or not the variable was set. Basically an unbound
   variable reference.
 - The Dataflow runner had a profile disabling it if
   runnableOnServicePipelineOptions was not set.
 - Before they got configured, Flink and Spark had to
   do extra work to explicitly prevent the invalid
   configuration from being used.

After this change:

 - All runners inherit the same integration-test execution
   but only if the variable it requires is present.
 - Dataflow doesn't have any special profile.
 - Flink and Spark are unchanged, since they do set
   up the variable themselves. When they move to running
   only as postcommit, like Dataflow does, the hardcoding
   is expected to either move to a profile or move to
   the Jenkins invocation.

This addresses the particular aspect of [BEAM-479](https://issues.apache.org/jira/browse/BEAM-479) about getting a symmetrical config. The way that the configuration is set up is an annoying barrier to new runners (they have to suppress the thing) and also less readable than a straightforward profile.