### PR TITLE
[BEAM-545] Promote JobName to PipelineOptions

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/common/ExampleBigQueryTableOptions.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/ExampleBigQueryTableOptions.java
@@ -49,8 +49,7 @@ public interface ExampleBigQueryTableOptions extends GcpOptions {
   static class BigQueryTableFactory implements DefaultValueFactory<String> {
     @Override
     public String create(PipelineOptions options) {
-      return options.as(ExampleOptions.class).getNormalizedUniqueName()
-          .replace('-', '_');
+      return options.getJobName().replace('-', '_');
     }
   }
 }

--- a/examples/java/src/main/java/org/apache/beam/examples/common/ExampleOptions.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/ExampleOptions.java
@@ -17,17 +17,9 @@
  */
 package org.apache.beam.examples.common;
 
-import com.google.common.base.MoreObjects;
-import java.util.concurrent.ThreadLocalRandom;
-import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
-import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 /**
  * Options that can be used to configure the Beam examples.
@@ -42,39 +34,4 @@ public interface ExampleOptions extends PipelineOptions {
   @Default.Integer(1)
   int getInjectorNumWorkers();
   void setInjectorNumWorkers(int numWorkers);
-
-  @Description("A normalized unique name that is used to name anything related to the pipeline."
-      + "It defaults to ApplicationName-UserName-Date-RandomInteger")
-  @Default.InstanceFactory(NormalizedUniqueNameFactory.class)
-  String getNormalizedUniqueName();
-  void setNormalizedUniqueName(String numWorkers);
-
-  /**
-   * Returns a normalized unique name constructed from {@link ApplicationNameOptions#getAppName()},
-   * the local system user name (if available), the current time, and a random integer.
-   *
-   * <p>The normalization makes sure that the name matches the pattern of
-   * [a-z]([-a-z0-9]*[a-z0-9])?.
-   */
-  public static class NormalizedUniqueNameFactory implements DefaultValueFactory<String> {
-    private static final DateTimeFormatter FORMATTER =
-        DateTimeFormat.forPattern("MMddHHmmss").withZone(DateTimeZone.UTC);
-
-    @Override
-    public String create(PipelineOptions options) {
-      String appName = options.as(ApplicationNameOptions.class).getAppName();
-      String normalizedAppName = appName == null || appName.length() == 0 ? "BeamApp"
-          : appName.toLowerCase()
-                   .replaceAll("[^a-z0-9]", "0")
-                   .replaceAll("^[^a-z]", "a");
-      String userName = MoreObjects.firstNonNull(System.getProperty("user.name"), "");
-      String normalizedUserName = userName.toLowerCase()
-                                          .replaceAll("[^a-z0-9]", "0");
-      String datePart = FORMATTER.print(DateTimeUtils.currentTimeMillis());
-
-      String randomPart = Integer.toHexString(ThreadLocalRandom.current().nextInt());
-      return String.format("%s-%s-%s-%s",
-          normalizedAppName, normalizedUserName, datePart, randomPart);
-    }
-  }
 }

--- a/examples/java/src/main/java/org/apache/beam/examples/common/ExamplePubsubTopicAndSubscriptionOptions.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/ExamplePubsubTopicAndSubscriptionOptions.java
@@ -39,7 +39,7 @@ public interface ExamplePubsubTopicAndSubscriptionOptions extends ExamplePubsubT
     @Override
     public String create(PipelineOptions options) {
       return "projects/" + options.as(GcpOptions.class).getProject()
-          + "/subscriptions/" + options.as(ExampleOptions.class).getNormalizedUniqueName();
+          + "/subscriptions/" + options.getJobName();
     }
   }
 }

--- a/examples/java/src/main/java/org/apache/beam/examples/common/ExamplePubsubTopicOptions.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/ExamplePubsubTopicOptions.java
@@ -39,7 +39,7 @@ public interface ExamplePubsubTopicOptions extends GcpOptions {
     @Override
     public String create(PipelineOptions options) {
       return "projects/" + options.as(GcpOptions.class).getProject()
-          + "/topics/" + options.as(ExampleOptions.class).getNormalizedUniqueName();
+          + "/topics/" + options.getJobName();
     }
   }
 }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -22,14 +22,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
