### PR TITLE
[BEAM-592] Fix SparkRunner Dependency Problem in WordCount

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -97,6 +97,12 @@
           <version>${spark.version}</version>
           <scope>runtime</scope>
           <optional>true</optional>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>jul-to-slf4j</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <dependency>

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -98,6 +98,12 @@
           <version>${spark.version}</version>
           <scope>runtime</scope>
           <optional>true</optional>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>jul-to-slf4j</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Fix WordCount logging dependency issue which causing stackOverflowError when running with SparkRunner.

Test done by running WordCount:
```
mvn clean compile exec:java -Dexec.mainClass=org.apache.beam.examples.WordCount -Dexec.args="--inputFile=/tmp/kinglear.txt --runner=SparkRunner --sparkMaster=local --tempLocation=/tmp/out"
```
and WordCount e2e test:
```
mvn clean verify -am -DskipITs=false -DintegrationTestPipelineOptions='[ "--tempRoot=/tmp", "--runner=SparkRunner" ]' -Dit.test=WordCountIT