### PR TITLE
[BEAM-604] Use Watermark to Finish Streaming Job in TestDataflowRunner

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -216,6 +216,37 @@
         </plugins>
       </build>
     </profile>
+
+    <!--
+      This profile disable streaming integration tests which
+      have @Category(StreamingIT.class) annotation.
+
+      This profile can be abled on the command line
+      by specifying -P disable-streaming-ITs.
+    -->
+    <profile>
+      <id>disable-streaming-ITs</id>
+      <activation><activeByDefault>false</activeByDefault></activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <excludedGroups>org.apache.beam.sdk.testing.StreamingIT</excludedGroups>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -218,11 +218,8 @@
     </profile>
 
     <!--
-      This profile disable streaming integration tests which
-      have @Category(StreamingIT.class) annotation.
-
-      This profile can be abled on the command line
-      by specifying -P disable-streaming-ITs.
+      This profile disables streaming integration tests which
+      have the @Category(StreamingIT.class) annotation.
     -->
     <profile>
       <id>disable-streaming-ITs</id>

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -21,9 +21,12 @@ package org.apache.beam.examples;
 import java.io.IOException;
 import org.apache.beam.examples.WindowedWordCount.Options;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.testing.StreamingIT;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -36,13 +39,24 @@ public class WindowedWordCountIT {
   /**
    * Options for the {@link WindowedWordCount} Integration Test.
    */
-  public interface TestOptions extends Options, TestPipelineOptions {
+  public interface TestOptions extends Options, TestPipelineOptions, StreamingOptions{
   }
 
   @Test
-  public void testWindowedWordCount() throws IOException {
+  public void testWindowedWordCountInBatch() throws IOException {
+    testWindowedWordCountPipeline(false);
+  }
+
+  @Test
+  @Category(StreamingIT.class)
+  public void testWindowedWordCountInStreaming() throws IOException {
+    testWindowedWordCountPipeline(true);
+  }
+
+  private void testWindowedWordCountPipeline(boolean isStreaming) throws IOException {
     PipelineOptionsFactory.register(TestOptions.class);
     TestOptions options = TestPipeline.testingPipelineOptions().as(TestOptions.class);
+    options.setStreaming(isStreaming);
 
     WindowedWordCount.main(TestPipeline.convertToArgs(options));
   }

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.beam.examples;
 
 import java.io.IOException;
@@ -39,23 +38,25 @@ public class WindowedWordCountIT {
   /**
    * Options for the {@link WindowedWordCount} Integration Test.
    */
-  public interface TestOptions extends Options, TestPipelineOptions, StreamingOptions{
+  public interface WindowedWordCountITOptions
+      extends Options, TestPipelineOptions, StreamingOptions {
   }
 
   @Test
   public void testWindowedWordCountInBatch() throws IOException {
-    testWindowedWordCountPipeline(false);
+    testWindowedWordCountPipeline(false /* isStreaming */);
   }
 
   @Test
   @Category(StreamingIT.class)
   public void testWindowedWordCountInStreaming() throws IOException {
-    testWindowedWordCountPipeline(true);
+    testWindowedWordCountPipeline(true /* isStreaming */);
   }
 
   private void testWindowedWordCountPipeline(boolean isStreaming) throws IOException {
-    PipelineOptionsFactory.register(TestOptions.class);
-    TestOptions options = TestPipeline.testingPipelineOptions().as(TestOptions.class);
+    PipelineOptionsFactory.register(WindowedWordCountITOptions.class);
+    WindowedWordCountITOptions options =
+        TestPipeline.testingPipelineOptions().as(WindowedWordCountITOptions.class);
     options.setStreaming(isStreaming);
 
     WindowedWordCount.main(TestPipeline.convertToArgs(options));

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.examples;
+
+import java.io.IOException;
+import org.apache.beam.examples.WindowedWordCount.Options;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * End-to-end integration test of {@link WindowedWordCount}.
+ */
+@RunWith(JUnit4.class)
+public class WindowedWordCountIT {
+
+  /**
+   * Options for the {@link WindowedWordCount} Integration Test.
+   */
+  public interface TestOptions extends Options, TestPipelineOptions {
+  }
+
+  @Test
+  public void testWindowedWordCount() throws IOException {
+    PipelineOptionsFactory.register(TestOptions.class);
+    TestOptions options = TestPipeline.testingPipelineOptions().as(TestOptions.class);
+
+    WindowedWordCount.main(TestPipeline.convertToArgs(options));
+  }
+}

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -185,15 +185,14 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   }
 
   /**
-   * Check success status of a dataflow pipeline job with given job metrics.
+   * Check that PAssert expectations were met.
    *
-   * <p>If no PAssert is used, it'll immediately return Optional.of(true)
-   * when metrics become available. But pipeline may fail later.
+   * <p>If the pipeline is not in a failed/cancelled state and no PAsserts were used
+   * within the pipeline, then this method will state that all PAsserts succeeded.
    *
-   * @return Optional.of(false) if job failed/cancelled or PAssert failed,
-   *         Optional.of(true) if number of success PAssert meet expects,
-   *         or Optional.absent() if metrics not available or not all
-   *         PAssert passed.
+   * @return Optional.of(false) if the job failed, was cancelled or if any PAssert
+   *         expectation was not met, true if all the PAssert expectations passed,
+   *         Optional.absent() if the metrics were inconclusive.
    */
   @VisibleForTesting
   Optional<Boolean> checkForPAssertSuccess(DataflowPipelineJob job, @Nullable JobMetrics metrics)
@@ -243,9 +242,9 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   }
 
   /**
-   * Check data watermarks of the streaming job. At least one watermark metric must exist.
+   * Check watermarks of the streaming job. At least one watermark metric must exist.
    *
-   * @return true if all watermarks are max, false otherwise.
+   * @return true if all watermarks are at max, false otherwise.
    */
   @VisibleForTesting
   boolean atMaxWatermark(DataflowPipelineJob job, JobMetrics metrics) {

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
@@ -19,8 +19,10 @@ package org.apache.beam.runners.dataflow.testing;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -220,8 +222,13 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    when(request.execute()).thenReturn(
-        generateMockMetricResponse(true /* success */, true /* tentative */));
+    when(request.execute())
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */))
+        .thenReturn(generateMockStreamingMetricResponse(
+            true /* hasWatermark */,
+            true /* maxWatermark */,
+            false /* multipleWatermarks */,
+            false /* multipleMaxWatermark */));
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     runner.run(p, mockRunner);
   }
@@ -401,7 +408,7 @@ public class TestDataflowRunnerTest {
             false /* multipleWatermarks */,
             false /* multipleMaxWatermark */));
     doReturn(State.RUNNING).when(job).getState();
-    assertEquals(Optional.absent(), runner.checkMaxWatermark(job));
+    assertFalse(runner.checkMaxWatermark(job));
   }
 
   @Test
