### PR TITLE
[BEAM-572] Remove Spark Reference in WordCount

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
@@ -18,7 +18,6 @@
 package org.apache.beam.examples;
 
 import com.google.common.base.Strings;
-import com.google.common.io.Resources;
 import java.io.IOException;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
@@ -165,7 +164,7 @@ public class WordCount {
    */
   public static interface WordCountOptions extends PipelineOptions {
     @Description("Path of the file to read from")
-    @Default.InstanceFactory(InputFactory.class)
+    @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")
     String getInputFile();
     void setInputFile(String value);
 
@@ -191,27 +190,6 @@ public class WordCount {
           }
         } else {
           throw new IllegalArgumentException("Must specify --output or --tempLocation");
-        }
-      }
-    }
-
-    /**
-     * Return default input file path according to runner type.
-     *
-     * <p><ul>
-     *   <li>SparkRunner:
-     *   .../src/test/resources/LICENSE</li>
-     *   <li>other runners:
-     *   gs://apache-beam-samples/apache/LICENSE</li>
-     * </ul>
-     */
-    public static class InputFactory implements DefaultValueFactory<String> {
-      @Override
-      public String create(PipelineOptions options) {
-        if (options.getRunner().getName().contains("SparkRunner")) {
-          return Resources.getResource("LICENSE").getPath();
-        } else {
-          return "gs://apache-beam-samples/apache/LICENSE";
         }
       }
     }

--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.examples;
 
+import com.google.common.io.Resources;
 import java.util.Date;
 import org.apache.beam.examples.WordCount.WordCountOptions;
 import org.apache.beam.sdk.options.Default;
@@ -60,6 +61,14 @@ public class WordCountIT {
         "results"));
     options.setOnSuccessMatcher(
         new FileChecksumMatcher(options.getOutputChecksum(), options.getOutput() + "*"));
+
+    String e2eTestInputPath = "gs://apache-beam-samples/apache/LICENSE";
+    // Spark runner currently doesn't support GCS I/O, change default input to:
+    // .../src/test/resources/LICENSE
+    if (options.getRunner().getName().contains("SparkRunner")) {
+      e2eTestInputPath = Resources.getResource("LICENSE").getPath();
+    }
+    options.setInputFile(e2eTestInputPath);
 
     WordCount.main(TestPipeline.convertToArgs(options));
   }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

 - Remove spark reference in WordCount to keep WordCount simple and clear.
 - Moving input of SparkRunner logic to WordCountIT

Test done and pass with TestDataflowRunner and FlinkRunner. SparkRunner failed due to [BEAM-592](https://issues.apache.org/jira/browse/BEAM-592)