-import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.StreamingOptions;
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 /**
  * Options which can be used to configure a Flink PipelineRunner.
@@ -48,15 +43,6 @@ public interface FlinkPipelineOptions extends PipelineOptions, ApplicationNameOp
   @JsonIgnore
   List<String> getFilesToStage();
   void setFilesToStage(List<String> value);
-
-  /**
-   * The job name is used to identify jobs running on a Flink cluster.
-   */
-  @Description("Flink job name, to uniquely identify active jobs. "
-      + "Defaults to using the ApplicationName-UserName-Date.")
-  @Default.InstanceFactory(JobNameFactory.class)
-  String getJobName();
-  void setJobName(String value);
 
   /**
    * The url of the Flink JobManager on which to execute pipelines. This can either be
@@ -93,24 +79,4 @@ public interface FlinkPipelineOptions extends PipelineOptions, ApplicationNameOp
   @Default.Long(-1L)
   Long getExecutionRetryDelay();
   void setExecutionRetryDelay(Long delay);
-
-
-  class JobNameFactory implements DefaultValueFactory<String> {
-    private static final DateTimeFormatter FORMATTER =
-        DateTimeFormat.forPattern("MMddHHmmss").withZone(DateTimeZone.UTC);
-
-    @Override
-    public String create(PipelineOptions options) {
-      String appName = options.as(ApplicationNameOptions.class).getAppName();
-      String normalizedAppName = appName == null || appName.length() == 0 ? "FlinkRunner"
-          : appName.toLowerCase()
-          .replaceAll("[^a-z0-9]", "0")
-          .replaceAll("^[^a-z]", "a");
-      String userName = System.getProperty("user.name", "");
-      String normalizedUserName = userName.toLowerCase()
-          .replaceAll("[^a-z0-9]", "0");
-      String datePart = FORMATTER.print(DateTimeUtils.currentTimeMillis());
-      return normalizedAppName + "-" + normalizedUserName + "-" + datePart;
-    }
-  }
 }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.dataflow.options;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
-import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
@@ -35,10 +34,6 @@ import org.apache.beam.sdk.options.PubsubOptions;
 import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.util.IOChannelUtils;
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 
 /**
  * Options that can be used to configure the {@link DataflowRunner}.
@@ -76,21 +71,6 @@ public interface DataflowPipelineOptions
   void setStagingLocation(String value);
 
   /**
-   * The Dataflow job name is used as an idempotence key within the Dataflow service.
-   * If there is an existing job that is currently active, another active job with the same
-   * name will not be able to be created. Defaults to using the ApplicationName-UserName-Date.
-   */
-  @Description("The Dataflow job name is used as an idempotence key within the Dataflow service. "
-      + "For each running job in the same GCP project, jobs with the same name cannot be created "
-      + "unless the new job is an explicit update of the previous one. Defaults to using "
-      + "ApplicationName-UserName-Date. The job name must match the regular expression "
-      + "'[a-z]([-a-z0-9]{0,38}[a-z0-9])?'. The runner will automatically truncate the name of the "
-      + "job and convert to lower case.")
-  @Default.InstanceFactory(JobNameFactory.class)
-  String getJobName();
-  void setJobName(String value);
-
-  /**
    * Whether to update the currently running pipeline with the same name as this one.
    */
   @Description(
@@ -98,34 +78,6 @@ public interface DataflowPipelineOptions
           + "this pipeline, preserving state.")
   boolean isUpdate();
   void setUpdate(boolean value);
