### PR TITLE
Remove egg_info from setup.cfg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -795,6 +795,7 @@
               <exclude>**/test/**/.placeholder</exclude>
               <exclude>.repository/**/*</exclude>
               <exclude>**/nose-*.egg/**/*</exclude>
+              <exclude>**/.tox/**/*</exclude>
 
               <!-- Default eclipse excludes neglect subprojects -->
               <exclude>**/.checkstyle</exclude>

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -26,5 +26,3 @@ verbosity=2
 # fast_coders_test and typecoders_test.
 exclude=fast_coders_test|typecoders_test
 
-[egg_info]
-egg_base = target

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,9 +17,6 @@
 
 [tox]
 envlist = py27
-toxworkdir={toxinidir}/target/tox
-distdir={toxinidir}/target/dist
-distshare={toxinidir}/target/distshare
 
 [pep8]
 # Disable all errors and warnings except for the ones related to blank lines.


### PR DESCRIPTION
Removing not-needed egg_info section. egg_info change broke `python setup.py sdist`

