### PR TITLE
[Beam-556] Fix typo in documentation

### DIFF
--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -221,7 +221,7 @@ class PTransform(WithTypeHints):
     Args:
       args: A tuple of position arguments.
       kwargs: A dictionary of keyword arguments.
-      arg_name: The name of the second ergument.
+      arg_name: The name of the second argument.
 
     Returns:
       A (label, value) tuple. The label will be the one passed in or one


### PR DESCRIPTION
This is my first python submission.  It was built on top of origin/python-sdk rather than origin/master.  If I'm doing this wrong, please let me know.