### PR TITLE
[BEAM-498] Remove WindowingInternals support from DoFnReflector

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -28,7 +28,6 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
-import org.apache.beam.sdk.util.WindowingInternals;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -302,11 +301,43 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
     BoundedWindow window();
 
     /**
-     * Construct the {@link WindowingInternals} to use within a {@link DoFn} that
-     * needs it. This is called if the {@link ProcessElement} method has a parameter of type
-     * {@link WindowingInternals}.
+     * A placeholder for testing purposes. The return type itself is package-private and not
+     * implemented.
      */
-    WindowingInternals<InputT, OutputT> windowingInternals();
+    InputProvider<InputT> inputProvider();
+
+    /**
+     * A placeholder for testing purposes. The return type itself is package-private and not
+     * implemented.
+     */
+    OutputReceiver<OutputT> outputReceiver();
+  }
+
+  static interface OutputReceiver<T> {
+    void output(T output);
+  }
+
+  static interface InputProvider<T> {
+    T get();
+  }
+
+  /** For testing only, this {@link ExtraContextFactory} returns {@code null} for all parameters. */
+  public static class FakeExtraContextFactory<InputT, OutputT>
+      implements ExtraContextFactory<InputT, OutputT> {
+    @Override
+    public BoundedWindow window() {
+      return null;
+    }
+
+    @Override
+    public InputProvider<InputT> inputProvider() {
+      return null;
+    }
+
+    @Override
+    public OutputReceiver<OutputT> outputReceiver() {
+      return null;
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -331,8 +362,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <ul>
    *   <li>It must have at least one argument.
    *   <li>Its first argument must be a {@link DoFn.ProcessContext}.
-   *   <li>Its remaining arguments must be {@link BoundedWindow}, or
-   *   {@link WindowingInternals WindowingInternals&lt;InputT, OutputT&gt;}.
+   *   <li>Its remaining argument, if any, must be {@link BoundedWindow}.
    * </ul>
    */
   @Documented

--- a/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnReflectorBenchmark.java
+++ b/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnReflectorBenchmark.java
@@ -58,18 +58,7 @@ public class DoFnReflectorBenchmark {
   private StubDoFnProcessContext stubDoFnContext =
       new StubDoFnProcessContext(doFn, ELEMENT);
   private ExtraContextFactory<String, String> extraContextFactory =
-      new ExtraContextFactory<String, String>() {
-
-    @Override
-    public BoundedWindow window() {
-      return null;
-    }
-
-    @Override
-    public WindowingInternals<String, String> windowingInternals() {
-      return null;
-    }
-  };
+      new DoFn.FakeExtraContextFactory<>();
 
   private DoFnReflector doFnReflector;
   private OldDoFn<String, String> adaptedDoFnWithContext;


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The test themselves are replaced by mostly-hidden placeholders, to ensure that our code for handling generic parameters remains in place until new context parameters that use generics are added back.

R: @bjchambers since `ExtraContextFactory` is a public interface, currently the hiding is a bit hackish. Probably we can and should refactor it a bit anyhow, but how about this for short term prevention of abuse?