### PR TITLE
Fix inconsistent in formatting flink logs

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchPipelineTranslator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchPipelineTranslator.java
@@ -65,6 +65,7 @@ public class FlinkBatchPipelineTranslator extends FlinkPipelineTranslator {
   @Override
   public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
     LOG.info(genSpaces(this.depth) + "enterCompositeTransform- " + formatNodeName(node));
+    this.depth++;
 
     BatchTransformTranslator<?> translator = getTranslator(node);
 
@@ -73,7 +74,6 @@ public class FlinkBatchPipelineTranslator extends FlinkPipelineTranslator {
       LOG.info(genSpaces(this.depth) + "translated-" + formatNodeName(node));
       return CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
     } else {
-      this.depth++;
       return CompositeBehavior.ENTER_TRANSFORM;
     }
   }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingPipelineTranslator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingPipelineTranslator.java
@@ -52,6 +52,7 @@ public class FlinkStreamingPipelineTranslator extends FlinkPipelineTranslator {
   @Override
   public CompositeBehavior enterCompositeTransform(TransformTreeNode node) {
     LOG.info(genSpaces(this.depth) + "enterCompositeTransform- " + formatNodeName(node));
+    this.depth++;
 
     PTransform<?, ?> transform = node.getTransform();
     if (transform != null) {
@@ -64,7 +65,6 @@ public class FlinkStreamingPipelineTranslator extends FlinkPipelineTranslator {
         return CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
       }
     }
-    this.depth++;
     return CompositeBehavior.ENTER_TRANSFORM;
   }
 


### PR DESCRIPTION
**leaveCompositeTransform** always decrement _this.depth_, 
but **enterCompositeTransform** increment _this.depth_ only on ENTER_TRANSFORM