-
-  /**
-   * Returns a normalized job name constructed from {@link ApplicationNameOptions#getAppName()}, the
-   * local system user name (if available), and the current time. The normalization makes sure that
-   * the job name matches the required pattern of [a-z]([-a-z0-9]*[a-z0-9])? and length limit of 40
-   * characters.
-   *
-   * <p>This job name factory is only able to generate one unique name per second per application
-   * and user combination.
-   */
-  public static class JobNameFactory implements DefaultValueFactory<String> {
-    private static final DateTimeFormatter FORMATTER =
-        DateTimeFormat.forPattern("MMddHHmmss").withZone(DateTimeZone.UTC);
-
-    @Override
-    public String create(PipelineOptions options) {
-      String appName = options.as(ApplicationNameOptions.class).getAppName();
-      String normalizedAppName = appName == null || appName.length() == 0 ? "dataflow"
-          : appName.toLowerCase()
-                   .replaceAll("[^a-z0-9]", "0")
-                   .replaceAll("^[^a-z]", "a");
-      String userName = MoreObjects.firstNonNull(System.getProperty("user.name"), "");
-      String normalizedUserName = userName.toLowerCase()
-                                          .replaceAll("[^a-z0-9]", "0");
-      String datePart = FORMATTER.print(DateTimeUtils.currentTimeMillis());
-      return normalizedAppName + "-" + normalizedUserName + "-" + datePart;
-    }
-  }
 
   /**
    * Returns a default staging location under {@link GcpOptions#getGcpTempLocation}.

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
@@ -53,7 +53,13 @@ public class DataflowPipelineOptionsTest {
     System.getProperties().remove("user.name");
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setAppName("TestApplication");
-    assertEquals("testapplication--1208190706", options.getJobName());
+    String[] nameComponents = options.getJobName().split("-");
+    assertEquals(4, nameComponents.length);
+    assertEquals("testapplication", nameComponents[0]);
+    assertEquals("", nameComponents[1]);
+    assertEquals("1208190706", nameComponents[2]);
+    // Verify the last component is a hex integer (unsigned).
+    Long.parseLong(nameComponents[3], 16);
     assertTrue(options.getJobName().length() <= 40);
   }
 
@@ -63,9 +69,13 @@ public class DataflowPipelineOptionsTest {
     System.getProperties().put("user.name", "abcdeabcdeabcdeabcdeabcdeabcde");
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setAppName("1234567890123456789012345678901234567890");
-    assertEquals(
-        "a234567890123456789012345678901234567890-abcdeabcdeabcdeabcdeabcdeabcde-1208190706",
-        options.getJobName());
+    String[] nameComponents = options.getJobName().split("-");
+    assertEquals(4, nameComponents.length);
+    assertEquals("a234567890123456789012345678901234567890", nameComponents[0]);
+    assertEquals("abcdeabcdeabcdeabcdeabcdeabcde", nameComponents[1]);
+    assertEquals("1208190706", nameComponents[2]);
+    // Verify the last component is a hex integer (unsigned).
+    Long.parseLong(nameComponents[3], 16);
   }
 
   @Test
@@ -74,7 +84,13 @@ public class DataflowPipelineOptionsTest {
     System.getProperties().put("user.name", "abcde");
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setAppName("1234567890123456789012345678901234567890");
-    assertEquals("a234567890123456789012345678901234567890-abcde-1208190706", options.getJobName());
+    String[] nameComponents = options.getJobName().split("-");
+    assertEquals(4, nameComponents.length);
+    assertEquals("a234567890123456789012345678901234567890", nameComponents[0]);
+    assertEquals("abcde", nameComponents[1]);
+    assertEquals("1208190706", nameComponents[2]);
+    // Verify the last component is a hex integer (unsigned).
+    Long.parseLong(nameComponents[3], 16);
   }
 
   @Test
@@ -83,7 +99,13 @@ public class DataflowPipelineOptionsTest {
     System.getProperties().put("user.name", "abcdeabcdeabcdeabcdeabcdeabcde");
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setAppName("1234567890");
-    assertEquals("a234567890-abcdeabcdeabcdeabcdeabcdeabcde-1208190706", options.getJobName());
+    String[] nameComponents = options.getJobName().split("-");
+    assertEquals(4, nameComponents.length);
+    assertEquals("a234567890", nameComponents[0]);
+    assertEquals("abcdeabcdeabcdeabcdeabcdeabcde", nameComponents[1]);
+    assertEquals("1208190706", nameComponents[2]);
+    // Verify the last component is a hex integer (unsigned).
+    Long.parseLong(nameComponents[3], 16);
   }
 
   @Test
@@ -92,7 +114,13 @@ public class DataflowPipelineOptionsTest {
     System.getProperties().put("user.name", "ði ıntəˈnæʃənəl ");
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setAppName("fəˈnɛtık əsoʊsiˈeıʃn");
-    assertEquals("f00n0t0k00so0si0e00n-0i00nt00n000n0l0-1208190706", options.getJobName());
+    String[] nameComponents = options.getJobName().split("-");
+    assertEquals(4, nameComponents.length);
+    assertEquals("f00n0t0k00so0si0e00n", nameComponents[0]);
+    assertEquals("0i00nt00n000n0l0", nameComponents[1]);
+    assertEquals("1208190706", nameComponents[2]);
+    // Verify the last component is a hex integer (unsigned).
+    Long.parseLong(nameComponents[3], 16);
   }
 
   @Test


### PR DESCRIPTION
This RP also fixed https://issues.apache.org/jira/browse/BEAM-483 "Generated job names easily collide"