### PR TITLE
[BEAM-479] Move local Flink integration tests to a profile

### DIFF
--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -42,6 +42,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <executions>
+
+              <!-- This configures the inherited runnable-on-service-tests
+                   execution to execute with a local Flink instance. -->
               <execution>
                 <id>runnable-on-service-tests</id>
                 <phase>integration-test</phase>
@@ -54,6 +57,32 @@
                       [
                         "--runner=TestFlinkRunner",
                         "--streaming=false"
+                      ]
+                    </beamTestPipelineOptions>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+
+              <!-- This second execution runs the tests in streaming mode -->
+              <execution>
+                <id>streaming-runnable-on-service-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                  <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
+                  <parallel>none</parallel>
+                  <failIfNoTests>true</failIfNoTests>
+                  <dependenciesToScan>
+                    <dependency>org.apache.beam:beam-sdks-java-core</dependency>
+                  </dependenciesToScan>
+                  <systemPropertyVariables>
+                    <beamTestPipelineOptions>
+                      [
+                        "--runner=TestFlinkRunner",
+                        "--streaming=true"
                       ]
                     </beamTestPipelineOptions>
                   </systemPropertyVariables>
@@ -225,34 +254,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>streaming-runnable-on-service-tests</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <skip>true</skip>
-              <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
-              <parallel>none</parallel>
-              <failIfNoTests>true</failIfNoTests>
-              <dependenciesToScan>
-                <dependency>org.apache.beam:beam-sdks-java-core</dependency>
-              </dependenciesToScan>
-              <systemPropertyVariables>
-                <beamTestPipelineOptions>
-                  [
-                    "--runner=TestFlinkRunner",
-                    "--streaming=true"
-                  ]
-                </beamTestPipelineOptions>
-              </systemPropertyVariables>
-              <excludes>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
     </plugins>

--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -32,6 +32,40 @@
 
   <packaging>jar</packaging>
 
+  <profiles>
+    <profile>
+      <id>local-runnable-on-service-tests</id>
+      <activation><activeByDefault>false</activeByDefault></activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>runnable-on-service-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <beamTestPipelineOptions>
+                      [
+                        "--runner=TestFlinkRunner",
+                        "--streaming=false"
+                      ]
+                    </beamTestPipelineOptions>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <dependencies>
     <!-- Flink dependencies -->
     <dependency>
@@ -192,29 +226,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
-          <execution>
-            <id>runnable-on-service-tests</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
-              <parallel>none</parallel>
-              <failIfNoTests>true</failIfNoTests>
-              <dependenciesToScan>
-                <dependency>org.apache.beam:beam-sdks-java-core</dependency>
-              </dependenciesToScan>
-              <systemPropertyVariables>
-                <beamTestPipelineOptions>
-                  [
-                    "--runner=TestFlinkRunner",
-                    "--streaming=false"
-                  ]
-                </beamTestPipelineOptions>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
           <execution>
             <id>streaming-runnable-on-service-tests</id>
             <phase>integration-test</phase>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

These tests are now activated by Jenkins in the intended way, the same as Dataflow, via `mvn -DrunnableOnServicePipelineOptions=...`

Since a local configuration is convenient and canonical, it is also valuable to have them in the config, so I have put them in a profile where the option string is hardcoded. This can be activated on the with `mvn -P local-runnable-on-service-tests`.