### PR TITLE
Fix hashing and comparison for compression types

### DIFF
--- a/sdks/python/apache_beam/io/fileio.py
+++ b/sdks/python/apache_beam/io/fileio.py
@@ -283,7 +283,17 @@ class _CompressionType(object):
     self.identifier = identifier
 
   def __eq__(self, other):
-    return self.identifier == other.identifier
+    return (isinstance(other, _CompressionType) and
+            self.identifier == other.identifier)
+
+  def __hash__(self):
+    return hash((self.identifier))
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+  def __repr__(self):
+    return '_CompressionType(%s)' % self.identifier
 
 
 class CompressionTypes(object):

--- a/sdks/python/apache_beam/io/fileio.py
+++ b/sdks/python/apache_beam/io/fileio.py
@@ -287,7 +287,7 @@ class _CompressionType(object):
             self.identifier == other.identifier)
 
   def __hash__(self):
-    return hash((self.identifier))
+    return hash(self.identifier)
 
   def __ne__(self, other):
     return not self.__eq__(other)


### PR DESCRIPTION
Fix up to @silviulica's #751, addressing @robertwb's comments.

`CompressionType` cannot be converted to `enum`, since it is not supported in python 2.7. Merging of `CompressionType` and `CompressionTypes` should be tracked separately.