### PR TITLE
[BEAM-383] BigQueryIO.Write: raise size limit to 11 TiB

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1423,8 +1423,8 @@ public class BigQueryIO {
       // Maximum number of files in a single partition.
       static final int MAX_NUM_FILES = 10000;
 
-      // Maximum number of bytes in a single partition.
-      static final long MAX_SIZE_BYTES = 3 * (1L << 40);
+      // Maximum number of bytes in a single partition -- 11 TiB just under BQ's 12 TiB limit.
+      static final long MAX_SIZE_BYTES = 11 * (1L << 40);
 
       // The maximum number of retry jobs.
       static final int MAX_RETRY_JOBS = 3;


### PR DESCRIPTION
BigQuery has changed their total size quota to 12 TiB.
https://cloud.google.com/bigquery/quota-policy#import