@@ -419,7 +426,7 @@ public class TestDataflowRunnerTest {
             false /* multipleWatermarks */,
             false /* multipleMaxWatermark */));
     doReturn(State.RUNNING).when(job).getState();
-    assertEquals(Optional.of(true), runner.checkMaxWatermark(job));
+    assertTrue(runner.checkMaxWatermark(job));
   }
 
   @Test
@@ -437,7 +444,7 @@ public class TestDataflowRunnerTest {
             false /* multipleWatermarks */,
             false /* multipleMaxWatermark */));
     doReturn(State.RUNNING).when(job).getState();
-    assertEquals(Optional.absent(), runner.checkMaxWatermark(job));
+    assertFalse(runner.checkMaxWatermark(job));
   }
 
   @Test
@@ -455,7 +462,7 @@ public class TestDataflowRunnerTest {
             true /* multipleWatermarks */,
             true /* multipleMaxWatermark */));
     doReturn(State.RUNNING).when(job).getState();
-    assertEquals(Optional.of(true), runner.checkMaxWatermark(job));
+    assertTrue(runner.checkMaxWatermark(job));
   }
 
   @Test
@@ -473,7 +480,7 @@ public class TestDataflowRunnerTest {
             true /* multipleWatermarks */,
             false /* multipleMaxWatermark */));
     doReturn(State.RUNNING).when(job).getState();
