### PR TITLE
Remove overrides of isStreaming() and getAppName() in SparkPipelineOptions

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineOptions.java
@@ -32,14 +32,5 @@ public interface SparkPipelineOptions extends PipelineOptions, StreamingOptions,
   @Description("The url of the spark master to connect to, (e.g. spark://host:port, local[4]).")
   @Default.String("local[1]")
   String getSparkMaster();
-
   void setSparkMaster(String master);
-
-  @Override
-  @Default.Boolean(false)
-  boolean isStreaming();
-
-  @Override
-  @Default.String("spark dataflow pipeline job")
-  String getAppName();
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkStreamingPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkStreamingPipelineOptions.java
@@ -28,10 +28,5 @@ public interface SparkStreamingPipelineOptions extends SparkPipelineOptions {
           + "execution is stopped")
   @Default.Long(-1)
   Long getTimeout();
-
   void setTimeout(Long batchInterval);
-
-  @Override
-  @Default.Boolean(true)
-  boolean isStreaming();
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkStreamingPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkStreamingPipelineOptions.java
@@ -34,8 +34,4 @@ public interface SparkStreamingPipelineOptions extends SparkPipelineOptions {
   @Override
   @Default.Boolean(true)
   boolean isStreaming();
-
-  @Override
-  @Default.String("spark streaming dataflow pipeline job")
-  String getAppName();
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/FlattenStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/FlattenStreamingTest.java
@@ -59,8 +59,8 @@ public class FlattenStreamingTest {
   public void testRun() throws Exception {
     SparkStreamingPipelineOptions options =
         PipelineOptionsFactory.as(SparkStreamingPipelineOptions.class);
-    options.setAppName(this.getClass().getSimpleName());
     options.setRunner(SparkRunner.class);
+    options.setStreaming(true);
     options.setTimeout(TEST_TIMEOUT_MSEC); // run for one interval
     Pipeline p = Pipeline.create(options);
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/KafkaStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/KafkaStreamingTest.java
@@ -91,8 +91,8 @@ public class KafkaStreamingTest {
     // test read from Kafka
     SparkStreamingPipelineOptions options =
         PipelineOptionsFactory.as(SparkStreamingPipelineOptions.class);
-    options.setAppName(this.getClass().getSimpleName());
     options.setRunner(SparkRunner.class);
+    options.setStreaming(true);
     options.setTimeout(TEST_TIMEOUT_MSEC); // run for one interval
     Pipeline p = Pipeline.create(options);
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/SimpleStreamingWordCountTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/SimpleStreamingWordCountTest.java
@@ -55,8 +55,8 @@ public class SimpleStreamingWordCountTest implements Serializable {
   public void testRun() throws Exception {
     SparkStreamingPipelineOptions options =
         PipelineOptionsFactory.as(SparkStreamingPipelineOptions.class);
-    options.setAppName(this.getClass().getSimpleName());
     options.setRunner(SparkRunner.class);
+    options.setStreaming(true);
     options.setTimeout(TEST_TIMEOUT_MSEC); // run for one interval
     Pipeline p = Pipeline.create(options);
 


### PR DESCRIPTION
isStreaming() is already default to false implicitly, since it is not set.
getAppName() defaults to the name of the class that constructs the PipelineOptions via the PipelineOptionsFactory.

I think both should work in Spark. And, I see no reason to override them.