### PR TITLE
Make save_main_session optional

### DIFF
--- a/sdks/python/apache_beam/examples/complete/autocomplete.py
+++ b/sdks/python/apache_beam/examples/complete/autocomplete.py
@@ -36,6 +36,9 @@ def run(argv=None):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -106,6 +106,9 @@ def run(argv=None):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
   (p  # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/examples/complete/tfidf.py
+++ b/sdks/python/apache_beam/examples/complete/tfidf.py
@@ -183,6 +183,9 @@ def run(argv=None):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
   # Read documents specified by the uris command line option.

--- a/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
+++ b/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
@@ -158,6 +158,9 @@ def run(argv=None):
                       default=0.1,
                       help='Fraction of entries used for session tracking')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_side_input.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_side_input.py
@@ -84,6 +84,10 @@ def run(argv=None):
   parser.add_argument('--num_groups')
 
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
+
   p = beam.Pipeline(argv=pipeline_args)
 
   group_ids = []

--- a/sdks/python/apache_beam/examples/cookbook/bigshuffle.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigshuffle.py
@@ -44,6 +44,9 @@ def run(argv=None):
   parser.add_argument('--checksum_output',
                       help='Checksum output file pattern.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/cookbook/coders.py
+++ b/sdks/python/apache_beam/examples/cookbook/coders.py
@@ -77,6 +77,9 @@ def run(argv=None):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
   (p  # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
@@ -85,6 +85,9 @@ def run(argv=sys.argv[1:]):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/cookbook/mergecontacts.py
+++ b/sdks/python/apache_beam/examples/cookbook/mergecontacts.py
@@ -60,6 +60,9 @@ def run(argv=None, assert_results=None):
                       required=True,
                       help='Output file for statistics about the input.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
+++ b/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
@@ -129,6 +129,9 @@ def run(argv=None):
                       required=True,
                       help='Output prefix for files to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -68,6 +68,9 @@ def run(argv=None):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging.py
@@ -115,6 +115,9 @@ def run(argv=None):
                       required=True,
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   p = beam.Pipeline(argv=pipeline_args)
 

--- a/sdks/python/apache_beam/examples/wordcount_minimal.py
+++ b/sdks/python/apache_beam/examples/wordcount_minimal.py
@@ -68,6 +68,9 @@ def run(argv=None):
                       default='gs://YOUR_OUTPUT_BUCKET/AND_OUTPUT_PREFIX',
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_args.append('--save-main-session')
 
   pipeline_args.extend([
       # CHANGE 2/5: (OPTIONAL) Change this to BlockingDataflowPipelineRunner to

--- a/sdks/python/apache_beam/utils/dependency_test.py
+++ b/sdks/python/apache_beam/utils/dependency_test.py
@@ -88,11 +88,8 @@ class SetupTest(unittest.TestCase):
     self.update_options(options)
 
     self.assertEqual(
-        [names.PICKLED_MAIN_SESSION_FILE],
+        [],
         dependency.stage_job_resources(options))
-    self.assertTrue(
-        os.path.isfile(
-            os.path.join(staging_dir, names.PICKLED_MAIN_SESSION_FILE)))
 
   def test_with_requirements_file(self):
     staging_dir = tempfile.mkdtemp()
@@ -106,7 +103,7 @@ class SetupTest(unittest.TestCase):
     self.create_temp_file(
         os.path.join(source_dir, dependency.REQUIREMENTS_FILE), 'nothing')
     self.assertEqual(
-        sorted([dependency.REQUIREMENTS_FILE, names.PICKLED_MAIN_SESSION_FILE,
+        sorted([dependency.REQUIREMENTS_FILE,
                 'abc.txt', 'def.txt']),
         sorted(dependency.stage_job_resources(
             options,
@@ -145,7 +142,7 @@ class SetupTest(unittest.TestCase):
     self.create_temp_file(
         os.path.join(source_dir, dependency.REQUIREMENTS_FILE), 'nothing')
     self.assertEqual(
-        sorted([dependency.REQUIREMENTS_FILE, names.PICKLED_MAIN_SESSION_FILE,
+        sorted([dependency.REQUIREMENTS_FILE,
                 'abc.txt', 'def.txt']),
         sorted(dependency.stage_job_resources(
             options,
@@ -169,8 +166,7 @@ class SetupTest(unittest.TestCase):
         source_dir, 'setup.py')
 
     self.assertEqual(
-        [dependency.WORKFLOW_TARBALL_FILE,
-         names.PICKLED_MAIN_SESSION_FILE],
+        [dependency.WORKFLOW_TARBALL_FILE],
         dependency.stage_job_resources(
             options,
             # We replace the build setup command because a realistic one would
@@ -265,8 +261,7 @@ class SetupTest(unittest.TestCase):
     options.view_as(SetupOptions).sdk_location = 'default'
 
     self.assertEqual(
-        [names.PICKLED_MAIN_SESSION_FILE,
-         names.DATAFLOW_SDK_TARBALL_FILE],
+        [names.DATAFLOW_SDK_TARBALL_FILE],
         dependency.stage_job_resources(
             options,
             file_copy=dependency._dependency_file_copy))
@@ -286,8 +281,7 @@ class SetupTest(unittest.TestCase):
     options.view_as(SetupOptions).sdk_location = sdk_location
 
     self.assertEqual(
-        [names.PICKLED_MAIN_SESSION_FILE,
-         names.DATAFLOW_SDK_TARBALL_FILE],
+        [names.DATAFLOW_SDK_TARBALL_FILE],
         dependency.stage_job_resources(options))
     tarball_path = os.path.join(
         staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)
@@ -321,8 +315,7 @@ class SetupTest(unittest.TestCase):
     options.view_as(SetupOptions).sdk_location = sdk_location
 
     self.assertEqual(
-        [names.PICKLED_MAIN_SESSION_FILE,
-         names.DATAFLOW_SDK_TARBALL_FILE],
+        [names.DATAFLOW_SDK_TARBALL_FILE],
         dependency.stage_job_resources(options))
 
   def test_with_extra_packages(self):
@@ -363,8 +356,7 @@ class SetupTest(unittest.TestCase):
 
     self.assertEqual(
         ['abc.tar.gz', 'xyz.tar.gz', 'xyz2.tar', 'gcs.tar.gz',
-         dependency.EXTRA_PACKAGES_FILE,
-         names.PICKLED_MAIN_SESSION_FILE],
+         dependency.EXTRA_PACKAGES_FILE],
         dependency.stage_job_resources(options))
     with open(os.path.join(staging_dir, dependency.EXTRA_PACKAGES_FILE)) as f:
       self.assertEqual(['abc.tar.gz\n', 'xyz.tar.gz\n', 'xyz2.tar\n',

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -412,7 +412,7 @@ class SetupOptions(PipelineOptions):
          'install the resulting package before running any custom code.'))
     parser.add_argument(
         '--save_main_session',
-        default=True,
+        default=False,
         action='store_true',
         help=
         ('Save the main session state so that pickled functions and classes '

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -15,11 +15,30 @@
 # limitations under the License.
 #
 
-"""Apache Beam SDK setup configuration."""
+"""Apache Beam SDK for Python setup file."""
 
 import os
 import platform
 import setuptools
+
+
+def get_version():
+  global_names = {}
+  execfile(os.path.normpath('./apache_beam/version.py'),
+           global_names)
+  return global_names['__version__']
+
+PACKAGE_NAME = 'apache-beam-sdk'
+PACKAGE_VERSION = get_version()
+PACKAGE_DESCRIPTION = 'Apache Beam SDK for Python'
+PACKAGE_URL = 'https://beam.incubator.apache.org'
+PACKAGE_DOWNLOAD_URL = 'TBD'
+PACKAGE_AUTHOR = 'Apache Software Foundation'
+PACKAGE_EMAIL = 'dev@beam.incubator.apache.org'
+PACKAGE_KEYWORDS = 'apache beam'
+PACKAGE_LONG_DESCRIPTION = '''
+TBD
+'''
 
 
 # Currently all compiled modules are optional  (for performance only).
@@ -34,27 +53,12 @@ else:
     cythonize = lambda *args, **kwargs: []
 
 
-def get_version():
-  global_names = {}
-  execfile(os.path.normpath('./apache_beam/version.py'),
-           global_names)
-  return global_names['__version__']
-
-
-# Configure the required packages and scripts to install.
 REQUIRED_PACKAGES = [
     'avro>=1.7.7',
     'dill>=0.2.5',
     'google-apitools>=0.5.2',
-    # TODO(silviuc): Reenable api client package dependencies when we can
-    # update the packages to the latest version without affecting previous
-    # SDK releases.
-    # 'google-apitools-bigquery-v2',
-    # 'google-apitools-dataflow-v1b3>=0.4.20160217',
-    # 'google-apitools-storage-v1',
     'httplib2>=0.8',
     'mock>=1.0.1',
-    'nose>=1.0',
     'oauth2client>=2.0.1',
     'protorpc>=0.9.1',
     'python-gflags>=2.0',
@@ -63,14 +67,16 @@ REQUIRED_PACKAGES = [
 
 
 setuptools.setup(
-    name='apache-beam-sdk',
-    version=get_version(),
-    description='Apache Beam SDK for Python',
-    long_description='',
-    url='https://beam.incubator.apache.org',
-    download_url='TBD',
-    author='Apache Software Foundation',
+    name=PACKAGE_NAME,
+    version=PACKAGE_VERSION,
+    description=PACKAGE_DESCRIPTION,
+    long_description=PACKAGE_LONG_DESCRIPTION,
+    url=PACKAGE_URL,
+    download_url=PACKAGE_DOWNLOAD_URL,
+    author=PACKAGE_AUTHOR,
+    author_email=PACKAGE_EMAIL,
     packages=setuptools.find_packages(),
+    package_data={'apache_beam': ['**/*.pyx', '**/*.pxd']},
     ext_modules=cythonize([
         '**/*.pyx',
         'apache_beam/coders/coder_impl.py',
@@ -79,8 +85,8 @@ setuptools.setup(
         'apache_beam/utils/counters.py',
         'apache_beam/utils/windowed_value.py',
     ]),
+    setup_requires=['nose>=1.0'],
     install_requires=REQUIRED_PACKAGES,
-    package_data={'': ['*.pyx', '*.pxd']},
     test_suite='nose.collector',
     zip_safe=False,
     # PyPI package information.
@@ -93,5 +99,5 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         ],
     license='Apache 2.0',
-    keywords='apache beam',
+    keywords=PACKAGE_KEYWORDS,
     )


### PR DESCRIPTION
This PR does 3 things:
1) make --save_main_session optional
2) Sets it to true in all examples that need it (e.g., wordcount needs it)
3) refactor setup.py to separate as much as possible setup logic from strings/versions.

