### PR TITLE
[BEAM-436] Re-enable RunnableOnService tests which need tempRoot

### DIFF
--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -88,7 +88,8 @@
               <systemPropertyVariables>
                 <beamTestPipelineOptions>
                   [
-                    "--runner=DirectRunner"
+                    "--runner=DirectRunner",
+                    "--tempRoot=${project.build.directory}/runnableOnServiceTests/tempRoot"
                   ]
                 </beamTestPipelineOptions>
               </systemPropertyVariables>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -157,6 +157,13 @@ public class TestPipeline extends Pipeline {
       }
       options.setStableUniqueNames(CheckEnabled.ERROR);
 
+      if (options.getTempLocation() == null) {
+        String tempRoot = options.as(TestPipelineOptions.class).getTempRoot();
+        if (tempRoot != null) {
+          options.setTempLocation(tempRoot);
+        }
+      }
+
       IOChannelUtils.registerStandardIOFactories(options);
       return options;
     } catch (IOException e) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -50,7 +50,6 @@ import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.reflect.Nullable;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -322,7 +321,6 @@ public class AvroIOTest {
 
   @Test
   @Category(RunnableOnService.class)
-  @Ignore("[BEAM-436] DirectRunner RunnableOnService tempLocation configuration insufficient")
   public void testPrimitiveWriteDisplayData() throws IOException {
     PipelineOptions options = DisplayDataEvaluator.getDefaultOptions();
     String tempRoot = options.as(TestPipelineOptions.class).getTempRoot();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -349,7 +349,6 @@ public class TextIOTest {
 
   @Test
   @Category(RunnableOnService.class)
-  @Ignore("[BEAM-436] DirectRunner RunnableOnService tempLocation configuration insufficient")
   public void testPrimitiveWriteDisplayData() throws IOException {
     PipelineOptions options = DisplayDataEvaluator.getDefaultOptions();
     String tempRoot = options.as(TestPipelineOptions.class).getTempRoot();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -61,7 +61,6 @@ import org.apache.beam.sdk.values.PCollection;
 import com.google.common.collect.ImmutableList;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import org.apache.beam.sdk.PipelineResult;
@@ -30,6 +31,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Create;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.hamcrest.BaseMatcher;
@@ -59,16 +61,20 @@ public class TestPipelineTest {
 
   @Test
   public void testCreationOfPipelineOptions() throws Exception {
-    ObjectMapper mapper = new ObjectMapper();
-    String stringOptions = mapper.writeValueAsString(new String[]{
+    setTestOptionsSystemProperty(new String[]{
       "--runner=org.apache.beam.sdk.testing.CrashingRunner",
       "--project=testProject"
     });
-    System.getProperties().put("beamTestPipelineOptions", stringOptions);
     GcpOptions options =
         TestPipeline.testingPipelineOptions().as(GcpOptions.class);
     assertEquals(CrashingRunner.class, options.getRunner());
     assertEquals(options.getProject(), "testProject");
+  }
+
+  private void setTestOptionsSystemProperty(String[] optionsArgs) throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    String stringOptions = mapper.writeValueAsString(optionsArgs);
+    System.getProperties().put("beamTestPipelineOptions", stringOptions);
   }
 
   @Test
@@ -76,6 +82,35 @@ public class TestPipelineTest {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     assertThat(options.as(ApplicationNameOptions.class).getAppName(), startsWith(
         "TestPipelineTest-testCreationOfPipelineOptionsFromReallyVerboselyNamedTestCase"));
+  }
+
+  @Test
+  public void testLocationDefaultsWithSetTempRoot() throws JsonProcessingException {
+    setTestOptionsSystemProperty(new String[]{ "--tempRoot=foo://bar" });
+    TestPipelineOptions opt = TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    assertEquals("foo://bar", opt.getTempRoot());
+    assertEquals("tempLocation defaults to tempRoot", "foo://bar", opt.getTempLocation());
+  }
+
+  @Test
+  public void testLocationDefaultsWithSetTempRootAndTempLocation() throws JsonProcessingException {
+    setTestOptionsSystemProperty(new String[]{
+        "--tempRoot=foo://bar",
+        "--tempLocation=bar://baz"
+    });
+    TestPipelineOptions opt = TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    assertEquals("foo://bar", opt.getTempRoot());
+    assertEquals("bar://baz", opt.getTempLocation());
+  }
+
+  @Test public void testLocationDefaultsWithoutTempRoot() {
+    // tempRoot System property not set
+    TestPipelineOptions opt = TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+
+    assertNull(opt.getTempRoot());
+    assertNull(opt.getTempLocation());
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -644,7 +644,6 @@ public class BigQueryIOTest implements Serializable {
 
   @Test
   @Category(RunnableOnService.class)
-  @Ignore("[BEAM-436] DirectRunner RunnableOnService tempLocation configuration insufficient")
   public void testTableSourcePrimitiveDisplayData() throws IOException, InterruptedException {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
     BigQueryIO.Read.Bound read = BigQueryIO.Read
@@ -661,7 +660,6 @@ public class BigQueryIOTest implements Serializable {
 
   @Test
   @Category(RunnableOnService.class)
-  @Ignore("[BEAM-436] DirectRunner RunnableOnService tempLocation configuration insufficient")
   public void testQuerySourcePrimitiveDisplayData() throws IOException, InterruptedException {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
     BigQueryIO.Read.Bound read = BigQueryIO.Read
@@ -687,14 +685,12 @@ public class BigQueryIOTest implements Serializable {
 
   @Test
   @Category(RunnableOnService.class)
-  @Ignore("[BEAM-436] DirectRunner RunnableOnService tempLocation configuration insufficient")
   public void testBatchSinkPrimitiveDisplayData() throws IOException, InterruptedException {
     testSinkPrimitiveDisplayData(/* streaming: */ false);
   }
 
   @Test
   @Category(RunnableOnService.class)
-  @Ignore("[BEAM-436] DirectRunner RunnableOnService tempLocation configuration insufficient")
   public void testStreamingSinkPrimitiveDisplayData() throws IOException, InterruptedException {
     testSinkPrimitiveDisplayData(/* streaming: */ true);
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -94,7 +94,6 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

@peihe's recent work to improve tempRoot handling means that these tests are now working properly. They can be re-enabled to validate runner display data for i/o transforms.