### PR TITLE
Bind checkstyle:check to the test-compile phase to fail earlier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,15 @@
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
           </configuration>
           <executions>
+            <!--
+              Execute checkstyle after compilation but before tests.
+
+              This ensures that any parsing or type checking errors are from
+              javac, so they look as expected. Beyond that, we want to
+              fail as early as possible.
+            -->
             <execution>
+              <phase>test-compile</phase>
               <goals>
                 <goal>check</goal>
               </goals>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Today we run checkstyle _after packaging_ so we have to wait for all the various jars to be built before we fail.

This change binds checkstyle to the earliest phase that seems reasonable.

R: anyone