### PR TITLE
Optimize Map and Flatmap when there are no side inputs.

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -226,7 +226,6 @@ class CallableWrapperDoFn(DoFn):
       raise TypeError('Expected a callable object instead of: %r' % fn)
 
     self._fn = fn
-    # pylint: disable=method-hidden
     if _fn_takes_side_inputs(fn):
       self.process = lambda context, *args, **kwargs: fn(
           context.element, *args, **kwargs)
@@ -254,9 +253,6 @@ class CallableWrapperDoFn(DoFn):
   def infer_output_type(self, input_type):
     return self._strip_output_annotations(
         trivial_inference.infer_return_type(self._fn, [input_type]))
-
-  def process(self, context, *args, **kwargs):
-    return self._fn(context.element, *args, **kwargs)
 
   def process_argspec_fn(self):
     return getattr(self._fn, '_argspec_fn', self._fn)

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -226,6 +226,7 @@ class CallableWrapperDoFn(DoFn):
       raise TypeError('Expected a callable object instead of: %r' % fn)
 
     self._fn = fn
+    # pylint: disable=method-hidden
     if _fn_takes_side_inputs(fn):
       self.process = lambda context, *args, **kwargs: fn(
           context.element, *args, **kwargs)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

varargs and kwargs are expensive, even when they're empty.

This is especially true for otherwise one-argument Python calls
which are special cased in CPython.