### PR TITLE
CoderRegistry: make deprecated method private

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -387,6 +387,8 @@ public class CoderRegistry implements CoderProvider {
     return fallbackCoderProvider;
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+
   /**
    * Returns a {@code Map} from each of {@code baseClass}'s type parameters to the {@link Coder} to
    * use by default for it, in the context of {@code subClass}'s specialization of
@@ -525,8 +527,6 @@ public class CoderRegistry implements CoderProvider {
     return result;
   }
 
-
-  /////////////////////////////////////////////////////////////////////////////
 
   /**
    * Thrown when a {@link Coder} cannot possibly encode a type, yet has been proposed as a

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -75,12 +75,12 @@ import javax.annotation.Nullable;
  *       of {@link CoderProviders#fromStaticMethods}.
  *   <li>Fallback: A fallback {@link CoderProvider} is used to attempt to provide a {@link Coder}
  *       for any type. By default, there are two chained fallback coders:
- *       {@link ProtoCoder#coderProvider}, which can efficiently serialize any Protocol Buffers
- *       message, and then {@link SerializableCoder#PROVIDER}, which can provide a {@link Coder} for
- *       any type that is serializable via Java serialization. The fallback {@link CoderProvider}
- *       can be get and set respectively using {@link #getFallbackCoderProvider()} and
- *       {@link #setFallbackCoderProvider}. Multiple fallbacks can be chained together using
- *       {@link CoderProviders#firstOf}.
+ *       {@link ProtoCoder#coderProvider}, which can provide a coder to efficiently serialize any
+ *       Protocol Buffers message, and then {@link SerializableCoder#PROVIDER}, which can provide a
+ *       {@link Coder} for any type that is serializable via Java serialization. The fallback
+ *       {@link CoderProvider} can be get and set respectively using
+ *       {@link #getFallbackCoderProvider()} and {@link #setFallbackCoderProvider}. Multiple
+ *       fallbacks can be chained together using {@link CoderProviders#firstOf}.
  * </ol>
  */
 public class CoderRegistry implements CoderProvider {
@@ -369,7 +369,7 @@ public class CoderRegistry implements CoderProvider {
    * providing a {@code Coder<T>} for a type {@code T}, then the registry will attempt to create
    * a {@link Coder} using this {@link CoderProvider}.
    *
-   * <p>By default, this is set to a the chain of {@link ProtoCoder#coderProvider()} and
+   * <p>By default, this is set to the chain of {@link ProtoCoder#coderProvider()} and
    * {@link SerializableCoder#PROVIDER}.
    *
    * <p>See {@link #getFallbackCoderProvider}.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -370,7 +370,7 @@ public class CoderRegistry implements CoderProvider {
    *
    * <p>See {@link #getFallbackCoderProvider}.
    */
-  public void setFallbackCoderProvider(CoderProvider coderProvider) {
+  void setFallbackCoderProvider(CoderProvider coderProvider) {
     fallbackCoderProvider = coderProvider;
   }
 
@@ -379,7 +379,7 @@ public class CoderRegistry implements CoderProvider {
    *
    * <p>See {@link #setFallbackCoderProvider}.
    */
-  public CoderProvider getFallbackCoderProvider() {
+  private CoderProvider getFallbackCoderProvider() {
     return fallbackCoderProvider;
   }
 
@@ -413,11 +413,8 @@ public class CoderRegistry implements CoderProvider {
    * @param baseClass the base type, a parameterized class
    * @param knownCoders a map corresponding to the set of known {@link Coder Coders} indexed by
    * parameter name
-   *
-   * @deprecated this method is not part of the public interface and will be made private
    */
-  @Deprecated
-  public <T> Map<Type, Coder<?>> getDefaultCoders(
+  private <T> Map<Type, Coder<?>> getDefaultCoders(
       Class<? extends T> subClass,
       Class<T> baseClass,
       Map<Type, ? extends Coder<?>> knownCoders) {
@@ -535,13 +532,13 @@ public class CoderRegistry implements CoderProvider {
     private Coder<?> coder;
     private Type type;
 
-    public IncompatibleCoderException(String message, Coder<?> coder, Type type) {
+    IncompatibleCoderException(String message, Coder<?> coder, Type type) {
       super(message);
       this.coder = coder;
       this.type = type;
     }
 
-    public IncompatibleCoderException(String message, Coder<?> coder, Type type, Throwable cause) {
+    IncompatibleCoderException(String message, Coder<?> coder, Type type, Throwable cause) {
       super(message, cause);
       this.coder = coder;
       this.type = type;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -73,10 +74,12 @@ import javax.annotation.Nullable;
  *       the default {@code Coder} type. The {@link Coder} class must satisfy the requirements
  *       of {@link CoderProviders#fromStaticMethods}.
  *   <li>Fallback: A fallback {@link CoderProvider} is used to attempt to provide a {@link Coder}
- *       for any type. By default, this is {@link SerializableCoder#PROVIDER}, which can provide
- *       a {@link Coder} for any type that is serializable via Java serialization. The fallback
- *       {@link CoderProvider} can be get and set via {@link #getFallbackCoderProvider()}
- *       and {@link #setFallbackCoderProvider}. Multiple fallbacks can be chained together using
+ *       for any type. By default, there are two chained fallback coders:
+ *       {@link ProtoCoder#coderProvider}, which can efficiently serialize any Protocol Buffers
+ *       message, and then {@link SerializableCoder#PROVIDER}, which can provide a {@link Coder} for
+ *       any type that is serializable via Java serialization. The fallback {@link CoderProvider}
+ *       can be get and set respectively using {@link #getFallbackCoderProvider()} and
+ *       {@link #setFallbackCoderProvider}. Multiple fallbacks can be chained together using
  *       {@link CoderProviders#firstOf}.
  * </ol>
  */
@@ -366,11 +369,12 @@ public class CoderRegistry implements CoderProvider {
    * providing a {@code Coder<T>} for a type {@code T}, then the registry will attempt to create
    * a {@link Coder} using this {@link CoderProvider}.
    *
-   * <p>By default, this is set to {@link SerializableCoder#PROVIDER}.
+   * <p>By default, this is set to a the chain of {@link ProtoCoder#coderProvider()} and
+   * {@link SerializableCoder#PROVIDER}.
    *
    * <p>See {@link #getFallbackCoderProvider}.
    */
-  void setFallbackCoderProvider(CoderProvider coderProvider) {
+  public void setFallbackCoderProvider(CoderProvider coderProvider) {
     fallbackCoderProvider = coderProvider;
   }
 
@@ -379,7 +383,7 @@ public class CoderRegistry implements CoderProvider {
    *
    * <p>See {@link #setFallbackCoderProvider}.
    */
-  private CoderProvider getFallbackCoderProvider() {
+  public CoderProvider getFallbackCoderProvider() {
     return fallbackCoderProvider;
   }
 


### PR DESCRIPTION
This was part of the public API signature in Dataflow, but need not be in Beam.

Also remove a few unneeded publics in the same file.

Also update CoderProvider javadoc