-    assertEquals(Optional.absent(), runner.checkMaxWatermark(job));
+    assertFalse(runner.checkMaxWatermark(job));
   }
 
   @Test
@@ -489,7 +496,6 @@ public class TestDataflowRunnerTest {
         generateMockMetricResponse(true /* success */, false /* tentative */));
     doReturn(State.FAILED).when(job).getState();
     assertEquals(Optional.of(false), runner.checkForSuccess(job));
-    assertEquals(Optional.of(false), runner.checkMaxWatermark(job));
   }
 
   @Test
@@ -580,8 +586,13 @@ public class TestDataflowRunnerTest {
     when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
         .thenReturn(State.DONE);
 
-    when(request.execute()).thenReturn(
-        generateMockMetricResponse(true /* success */, true /* tentative */));
+    when(request.execute())
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */))
+        .thenReturn(generateMockStreamingMetricResponse(
+            true /* hasWatermark */,
+            true /* maxWatermark */,
+            false /* multipleWatermarks */,
+            false /* multipleMaxWatermark */));
     runner.run(p, mockRunner);
   }
 
@@ -630,8 +641,13 @@ public class TestDataflowRunnerTest {
     when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
         .thenReturn(State.DONE);
 
-    when(request.execute()).thenReturn(
-        generateMockMetricResponse(true /* success */, true /* tentative */));
+    when(request.execute())
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */))
+        .thenReturn(generateMockStreamingMetricResponse(
+            true /* hasWatermark */,
+            true /* maxWatermark */,
+            false /* multipleWatermarks */,
+            false /* multipleMaxWatermark */));
     runner.run(p, mockRunner);
   }
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
@@ -354,7 +354,7 @@ public class TestDataflowRunnerTest {
     doReturn(State.DONE).when(job).getState();
     JobMetrics metrics = buildJobMetrics(
         generateMockMetrics(true /* success */, true /* tentative */));
-    assertEquals(Optional.of(true), runner.checkForSuccess(job, metrics));
+    assertEquals(Optional.of(true), runner.checkForPAssertSuccess(job, metrics));
   }
 
   @Test
@@ -369,7 +369,7 @@ public class TestDataflowRunnerTest {
     doReturn(State.DONE).when(job).getState();
     JobMetrics metrics = buildJobMetrics(
         generateMockMetrics(false /* success */, true /* tentative */));
-    assertEquals(Optional.of(false), runner.checkForSuccess(job, metrics));
+    assertEquals(Optional.of(false), runner.checkForPAssertSuccess(job, metrics));
   }
 
   @Test
@@ -384,7 +384,7 @@ public class TestDataflowRunnerTest {
     doReturn(State.RUNNING).when(job).getState();
     JobMetrics metrics = buildJobMetrics(
         generateMockMetrics(true /* success */, false /* tentative */));
-    assertEquals(Optional.absent(), runner.checkForSuccess(job, metrics));
+    assertEquals(Optional.absent(), runner.checkForPAssertSuccess(job, metrics));
   }
 
   @Test
