### PR TITLE
[BEAM-578] Updates FileBasedSource so that sub-classes can prevent splitting.

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -253,7 +253,8 @@ class TestFileBasedSource(unittest.TestCase):
 
   def _run_dataflow_test(self, pattern, expected_data, splittable=True):
     pipeline = beam.Pipeline('DirectPipelineRunner')
-    pcoll = pipeline | 'Read' >> beam.Read(LineSource(pattern, splittable=splittable))
+    pcoll = pipeline | 'Read' >> beam.Read(LineSource(
+        pattern, splittable=splittable))
     assert_that(pcoll, equal_to(expected_data))
     pipeline.run()
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -638,7 +638,8 @@ class RangeTracker(object):
       position: suggested position where the current range should try to
                 be split at.
     Returns:
-      a tuple containing the split position and split fraction.
+      a tuple containing the split position and split fraction if split is
+      successful. Returns ``None`` otherwise.
     """
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -324,5 +324,3 @@ class UnsplittableRangeTracker(iobase.RangeTracker):
 
   def fraction_consumed(self):
     return self._range_tracker.fraction_consumed()
-
-

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -284,3 +284,45 @@ class GroupedShuffleRangeTracker(iobase.RangeTracker):
     raise RuntimeError('GroupedShuffleRangeTracker does not measure fraction'
                        ' consumed due to positions being opaque strings'
                        ' that are interpreted by the service')
+
+
+class UnsplittableRangeTracker(iobase.RangeTracker):
+  """A RangeTracker that always ignores split requests.
+
+  This can be used to make a given ``RangeTracker`` object unsplittable by
+  ignoring all calls to ``try_split()``. All other calls will be delegated to
+  the given ``RangeTracker``.
+  """
+
+  def __init__(self, range_tracker):
+    """Initializes UnsplittableRangeTracker.
+
+    Args:
+      range_tracker: a ``RangeTracker`` to which all method calls expect calls
+      to ``try_split()`` will be delegated.
+    """
+    assert range_tracker
+    self._range_tracker = range_tracker
+
+  def start_position(self):
+    return self._range_tracker.start_position()
+
+  def stop_position(self):
+    return self._range_tracker.stop_position()
+
+  def position_at_fraction(self, fraction):
+    return self._range_tracker.position_at_fraction(fraction)
+
+  def try_claim(self, position):
+    return self._range_tracker.try_claim(position)
+
+  def try_split(self, position):
+    return None
+
+  def set_current_position(self, position):
+    self._range_tracker.set_current_position(position)
+
+  def fraction_consumed(self):
+    return self._range_tracker.fraction_consumed()
+
+

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -319,6 +319,30 @@ class GroupedShuffleRangeTrackerTest(unittest.TestCase):
         self.bytes_to_position([3, 2, 1])))
 
 
+class UnsplittableRangeTrackerTest(unittest.TestCase):
+
+  def test_try_claim(self):
+    tracker = range_trackers.UnsplittableRangeTracker(
+        range_trackers.OffsetRangeTracker(100, 200))
+    self.assertTrue(tracker.try_claim(110))
+    self.assertTrue(tracker.try_claim(140))
+    self.assertTrue(tracker.try_claim(183))
+    self.assertFalse(tracker.try_claim(210))
+
+  def test_try_split_fails(self):
+    tracker = range_trackers.UnsplittableRangeTracker(
+        range_trackers.OffsetRangeTracker(100, 200))
+    self.assertTrue(tracker.try_claim(110))
+    # Out of range
+    self.assertFalse(tracker.try_split(109))
+    self.assertFalse(tracker.try_split(210))
+
+    # Within range. But splitting is still unsuccessful.
+    self.assertFalse(copy.copy(tracker).try_split(111))
+    self.assertFalse(copy.copy(tracker).try_split(130))
+    self.assertFalse(copy.copy(tracker).try_split(199))
+
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()


### PR DESCRIPTION
File patterns will be split into sources of individual files, but any further splitting into data ranges will be prevented. This prevents both initial and dynamic splitting.

Introduces UnsplittableRangeTracker, which can be used to make any given RangeTracker object unsplittable.