### PR TITLE
[BEAM-479] Name local Spark RunnableOnService profile more precisely

### DIFF
--- a/runners/spark/pom.xml
+++ b/runners/spark/pom.xml
@@ -55,7 +55,7 @@
     <profile>
       <!-- This profile adds execution of RunnableOnService integration tests 
            against a local Spark endpoint. -->
-      <id>runnable-on-service-tests</id>
+      <id>local-runnable-on-service-tests</id>
       <activation><activeByDefault>false</activeByDefault></activation>
       <build>
         <pluginManagement>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Settling on the name `local-runnable-on-service-tests` for all profiles with a local endpoint. That way, this profile plus the desired module will suffice to run against a local endpoint if possible.