@@ -484,7 +484,7 @@ public class TestDataflowRunnerTest {
 
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     doReturn(State.FAILED).when(job).getState();
-    assertEquals(Optional.of(false), runner.checkForSuccess(job, null /* metrics */));
+    assertEquals(Optional.of(false), runner.checkForPAssertSuccess(job, null /* metrics */));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
@@ -141,7 +141,7 @@ public class TestDataflowRunnerTest {
 
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     assertEquals(mockJob, runner.run(p, mockRunner));
   }
 
@@ -161,7 +161,7 @@ public class TestDataflowRunnerTest {
 
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        false /* tentative */, null /* otherMetrics */));
+        false /* tentative */, null /* additionalMetrics */));
     try {
       runner.run(p, mockRunner);
     } catch (AssertionError expected) {
@@ -200,7 +200,7 @@ public class TestDataflowRunnerTest {
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
     when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     try {
       runner.run(p, mockRunner);
@@ -273,7 +273,7 @@ public class TestDataflowRunnerTest {
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
     when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     try {
       runner.run(p, mockRunner);
@@ -286,13 +286,13 @@ public class TestDataflowRunnerTest {
   }
 
   private LowLevelHttpResponse generateMockMetricResponse(boolean success, boolean tentative,
-                                                          Map<String, BigDecimal> otherMetrics)
+                                                          Map<String, BigDecimal> additionalMetrics)
       throws Exception {
     MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
     response.setContentType(Json.MEDIA_TYPE);
     List<MetricUpdate> metrics = generateMockMetrics(success, tentative);
-    if (otherMetrics != null && !otherMetrics.isEmpty()) {
-      metrics.addAll(generateMockStreamingMetrics(otherMetrics));
+    if (additionalMetrics != null && !additionalMetrics.isEmpty()) {
+      metrics.addAll(generateMockStreamingMetrics(additionalMetrics));
     }
     JobMetrics jobMetrics = buildJobMetrics(metrics);
     response.setContent(jobMetrics.toPrettyString());
@@ -402,7 +402,7 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testCheckMaxWatermarkWithSingleMaxWatermark() throws IOException {
+  public void testCheckMaxWatermarkWithSingleWatermarkAtMax() throws IOException {
     DataflowPipelineJob job =
         spy(new DataflowPipelineJob("test-project", "test-job", options, null));
     Pipeline p = TestPipeline.create(options);
@@ -416,7 +416,7 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testCheckMaxWatermarkWithSingleWatermarkNotMax() throws IOException {
+  public void testCheckMaxWatermarkWithSingleWatermarkNotAtMax() throws IOException {
     DataflowPipelineJob job =
         spy(new DataflowPipelineJob("test-project", "test-job", options, null));
     Pipeline p = TestPipeline.create(options);
@@ -430,7 +430,7 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testCheckMaxWatermarkWithMultipleMaxWatermark() throws IOException {
+  public void testCheckMaxWatermarkWithMultipleWatermarksAtMax() throws IOException {
     DataflowPipelineJob job =
         spy(new DataflowPipelineJob("test-project", "test-job", options, null));
     Pipeline p = TestPipeline.create(options);
@@ -445,7 +445,7 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testCheckMaxWatermarkWithMaxAndNotMaxWatermarkMixed() throws IOException {
+  public void testCheckMaxWatermarkWithMultipleMaxAndNotMaxWatermarks() throws IOException {
     DataflowPipelineJob job =
         spy(new DataflowPipelineJob("test-project", "test-job", options, null));
     Pipeline p = TestPipeline.create(options);
@@ -460,7 +460,7 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testCheckMaxWatermarkIgnoreUnrelatedMatrics() throws IOException {
+  public void testCheckMaxWatermarkIgnoresUnrelatedMatrics() throws IOException {
     DataflowPipelineJob job =
         spy(new DataflowPipelineJob("test-project", "test-job", options, null));
     Pipeline p = TestPipeline.create(options);
@@ -516,7 +516,7 @@ public class TestDataflowRunnerTest {
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
     when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     try {
       runner.run(p, mockRunner);
@@ -531,14 +531,14 @@ public class TestDataflowRunnerTest {
   }
 
   @Test
-  public void testGetJobMetricsThatSucceed() throws Exception {
+  public void testGetJobMetricsThatSucceeds() throws Exception {
     DataflowPipelineJob job =
         spy(new DataflowPipelineJob("test-project", "test-job", options, null));
     Pipeline p = TestPipeline.create(options);
     p.apply(Create.of(1, 2, 3));
 
     when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     TestDataflowRunner runner = (TestDataflowRunner) p.getRunner();
     JobMetrics metrics = runner.getJobMetrics(job);
 
@@ -578,7 +578,7 @@ public class TestDataflowRunnerTest {
         .setOnCreateMatcher(new TestSuccessMatcher(mockJob, 0));
 
     when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     runner.run(p, mockRunner);
   }
 
@@ -629,7 +629,7 @@ public class TestDataflowRunnerTest {
         .setOnSuccessMatcher(new TestSuccessMatcher(mockJob, 1));
 
     when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     runner.run(p, mockRunner);
   }
 
@@ -680,7 +680,7 @@ public class TestDataflowRunnerTest {
         .setOnSuccessMatcher(new TestFailureMatcher());
 
     when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* otherMetrics */));
+        true /* tentative */, null /* additionalMetrics */));
     try {
       runner.run(p, mockRunner);
     } catch (AssertionError expected) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+/**
+ * Category tag for validation tests which are expected running in streaming mode.
+ */
+public interface StreamingIT {
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
@@ -21,8 +21,8 @@ package org.apache.beam.sdk.testing;
  * Category tag for validation tests which are expected running in streaming mode.
  * Example usage:
  * <pre><code>
- *     {@literal @}Test
- *     {@literal @}Category(StreamingIT.class)
+ *    {@literal @}Test
+ *    {@literal @}Category(StreamingIT.class)
  *     public void testStreamingPipeline() {
  *       StreamingOptions options = ...;
  *       options.setStreaming(true);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
@@ -18,8 +18,8 @@
 package org.apache.beam.sdk.testing;
 
 /**
- * Category tag for validation tests which are expected running in streaming mode.
- * Example usage:
+ * Category tag that is used to validate tests which are expected running
+ * in streaming mode. Example usage:
  * <pre><code>
  *    {@literal @}Test
  *    {@literal @}Category(StreamingIT.class)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
@@ -19,6 +19,16 @@ package org.apache.beam.sdk.testing;
 
 /**
  * Category tag for validation tests which are expected running in streaming mode.
+ * Example usage:
+ * <pre><code>
+ *     {@literal @}Test
+ *     {@literal @}Category(StreamingIT.class)
+ *     public void testStreamingPipeline() {
+ *       StreamingOptions options = ...;
+ *       options.setStreaming(true);
+ *       StreamingPipeline.main(...);
+ *     }
+ * </code></pre>
  */
 public interface StreamingIT {
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/StreamingIT.java
@@ -18,7 +18,7 @@
 package org.apache.beam.sdk.testing;
 
 /**
- * Category tag that is used to validate tests which are expected running
+ * Category tag used to mark tests which execute using the Dataflow runner
  * in streaming mode. Example usage:
  * <pre><code>
  *    {@literal @}Test
@@ -30,5 +30,6 @@ package org.apache.beam.sdk.testing;
  *     }
  * </code></pre>
  */
+@Deprecated
 public interface StreamingIT {
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

 - Add checkMaxWatermark() function in TestDataflowRunner, so that when testing on streaming pipeline with bounded input, the job can be canceled as soon as all watermark reach to max value (by default is -2). Then, verification steps can be executed.
 - Add WindowedWordCountIT as a basic example of testing on streaming job. This test will be executed in Jenkins pre/post-commit build.
 - Add non-terminated check before canceling steaming job.
 - Add StreamingIT category for streaming integration test and a maven profile that is used to disable streaming integration tests if people only want to execute batch tests.

TODO:
 - Create verifier for WindowedWordCountIT. (BigQuery verifier)