### PR TITLE
Updates SourceTestBase concurrent splitting test to share thread pool

### DIFF
--- a/sdks/python/apache_beam/io/source_test_utils_test.py
+++ b/sdks/python/apache_beam/io/source_test_utils_test.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 #
 
+import logging
 import tempfile
 import unittest
-from filebasedsource_test import LineSource
-import source_test_utils
+
+from apache_beam.io.filebasedsource_test import LineSource
+import apache_beam.io.source_test_utils as source_test_utils
 
 
 class SourceTestUtilsTest(unittest.TestCase):
@@ -115,3 +117,7 @@ class SourceTestUtilsTest(unittest.TestCase):
     source = self._create_source(data)
 
     source_test_utils.assertSplitAtFractionExhaustive(source)
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()


### PR DESCRIPTION
Updates SourceTestBase concurrent splitting test to share thread pool across runs.

Without this, runs could fail in environments that prevents two many threads from being created.

Does some slight fixes to the source_test_utils_test.