### PR TITLE
Move test-jar back to default profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,6 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "$CUSTOM_JDK"; fi
   - export BEAM_SUREFIRE_ARGLINE="-Xmx512m"
 
-install:
-  - travis_retry mvn -B install clean -U -DskipTests=true
-
 script:
-  - travis_retry mvn -B $MAVEN_OVERRIDE install -U
+  - travis_retry mvn --batch-mode --update-snapshots $MAVEN_OVERRIDE verify
   - travis_retry testing/travis/test_wordcount.sh

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 
   <profiles>
     <!-- A global profile defined for all modules for release-level verification. 
-      Slow processes such as building source, javadoc, and test jars should be limited 
+      Optional processes such as building source and javadoc should be limited 
       to this profile. -->
     <profile>
       <id>release</id>
@@ -186,19 +186,6 @@
                   <phase>package</phase>
                   <goals>
                     <goal>test-jar-no-fork</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-jar-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>default-test-jar</id>
-                  <goals>
-                    <goal>test-jar</goal>
                   </goals>
                 </execution>
               </executions>
@@ -750,6 +737,12 @@
               <id>default-jar</id>
               <goals>
                 <goal>jar</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-test-jar</id>
+              <goals>
+                <goal>test-jar</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---


The test jars for beam-sdks-java-core and beam-runners-core-java are both mandatory artifacts with testing utilities intended for general use. These were moved out of the default profile since for most normal projects they are optional release-time distributions, but for us they are not.

R: @dhalperi @jbonofre 

It may be that these should just be done in the particular modules that intend to really distribute their tests for users. I'm not sure if it is just the two I mention in the commit message, or if there are more. For example, the `beam-examples-java` tests and various IO modules' tests are intended for use as integration tests.