### PR TITLE
[BEAM-557] Exclude guava-testlib from shading relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -633,6 +633,8 @@
       </dependency>
 
       <dependency>
+        <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+             excluding com.google.common.**.testing -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava-testlib</artifactId>
         <version>${guava.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -633,7 +633,7 @@
       </dependency>
 
       <dependency>
-        <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+        <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
              excluding com.google.common.**.testing -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava-testlib</artifactId>

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -192,6 +192,9 @@
                      the second relocation. -->
                 <relocation>
                   <pattern>com.google.common</pattern>
+                  <excludes>
+                    <exclude>com.google.common.**.testing</exclude>
+                  </excludes>
                   <shadedPattern>org.apache.beam.runners.direct.repackaged.com.google.common</shadedPattern>
                 </relocation>
                 <relocation>

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -193,6 +193,7 @@
                 <relocation>
                   <pattern>com.google.common</pattern>
                   <excludes>
+                    <!-- com.google.common is too generic, need to exclude guava-testlib -->
                     <exclude>com.google.common.**.testing</exclude>
                   </excludes>
                   <shadedPattern>org.apache.beam.runners.direct.repackaged.com.google.common</shadedPattern>
@@ -267,6 +268,8 @@
     </dependency>
 
     <dependency>
+      <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+     excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -268,7 +268,7 @@
     </dependency>
 
     <dependency>
-      <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+      <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
      excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -196,6 +196,7 @@
                 <relocation>
                   <pattern>com.google.common</pattern>
                   <excludes>
+                    <!-- com.google.common is too generic, need to exclude guava-testlib -->
                     <exclude>com.google.common.**.testing</exclude>
                   </excludes>
                   <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
@@ -312,6 +313,8 @@
     </dependency>
 
     <dependency>
+      <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+           excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -313,7 +313,7 @@
     </dependency>
 
     <dependency>
-      <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+      <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
            excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -195,6 +195,9 @@
                      the second relocation. -->
                 <relocation>
                   <pattern>com.google.common</pattern>
+                  <excludes>
+                    <exclude>com.google.common.**.testing</exclude>
+                  </excludes>
                   <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
                 </relocation>
                 <relocation>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -194,6 +194,7 @@
                 <relocation>
                   <pattern>com.google.common</pattern>
                   <excludes>
+                    <!-- com.google.common is too generic, need to exclude guava-testlib -->
                     <exclude>com.google.common.**.testing</exclude>
                   </excludes>
                   <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
@@ -424,6 +425,8 @@
     </dependency>
 
     <dependency>
+      <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+           excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -193,6 +193,9 @@
                   exclude 'org.apache.beam.**', and remove the second relocation. -->
                 <relocation>
                   <pattern>com.google.common</pattern>
+                  <excludes>
+                    <exclude>com.google.common.**.testing</exclude>
+                  </excludes>
                   <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
                 </relocation>
                 <relocation>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -425,7 +425,7 @@
     </dependency>
 
     <dependency>
-      <!-- Note: when package relocating guava, ensure guava-testlib is not also relocated by
+      <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
            excluding com.google.common.**.testing -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Previously, guava-testlib guava-testlib was being relocated as part of
the shading process, but test-scope dependencies aren't bundled in the
uber-jar. As a result, the output JAR was unusable without recreating the
same shading rules in a consuming project.