### PR TITLE
[BEAM-550] DatastoreIO Write PTranform for Bounded/Unbounded PCollections

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/DatastoreDelete.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/DatastoreDelete.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.examples.cookbook;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.gcp.datastore.DatastoreIO;
+import org.apache.beam.sdk.io.gcp.datastore.V1Beta3;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.Validation;
+import com.google.datastore.v1beta3.Query;
+
+import javax.annotation.Nullable;
+
+/**
+ * An example that deletes entities from Cloud Datastore using DatastoreIO.
+ *
+ * <p>This example shows how to use DatastoreIO to delete entities from Datastore. Note that this
+ * example will write data to Datastore, which may incur charge for Cloud Datastore operations.
+ *
+ * <p>To run this example, users need to use gcloud to get credential for Cloud Datastore:
+ * <pre>{@code
+ * $ gcloud auth login
+ * }</pre>
+ *
+ * <p>To run this pipeline locally, the following options must be provided:
+ * <pre>{@code
+ *   --project=YOUR_PROJECT_ID
+ *   --kind=YOUR_DATASTORE_KIND_NAME
+ * }</pre>
+ *
+ * <p>To run this example using Dataflow service, you must additionally
+ * provide either {@literal --tempLocation} or {@literal --tempLocation}, and
+ * select one of the Dataflow pipeline runners, eg
+ * {@literal --runner=BlockingDataflowRunner}.
+ *
+ */
+public class DatastoreDelete {
+  /**
+   * Options supported by {@link DatastoreDelete}.
+   *
+   * <p>Inherits standard configuration options.
+   */
+  public static interface Options extends PipelineOptions {
+    @Description("Project ID to read from datastore")
+    @Validation.Required
+    String getProject();
+    void setProject(String value);
+
+    @Description("Datastore Entity kind")
+    @Validation.Required
+    String getKind();
+    void setKind(String value);
+
+    @Description("Datastore Namespace")
+    String getNamespace();
+    void setNamespace(@Nullable String value);
+  }
+
+  public static void main(String[] args) {
+    Options options = PipelineOptionsFactory
+        .fromArgs(args).withValidation().as(DatastoreDelete.Options.class);
+
+    // A query to read all entities from the given kind.
+    Query.Builder query = Query.newBuilder();
+    query.addKindBuilder().setName(options.getKind());
+
+    // A transform to read entities
+    V1Beta3.Read read = DatastoreIO.v1beta3().read()
+        .withProjectId(options.getProject())
+        .withQuery(query.build())
+        .withNamespace(options.getNamespace());
+
+    // A transform to delete entities.
+    V1Beta3.Delete delete = DatastoreIO.v1beta3().delete()
+        .withProjectId(options.getProject());
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadEntities", read)
+        .apply("DeleteEntities", delete);
+
+    p.run();
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

- Implement Datastore Write as a composite transform of ParDo without using the Sink API
- Generalize the transform for handling idempotent Datastore Mutations. This allows for a Delete transform for deleting entities. 
- Add an example that deletes entities from Datastore.