### PR TITLE
[BEAM-557] Fix repackaging exclude pattern for guava-testlib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
 
       <dependency>
         <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
-             excluding com.google.common.**.testing -->
+             excluding com.google.common.**.testing.* -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava-testlib</artifactId>
         <version>${guava.version}</version>

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -194,7 +194,7 @@
                   <pattern>com.google.common</pattern>
                   <excludes>
                     <!-- com.google.common is too generic, need to exclude guava-testlib -->
-                    <exclude>com.google.common.**.testing</exclude>
+                    <exclude>com.google.common.**.testing.*</exclude>
                   </excludes>
                   <shadedPattern>org.apache.beam.runners.direct.repackaged.com.google.common</shadedPattern>
                 </relocation>
@@ -269,7 +269,7 @@
 
     <dependency>
       <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
-     excluding com.google.common.**.testing -->
+     excluding com.google.common.**.testing.* -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -198,7 +198,7 @@
                   <pattern>com.google.common</pattern>
                   <excludes>
                     <!-- com.google.common is too generic, need to exclude guava-testlib -->
-                    <exclude>com.google.common.**.testing</exclude>
+                    <exclude>com.google.common.**.testing.*</exclude>
                   </excludes>
                   <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
                 </relocation>
@@ -315,7 +315,7 @@
 
     <dependency>
       <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
-           excluding com.google.common.**.testing -->
+           excluding com.google.common.**.testing.* -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -195,7 +195,7 @@
                   <pattern>com.google.common</pattern>
                   <excludes>
                     <!-- com.google.common is too generic, need to exclude guava-testlib -->
-                    <exclude>com.google.common.**.testing</exclude>
+                    <exclude>com.google.common.**.testing.*</exclude>
                   </excludes>
                   <shadedPattern>org.apache.beam.sdk.repackaged.com.google.common</shadedPattern>
                 </relocation>
@@ -426,7 +426,7 @@
 
     <dependency>
       <!-- Note: when relocating guava, ensure guava-testlib is not also relocated by
-           excluding com.google.common.**.testing -->
+           excluding com.google.common.**.testing.* -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The previous fix was incorrect in that the exclude pattern requires `.*` at the end. Tested this iteration using `javap` to inspect generated `.class` files.