### PR TITLE
Remove EvaluationContext as a forApplication Parameter

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -245,7 +245,7 @@ public class DirectRunner
     // independent executor service for each run
     ExecutorService executorService = executorServiceSupplier.get();
 
-    TransformEvaluatorRegistry registry = TransformEvaluatorRegistry.defaultRegistry();
+    TransformEvaluatorRegistry registry = TransformEvaluatorRegistry.defaultRegistry(context);
     PipelineExecutor executor =
         ExecutorServiceParallelExecutor.create(
             executorService,

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -189,7 +189,6 @@ final class ExecutorServiceParallelExecutor implements PipelineExecutor {
         TransformExecutor.create(
             registry,
             enforcements,
-            evaluationContext,
             bundle,
             transform,
             onComplete,

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/FlattenEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/FlattenEvaluatorFactory.java
@@ -32,14 +32,20 @@ import org.apache.beam.sdk.values.PCollectionList;
  * {@link PTransform}.
  */
 class FlattenEvaluatorFactory implements TransformEvaluatorFactory {
+  private final EvaluationContext evaluationContext;
+
+  FlattenEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
+  }
+
   @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
-      CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) {
+      CommittedBundle<?> inputBundle
+      ) {
     @SuppressWarnings({"cast", "unchecked", "rawtypes"})
     TransformEvaluator<InputT> evaluator = (TransformEvaluator<InputT>) createInMemoryEvaluator(
-            (AppliedPTransform) application, inputBundle, evaluationContext);
+            (AppliedPTransform) application, inputBundle);
     return evaluator;
   }
 
@@ -50,8 +56,7 @@ class FlattenEvaluatorFactory implements TransformEvaluatorFactory {
       final AppliedPTransform<
               PCollectionList<InputT>, PCollection<InputT>, FlattenPCollectionList<InputT>>
           application,
-      final CommittedBundle<InputT> inputBundle,
-      final EvaluationContext evaluationContext) {
+      final CommittedBundle<InputT> inputBundle) {
     if (inputBundle == null) {
       // it is impossible to call processElement on a flatten with no input bundle. A Flatten with
       // no input bundle occurs as an output of Flatten.pcollections(PCollectionList.empty())

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupAlsoByWindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupAlsoByWindowEvaluatorFactory.java
@@ -47,15 +47,20 @@ import org.apache.beam.sdk.values.TupleTag;
  * {@link GroupByKeyOnly} {@link PTransform}.
  */
 class GroupAlsoByWindowEvaluatorFactory implements TransformEvaluatorFactory {
+  private final EvaluationContext evaluationContext;
+
+  GroupAlsoByWindowEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
+  }
+
   @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
-      CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) {
+      CommittedBundle<?> inputBundle) {
     @SuppressWarnings({"cast", "unchecked", "rawtypes"})
     TransformEvaluator<InputT> evaluator =
         createEvaluator(
-            (AppliedPTransform) application, (CommittedBundle) inputBundle, evaluationContext);
+            (AppliedPTransform) application, (CommittedBundle) inputBundle);
     return evaluator;
   }
 
@@ -68,8 +73,7 @@ class GroupAlsoByWindowEvaluatorFactory implements TransformEvaluatorFactory {
               PCollection<KV<K, Iterable<V>>>,
               DirectGroupAlsoByWindow<K, V>>
           application,
-      CommittedBundle<KeyedWorkItem<K, V>> inputBundle,
-      EvaluationContext evaluationContext) {
+      CommittedBundle<KeyedWorkItem<K, V>> inputBundle) {
     return new GroupAlsoByWindowEvaluator<>(
         evaluationContext, inputBundle, application);
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
@@ -47,15 +47,20 @@ import org.apache.beam.sdk.values.PCollection;
  * {@link GroupByKeyOnly} {@link PTransform}.
  */
 class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
+  private final EvaluationContext evaluationContext;
+
+  GroupByKeyOnlyEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
+  }
+
   @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
-      CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) {
+      CommittedBundle<?> inputBundle) {
     @SuppressWarnings({"cast", "unchecked", "rawtypes"})
     TransformEvaluator<InputT> evaluator =
         createEvaluator(
-            (AppliedPTransform) application, (CommittedBundle) inputBundle, evaluationContext);
+            (AppliedPTransform) application, (CommittedBundle) inputBundle);
     return evaluator;
   }
 
@@ -68,8 +73,7 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
           PCollection<KeyedWorkItem<K, V>>,
           DirectGroupByKeyOnly<K, V>>
           application,
-      final CommittedBundle<KV<K, WindowedValue<V>>> inputBundle,
-      final EvaluationContext evaluationContext) {
+      final CommittedBundle<KV<K, WindowedValue<V>>> inputBundle) {
     return new GroupByKeyOnlyEvaluator<>(evaluationContext, inputBundle, application);
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoMultiEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoMultiEvaluatorFactory.java
@@ -41,8 +41,10 @@ class ParDoMultiEvaluatorFactory implements TransformEvaluatorFactory {
   private static final Logger LOG = LoggerFactory.getLogger(ParDoMultiEvaluatorFactory.class);
   private final LoadingCache<AppliedPTransform<?, ?, BoundMulti<?, ?>>, DoFnLifecycleManager>
       fnClones;
+  private final EvaluationContext evaluationContext;
 
-  public ParDoMultiEvaluatorFactory() {
+  public ParDoMultiEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
     fnClones = CacheBuilder.newBuilder()
         .build(new CacheLoader<AppliedPTransform<?, ?, BoundMulti<?, ?>>, DoFnLifecycleManager>() {
           @Override
@@ -55,12 +57,10 @@ class ParDoMultiEvaluatorFactory implements TransformEvaluatorFactory {
 
   @Override
   public <T> TransformEvaluator<T> forApplication(
-      AppliedPTransform<?, ?, ?> application,
-      CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) throws Exception {
+      AppliedPTransform<?, ?, ?> application, CommittedBundle<?> inputBundle) throws Exception {
     @SuppressWarnings({"unchecked", "rawtypes"})
     TransformEvaluator<T> evaluator =
-        createMultiEvaluator((AppliedPTransform) application, inputBundle, evaluationContext);
+        createMultiEvaluator((AppliedPTransform) application, inputBundle);
     return evaluator;
   }
 
@@ -71,8 +71,7 @@ class ParDoMultiEvaluatorFactory implements TransformEvaluatorFactory {
 
   private <InT, OuT> TransformEvaluator<InT> createMultiEvaluator(
       AppliedPTransform<PCollection<InT>, PCollectionTuple, BoundMulti<InT, OuT>> application,
-      CommittedBundle<InT> inputBundle,
-      EvaluationContext evaluationContext) throws Exception {
+      CommittedBundle<InT> inputBundle) throws Exception {
     Map<TupleTag<?>, PCollection<?>> outputs = application.getOutput().getAll();
 
     DoFnLifecycleManager fnLocal = fnClones.getUnchecked((AppliedPTransform) application);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoSingleEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoSingleEvaluatorFactory.java
@@ -40,8 +40,10 @@ import org.slf4j.LoggerFactory;
 class ParDoSingleEvaluatorFactory implements TransformEvaluatorFactory {
   private static final Logger LOG = LoggerFactory.getLogger(ParDoSingleEvaluatorFactory.class);
   private final LoadingCache<AppliedPTransform<?, ?, Bound<?, ?>>, DoFnLifecycleManager> fnClones;
+  private final EvaluationContext evaluationContext;
 
-  public ParDoSingleEvaluatorFactory() {
+  public ParDoSingleEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
     fnClones =
         CacheBuilder.newBuilder()
             .build(
@@ -57,11 +59,10 @@ class ParDoSingleEvaluatorFactory implements TransformEvaluatorFactory {
   @Override
   public <T> TransformEvaluator<T> forApplication(
       final AppliedPTransform<?, ?, ?> application,
-      CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) throws Exception {
+      CommittedBundle<?> inputBundle) throws Exception {
     @SuppressWarnings({"unchecked", "rawtypes"})
     TransformEvaluator<T> evaluator =
-        createSingleEvaluator((AppliedPTransform) application, inputBundle, evaluationContext);
+        createSingleEvaluator((AppliedPTransform) application, inputBundle);
     return evaluator;
   }
 
@@ -73,8 +74,8 @@ class ParDoSingleEvaluatorFactory implements TransformEvaluatorFactory {
   private <InputT, OutputT> TransformEvaluator<InputT> createSingleEvaluator(
       AppliedPTransform<PCollection<InputT>, PCollection<OutputT>, Bound<InputT, OutputT>>
           application,
-      CommittedBundle<InputT> inputBundle,
-      EvaluationContext evaluationContext) throws Exception {
+      CommittedBundle<InputT> inputBundle)
+      throws Exception {
     TupleTag<OutputT> mainOutputTag = new TupleTag<>("out");
     String stepName = evaluationContext.getStepName(application);
     DirectStepContext stepContext =

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
@@ -53,15 +53,19 @@ import org.joda.time.Instant;
 class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {
   private final KeyedResourcePool<AppliedPTransform<?, ?, ?>, Evaluator<?>> evaluators =
       LockedKeyedResourcePool.create();
+  private final EvaluationContext evaluationContext;
+
+  TestStreamEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
+  }
 
   @Nullable
   @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
-      @Nullable CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext)
+      @Nullable CommittedBundle<?> inputBundle)
       throws Exception {
-    return createEvaluator((AppliedPTransform) application, evaluationContext);
+    return createEvaluator((AppliedPTransform) application);
   }
 
   @Override
@@ -76,8 +80,7 @@ class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {
    * a separate collection of events cannot be created.
    */
   private <InputT, OutputT> TransformEvaluator<? super InputT> createEvaluator(
-      AppliedPTransform<PBegin, PCollection<OutputT>, TestStream<OutputT>> application,
-      EvaluationContext evaluationContext)
+      AppliedPTransform<PBegin, PCollection<OutputT>, TestStream<OutputT>> application)
       throws ExecutionException {
     return evaluators
         .tryAcquire(application, new CreateEvaluator<>(application, evaluationContext, evaluators))

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorFactory.java
@@ -35,26 +35,26 @@ public interface TransformEvaluatorFactory {
   /**
    * Create a new {@link TransformEvaluator} for the application of the {@link PTransform}.
    *
-   * <p>Any work that must be done before input elements are processed (such as calling
-   * {@code DoFn.StartBundle}) must be done before the
-   * {@link TransformEvaluator} is made available to the caller.
+   * <p>Any work that must be done before input elements are processed (such as calling {@code
+   * DoFn.StartBundle}) must be done before the {@link TransformEvaluator} is made available to the
+   * caller.
    *
    * <p>May return null if the application cannot produce an evaluator (for example, it is a
    * {@link Read} {@link PTransform} where all evaluators are in-use).
    *
    * @return An evaluator capable of processing the transform on the bundle, or null if no evaluator
-   * can be constructed.
+   *     can be constructed.
    * @throws Exception whenever constructing the underlying evaluator throws an exception
    */
-  @Nullable <InputT> TransformEvaluator<InputT> forApplication(
-      AppliedPTransform<?, ?, ?> application, @Nullable CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) throws Exception;
+  @Nullable
+  <InputT> TransformEvaluator<InputT> forApplication(
+      AppliedPTransform<?, ?, ?> application, @Nullable CommittedBundle<?> inputBundle)
+      throws Exception;
 
   /**
-   * Cleans up any state maintained by this {@link TransformEvaluatorFactory}. Called after a
-   * {@link Pipeline} is shut down. No more calls to
-   * {@link #forApplication(AppliedPTransform, CommittedBundle, EvaluationContext)} will be made
-   * after a call to {@link #cleanup()}.
+   * Cleans up any state maintained by this {@link TransformEvaluatorFactory}. Called after a {@link
+   * Pipeline} is shut down. No more calls to {@link #forApplication(AppliedPTransform,
+   * CommittedBundle)} will be made after a call to {@link #cleanup()}.
    */
   void cleanup() throws Exception;
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutor.java
@@ -40,7 +40,6 @@ class TransformExecutor<T> implements Runnable {
   public static <T> TransformExecutor<T> create(
       TransformEvaluatorFactory factory,
       Iterable<? extends ModelEnforcementFactory> modelEnforcements,
-      EvaluationContext evaluationContext,
       CommittedBundle<T> inputBundle,
       AppliedPTransform<?, ?, ?> transform,
       CompletionCallback completionCallback,
@@ -48,7 +47,6 @@ class TransformExecutor<T> implements Runnable {
     return new TransformExecutor<>(
         factory,
         modelEnforcements,
-        evaluationContext,
         inputBundle,
         transform,
         completionCallback,
@@ -57,8 +55,6 @@ class TransformExecutor<T> implements Runnable {
 
   private final TransformEvaluatorFactory evaluatorFactory;
   private final Iterable<? extends ModelEnforcementFactory> modelEnforcements;
-
-  private final EvaluationContext evaluationContext;
 
   /** The transform that will be evaluated. */
   private final AppliedPTransform<?, ?, ?> transform;
@@ -73,14 +69,12 @@ class TransformExecutor<T> implements Runnable {
   private TransformExecutor(
       TransformEvaluatorFactory factory,
       Iterable<? extends ModelEnforcementFactory> modelEnforcements,
-      EvaluationContext evaluationContext,
       CommittedBundle<T> inputBundle,
       AppliedPTransform<?, ?, ?> transform,
       CompletionCallback completionCallback,
       TransformExecutorService transformEvaluationState) {
     this.evaluatorFactory = factory;
     this.modelEnforcements = modelEnforcements;
-    this.evaluationContext = evaluationContext;
 
     this.inputBundle = inputBundle;
     this.transform = transform;
@@ -107,7 +101,7 @@ class TransformExecutor<T> implements Runnable {
         enforcements.add(enforcement);
       }
       TransformEvaluator<T> evaluator =
-          evaluatorFactory.forApplication(transform, inputBundle, evaluationContext);
+          evaluatorFactory.forApplication(transform, inputBundle);
       if (evaluator == null) {
         onComplete.handleEmpty(transform);
         // Nothing to do

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ViewEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ViewEvaluatorFactory.java
@@ -47,14 +47,19 @@ import org.apache.beam.sdk.values.POutput;
  * written.
  */
 class ViewEvaluatorFactory implements TransformEvaluatorFactory {
+  private final EvaluationContext context;
+
+  ViewEvaluatorFactory(EvaluationContext context) {
+    this.context = context;
+  }
+
   @Override
   public <T> TransformEvaluator<T> forApplication(
       AppliedPTransform<?, ?, ?> application,
-      DirectRunner.CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) {
+      DirectRunner.CommittedBundle<?> inputBundle) {
     @SuppressWarnings({"cast", "unchecked", "rawtypes"})
     TransformEvaluator<T> evaluator = createEvaluator(
-            (AppliedPTransform) application, evaluationContext);
+            (AppliedPTransform) application);
     return evaluator;
   }
 
@@ -63,8 +68,7 @@ class ViewEvaluatorFactory implements TransformEvaluatorFactory {
 
   private <InT, OuT> TransformEvaluator<Iterable<InT>> createEvaluator(
       final AppliedPTransform<PCollection<Iterable<InT>>, PCollectionView<OuT>, WriteView<InT, OuT>>
-          application,
-      EvaluationContext context) {
+          application) {
     PCollection<Iterable<InT>> input = application.getInput();
     final PCollectionViewWriter<InT, OuT> writer =
         context.createPCollectionViewWriter(input, application.getOutput());

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -38,21 +38,25 @@ import org.joda.time.Instant;
  * {@link Bound Window.Bound} primitive {@link PTransform}.
  */
 class WindowEvaluatorFactory implements TransformEvaluatorFactory {
+  private final EvaluationContext evaluationContext;
+
+  WindowEvaluatorFactory(EvaluationContext evaluationContext) {
+    this.evaluationContext = evaluationContext;
+  }
 
   @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application,
-      @Nullable CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext)
+      @Nullable CommittedBundle<?> inputBundle
+ )
       throws Exception {
     return createTransformEvaluator(
-        (AppliedPTransform) application, inputBundle, evaluationContext);
+        (AppliedPTransform) application, inputBundle);
   }
 
   private <InputT> TransformEvaluator<InputT> createTransformEvaluator(
       AppliedPTransform<PCollection<InputT>, PCollection<InputT>, Window.Bound<InputT>> transform,
-      CommittedBundle<?> inputBundle,
-      EvaluationContext evaluationContext) {
+      CommittedBundle<?> inputBundle) {
     WindowFn<? super InputT, ?> fn = transform.getTransform().getWindowFn();
     UncommittedBundle<InputT> outputBundle =
         evaluationContext.createBundle(inputBundle, transform.getOutput());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
@@ -71,7 +71,7 @@ public class BoundedReadEvaluatorFactoryTest {
     TestPipeline p = TestPipeline.create();
     longs = p.apply(Read.from(source));
 
-    factory = new BoundedReadEvaluatorFactory();
+    factory = new BoundedReadEvaluatorFactory(context);
     bundleFactory = ImmutableListBundleFactory.create();
   }
 
@@ -81,7 +81,7 @@ public class BoundedReadEvaluatorFactoryTest {
     when(context.createRootBundle(longs)).thenReturn(output);
 
     TransformEvaluator<?> evaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
     TransformResult result = evaluator.finishBundle();
     assertThat(result.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
     assertThat(
@@ -101,7 +101,7 @@ public class BoundedReadEvaluatorFactoryTest {
     when(context.createRootBundle(longs)).thenReturn(output);
 
     TransformEvaluator<?> evaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
     TransformResult result = evaluator.finishBundle();
     assertThat(result.getWatermarkHold(), equalTo(BoundedWindow.TIMESTAMP_MAX_VALUE));
     Iterable<? extends WindowedValue<Long>> outputElements =
@@ -114,7 +114,7 @@ public class BoundedReadEvaluatorFactoryTest {
     UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
     when(context.createRootBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
     assertThat(secondEvaluator, nullValue());
   }
 
@@ -130,9 +130,9 @@ public class BoundedReadEvaluatorFactoryTest {
 
     // create both evaluators before finishing either.
     TransformEvaluator<?> evaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
     TransformEvaluator<?> secondEvaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
     assertThat(secondEvaluator, nullValue());
 
     TransformResult result = evaluator.finishBundle();
@@ -163,7 +163,7 @@ public class BoundedReadEvaluatorFactoryTest {
     UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
     when(context.createRootBundle(pcollection)).thenReturn(output);
 
-    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null, context);
+    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();
     CommittedBundle<Long> committed = output.commit(Instant.now());
     assertThat(committed.getElements(), containsInAnyOrder(gw(2L), gw(3L), gw(1L)));
@@ -181,7 +181,7 @@ public class BoundedReadEvaluatorFactoryTest {
     UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
     when(context.createRootBundle(pcollection)).thenReturn(output);
 
-    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null, context);
+    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();
     CommittedBundle<Long> committed = output.commit(Instant.now());
     assertThat(committed.getElements(), emptyIterable());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
@@ -67,14 +67,11 @@ public class FlattenEvaluatorFactoryTest {
     when(context.createBundle(leftBundle, flattened)).thenReturn(flattenedLeftBundle);
     when(context.createBundle(rightBundle, flattened)).thenReturn(flattenedRightBundle);
 
-    FlattenEvaluatorFactory factory = new FlattenEvaluatorFactory();
+    FlattenEvaluatorFactory factory = new FlattenEvaluatorFactory(context);
     TransformEvaluator<Integer> leftSideEvaluator =
-        factory.forApplication(flattened.getProducingTransformInternal(), leftBundle, context);
+        factory.forApplication(flattened.getProducingTransformInternal(), leftBundle);
     TransformEvaluator<Integer> rightSideEvaluator =
-        factory.forApplication(
-            flattened.getProducingTransformInternal(),
-            rightBundle,
-            context);
+        factory.forApplication(flattened.getProducingTransformInternal(), rightBundle);
 
     leftSideEvaluator.processElement(WindowedValue.valueInGlobalWindow(1));
     rightSideEvaluator.processElement(WindowedValue.valueInGlobalWindow(-1));
@@ -123,11 +120,11 @@ public class FlattenEvaluatorFactoryTest {
 
     PCollection<Integer> flattened = list.apply(Flatten.<Integer>pCollections());
 
-    EvaluationContext context = mock(EvaluationContext.class);
+    EvaluationContext evaluationContext = mock(EvaluationContext.class);
 
-    FlattenEvaluatorFactory factory = new FlattenEvaluatorFactory();
+    FlattenEvaluatorFactory factory = new FlattenEvaluatorFactory(evaluationContext);
     TransformEvaluator<Integer> emptyEvaluator =
-        factory.forApplication(flattened.getProducingTransformInternal(), null, context);
+        factory.forApplication(flattened.getProducingTransformInternal(), null);
 
     TransformResult leftSideResult = emptyEvaluator.finishBundle();
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyEvaluatorFactoryTest.java
@@ -99,9 +99,8 @@ public class GroupByKeyEvaluatorFactoryTest {
     Coder<String> keyCoder =
         ((KvCoder<String, WindowedValue<Integer>>) kvs.getCoder()).getKeyCoder();
     TransformEvaluator<KV<String, WindowedValue<Integer>>> evaluator =
-        new GroupByKeyOnlyEvaluatorFactory()
-            .forApplication(
-                groupedKvs.getProducingTransformInternal(), inputBundle, evaluationContext);
+        new GroupByKeyOnlyEvaluatorFactory(evaluationContext)
+            .forApplication(groupedKvs.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInEmptyWindows(gwValue(firstFoo)));
     evaluator.processElement(WindowedValue.valueInEmptyWindows(gwValue(secondFoo)));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactoryTest.java
@@ -101,9 +101,9 @@ public class GroupByKeyOnlyEvaluatorFactoryTest {
     Coder<String> keyCoder =
         ((KvCoder<String, WindowedValue<Integer>>) kvs.getCoder()).getKeyCoder();
     TransformEvaluator<KV<String, WindowedValue<Integer>>> evaluator =
-        new GroupByKeyOnlyEvaluatorFactory()
+        new GroupByKeyOnlyEvaluatorFactory(evaluationContext)
             .forApplication(
-                groupedKvs.getProducingTransformInternal(), inputBundle, evaluationContext);
+                groupedKvs.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInEmptyWindows(gwValue(firstFoo)));
     evaluator.processElement(WindowedValue.valueInEmptyWindows(gwValue(secondFoo)));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoMultiEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoMultiEvaluatorFactoryTest.java
@@ -119,9 +119,9 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     TransformEvaluator<String> evaluator =
-        new ParDoMultiEvaluatorFactory()
+        new ParDoMultiEvaluatorFactory(evaluationContext)
             .forApplication(
-                mainOutput.getProducingTransformInternal(), inputBundle, evaluationContext);
+                mainOutput.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(
@@ -206,9 +206,9 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     TransformEvaluator<String> evaluator =
-        new ParDoMultiEvaluatorFactory()
+        new ParDoMultiEvaluatorFactory(evaluationContext)
             .forApplication(
-                mainOutput.getProducingTransformInternal(), inputBundle, evaluationContext);
+                mainOutput.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(
@@ -300,9 +300,9 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     TransformEvaluator<String> evaluator =
-        new ParDoMultiEvaluatorFactory()
+        new ParDoMultiEvaluatorFactory(evaluationContext)
             .forApplication(
-                mainOutput.getProducingTransformInternal(), inputBundle, evaluationContext);
+                mainOutput.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(
@@ -413,9 +413,9 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     TransformEvaluator<String> evaluator =
-        new ParDoMultiEvaluatorFactory()
+        new ParDoMultiEvaluatorFactory(evaluationContext)
             .forApplication(
-                mainOutput.getProducingTransformInternal(), inputBundle, evaluationContext);
+                mainOutput.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoSingleEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoSingleEvaluatorFactoryTest.java
@@ -95,9 +95,9 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     org.apache.beam.runners.direct.TransformEvaluator<String> evaluator =
-        new ParDoSingleEvaluatorFactory()
+        new ParDoSingleEvaluatorFactory(evaluationContext)
             .forApplication(
-                collection.getProducingTransformInternal(), inputBundle, evaluationContext);
+                collection.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(
@@ -149,9 +149,9 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     TransformEvaluator<String> evaluator =
-        new ParDoSingleEvaluatorFactory()
+        new ParDoSingleEvaluatorFactory(evaluationContext)
             .forApplication(
-                collection.getProducingTransformInternal(), inputBundle, evaluationContext);
+                collection.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(
@@ -217,9 +217,9 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     org.apache.beam.runners.direct.TransformEvaluator<String> evaluator =
-        new ParDoSingleEvaluatorFactory()
+        new ParDoSingleEvaluatorFactory(evaluationContext)
             .forApplication(
-                mainOutput.getProducingTransformInternal(), inputBundle, evaluationContext);
+                mainOutput.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
     evaluator.processElement(
@@ -320,9 +320,9 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     when(evaluationContext.getAggregatorMutator()).thenReturn(mutator);
 
     TransformEvaluator<String> evaluator =
-        new ParDoSingleEvaluatorFactory()
+        new ParDoSingleEvaluatorFactory(evaluationContext)
             .forApplication(
-                mainOutput.getProducingTransformInternal(), inputBundle, evaluationContext);
+                mainOutput.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(WindowedValue.valueInGlobalWindow("foo"));
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
@@ -60,10 +60,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-
-/**
- * Tests for {@link TransformExecutor}.
- */
+/** Tests for {@link TransformExecutor}. */
 @RunWith(JUnit4.class)
 public class TransformExecutorTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -114,14 +111,13 @@ public class TransformExecutorTest {
           }
         };
 
-    when(registry.forApplication(created.getProducingTransformInternal(), null, evaluationContext))
+    when(registry.forApplication(created.getProducingTransformInternal(), null))
         .thenReturn(evaluator);
 
     TransformExecutor<Object> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>emptyList(),
-            evaluationContext,
             null,
             created.getProducingTransformInternal(),
             completionCallback,
@@ -135,17 +131,16 @@ public class TransformExecutorTest {
 
   @Test
   public void nullTransformEvaluatorTerminates() throws Exception {
-    when(registry.forApplication(created.getProducingTransformInternal(),
-        null,
-        evaluationContext)).thenReturn(null);
+    when(registry.forApplication(created.getProducingTransformInternal(), null)).thenReturn(null);
 
-    TransformExecutor<Object> executor = TransformExecutor.create(registry,
-        Collections.<ModelEnforcementFactory>emptyList(),
-        evaluationContext,
-        null,
-        created.getProducingTransformInternal(),
-        completionCallback,
-        transformEvaluationState);
+    TransformExecutor<Object> executor =
+        TransformExecutor.create(
+            registry,
+            Collections.<ModelEnforcementFactory>emptyList(),
+            null,
+            created.getProducingTransformInternal(),
+            completionCallback,
+            transformEvaluationState);
     executor.run();
 
     assertThat(completionCallback.handledResult, is(nullValue()));
@@ -177,16 +172,13 @@ public class TransformExecutorTest {
     WindowedValue<String> third = WindowedValue.valueInGlobalWindow("third");
     CommittedBundle<String> inputBundle =
         bundleFactory.createRootBundle(created).add(foo).add(spam).add(third).commit(Instant.now());
-    when(
-            registry.<String>forApplication(
-                downstream.getProducingTransformInternal(), inputBundle, evaluationContext))
+    when(registry.<String>forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
     TransformExecutor<String> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>emptyList(),
-            evaluationContext,
             inputBundle,
             downstream.getProducingTransformInternal(),
             completionCallback,
@@ -222,16 +214,13 @@ public class TransformExecutorTest {
     WindowedValue<String> foo = WindowedValue.valueInGlobalWindow("foo");
     CommittedBundle<String> inputBundle =
         bundleFactory.createRootBundle(created).add(foo).commit(Instant.now());
-    when(
-            registry.<String>forApplication(
-                downstream.getProducingTransformInternal(), inputBundle, evaluationContext))
+    when(registry.<String>forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
     TransformExecutor<String> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>emptyList(),
-            evaluationContext,
             inputBundle,
             downstream.getProducingTransformInternal(),
             completionCallback,
@@ -260,16 +249,13 @@ public class TransformExecutorTest {
 
     CommittedBundle<String> inputBundle =
         bundleFactory.createRootBundle(created).commit(Instant.now());
-    when(
-            registry.<String>forApplication(
-                downstream.getProducingTransformInternal(), inputBundle, evaluationContext))
+    when(registry.<String>forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
     TransformExecutor<String> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>emptyList(),
-            evaluationContext,
             inputBundle,
             downstream.getProducingTransformInternal(),
             completionCallback,
@@ -303,14 +289,13 @@ public class TransformExecutorTest {
           }
         };
 
-    when(registry.forApplication(created.getProducingTransformInternal(), null, evaluationContext))
+    when(registry.forApplication(created.getProducingTransformInternal(), null))
         .thenReturn(evaluator);
 
     TransformExecutor<String> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>emptyList(),
-            evaluationContext,
             null,
             created.getProducingTransformInternal(),
             completionCallback,
@@ -332,8 +317,7 @@ public class TransformExecutorTest {
     TransformEvaluator<Object> evaluator =
         new TransformEvaluator<Object>() {
           @Override
-          public void processElement(WindowedValue<Object> element) throws Exception {
-          }
+          public void processElement(WindowedValue<Object> element) throws Exception {}
 
           @Override
           public TransformResult finishBundle() throws Exception {
@@ -345,9 +329,7 @@ public class TransformExecutorTest {
     WindowedValue<String> barElem = WindowedValue.valueInGlobalWindow("bar");
     CommittedBundle<String> inputBundle =
         bundleFactory.createRootBundle(created).add(fooElem).add(barElem).commit(Instant.now());
-    when(
-            registry.forApplication(
-                downstream.getProducingTransformInternal(), inputBundle, evaluationContext))
+    when(registry.forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
     TestEnforcementFactory enforcement = new TestEnforcementFactory();
@@ -355,7 +337,6 @@ public class TransformExecutorTest {
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>singleton(enforcement),
-            evaluationContext,
             inputBundle,
             downstream.getProducingTransformInternal(),
             completionCallback,
@@ -406,16 +387,13 @@ public class TransformExecutorTest {
     WindowedValue<byte[]> fooBytes = WindowedValue.valueInGlobalWindow("foo".getBytes());
     CommittedBundle<byte[]> inputBundle =
         bundleFactory.createRootBundle(pcBytes).add(fooBytes).commit(Instant.now());
-    when(
-            registry.forApplication(
-                pcBytes.getProducingTransformInternal(), inputBundle, evaluationContext))
+    when(registry.forApplication(pcBytes.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
     TransformExecutor<byte[]> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>singleton(ImmutabilityEnforcementFactory.create()),
-            evaluationContext,
             inputBundle,
             pcBytes.getProducingTransformInternal(),
             completionCallback,
@@ -465,16 +443,13 @@ public class TransformExecutorTest {
     WindowedValue<byte[]> fooBytes = WindowedValue.valueInGlobalWindow("foo".getBytes());
     CommittedBundle<byte[]> inputBundle =
         bundleFactory.createRootBundle(pcBytes).add(fooBytes).commit(Instant.now());
-    when(
-            registry.forApplication(
-                pcBytes.getProducingTransformInternal(), inputBundle, evaluationContext))
+    when(registry.forApplication(pcBytes.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
     TransformExecutor<byte[]> executor =
         TransformExecutor.create(
             registry,
             Collections.<ModelEnforcementFactory>singleton(ImmutabilityEnforcementFactory.create()),
-            evaluationContext,
             inputBundle,
             pcBytes.getProducingTransformInternal(),
             completionCallback,
@@ -500,18 +475,19 @@ public class TransformExecutorTest {
     }
 
     @Override
-    public CommittedResult handleResult(
-        CommittedBundle<?> inputBundle, TransformResult result) {
+    public CommittedResult handleResult(CommittedBundle<?> inputBundle, TransformResult result) {
       handledResult = result;
       onMethod.countDown();
-      @SuppressWarnings("rawtypes") Iterable unprocessedElements =
+      @SuppressWarnings("rawtypes")
+      Iterable unprocessedElements =
           result.getUnprocessedElements() == null
               ? Collections.emptyList()
               : result.getUnprocessedElements();
 
       CommittedBundle<?> unprocessedBundle =
           inputBundle == null ? null : inputBundle.withElements(unprocessedElements);
-      return CommittedResult.create(result,
+      return CommittedResult.create(
+          result,
           unprocessedBundle,
           Collections.<CommittedBundle<?>>emptyList(),
           EnumSet.noneOf(OutputType.class));
@@ -532,6 +508,7 @@ public class TransformExecutorTest {
 
   private static class TestEnforcementFactory implements ModelEnforcementFactory {
     private TestEnforcement<?> instance;
+
     @Override
     public <T> TestEnforcement<T> forBundle(
         CommittedBundle<T> input, AppliedPTransform<?, ?, ?> consumer) {

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
@@ -81,8 +81,8 @@ public class UnboundedReadEvaluatorFactoryTest {
     TestPipeline p = TestPipeline.create();
     longs = p.apply(Read.from(source));
 
-    factory = new UnboundedReadEvaluatorFactory();
     context = mock(EvaluationContext.class);
+    factory = new UnboundedReadEvaluatorFactory(context);
     output = bundleFactory.createRootBundle(longs);
     when(context.createRootBundle(longs)).thenReturn(output);
   }
@@ -90,7 +90,7 @@ public class UnboundedReadEvaluatorFactoryTest {
   @Test
   public void unboundedSourceInMemoryTransformEvaluatorProducesElements() throws Exception {
     TransformEvaluator<?> evaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
 
     TransformResult result = evaluator.finishBundle();
     assertThat(
@@ -109,7 +109,7 @@ public class UnboundedReadEvaluatorFactoryTest {
   @Test
   public void unboundedSourceInMemoryTransformEvaluatorMultipleSequentialCalls() throws Exception {
     TransformEvaluator<?> evaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
 
     TransformResult result = evaluator.finishBundle();
     assertThat(
@@ -123,7 +123,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
     when(context.createRootBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
     TransformResult secondResult = secondEvaluator.finishBundle();
     assertThat(
         secondResult.getWatermarkHold(),
@@ -150,7 +150,7 @@ public class UnboundedReadEvaluatorFactoryTest {
 
     UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
     when(context.createRootBundle(pcollection)).thenReturn(output);
-    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null, context);
+    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
 
     evaluator.finishBundle();
     assertThat(
@@ -159,7 +159,7 @@ public class UnboundedReadEvaluatorFactoryTest {
 
     UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
     when(context.createRootBundle(longs)).thenReturn(secondOutput);
-    TransformEvaluator<?> secondEvaluator = factory.forApplication(sourceTransform, null, context);
+    TransformEvaluator<?> secondEvaluator = factory.forApplication(sourceTransform, null);
     secondEvaluator.finishBundle();
     assertThat(
         secondOutput.commit(Instant.now()).getElements(),
@@ -182,7 +182,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     when(context.createRootBundle(pcollection)).thenReturn(output);
 
     for (int i = 0; i < UnboundedReadEvaluatorFactory.MAX_READER_REUSE_COUNT + 1; i++) {
-      TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null, context);
+      TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
       evaluator.finishBundle();
     }
     assertThat(TestUnboundedSource.readerClosedCount, equalTo(1));
@@ -200,14 +200,14 @@ public class UnboundedReadEvaluatorFactoryTest {
     UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
     when(context.createRootBundle(pcollection)).thenReturn(output);
 
-    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null, context);
+    TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();
     CommittedBundle<Long> committed = output.commit(Instant.now());
     assertThat(ImmutableList.copyOf(committed.getElements()), hasSize(3));
     assertThat(TestUnboundedSource.readerClosedCount, equalTo(0));
     assertThat(TestUnboundedSource.readerAdvancedCount, equalTo(4));
 
-    evaluator = factory.forApplication(sourceTransform, null, context);
+    evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();
     assertThat(TestUnboundedSource.readerClosedCount, equalTo(0));
     // Tried to advance again, even with no elements
@@ -226,7 +226,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     when(context.createRootBundle(pcollection)).thenReturn(output);
 
     for (int i = 0; i < 2 * UnboundedReadEvaluatorFactory.MAX_READER_REUSE_COUNT; i++) {
-      TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null, context);
+      TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
       evaluator.finishBundle();
     }
     assertThat(TestUnboundedSource.readerClosedCount, equalTo(0));
@@ -243,10 +243,10 @@ public class UnboundedReadEvaluatorFactoryTest {
   @Test
   public void unboundedSourceWithMultipleSimultaneousEvaluatorsIndependent() throws Exception {
     TransformEvaluator<?> evaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
 
     TransformEvaluator<?> secondEvaluator =
-        factory.forApplication(longs.getProducingTransformInternal(), null, context);
+        factory.forApplication(longs.getProducingTransformInternal(), null);
 
     assertThat(secondEvaluator, nullValue());
     TransformResult result = evaluator.finishBundle();

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
@@ -74,8 +74,8 @@ public class ViewEvaluatorFactoryTest {
     CommittedBundle<String> inputBundle =
         bundleFactory.createRootBundle(input).commit(Instant.now());
     TransformEvaluator<Iterable<String>> evaluator =
-        new ViewEvaluatorFactory()
-            .forApplication(view.getProducingTransformInternal(), inputBundle, context);
+        new ViewEvaluatorFactory(context)
+            .forApplication(view.getProducingTransformInternal(), inputBundle);
 
     evaluator.processElement(
         WindowedValue.<Iterable<String>>valueInGlobalWindow(ImmutableList.of("foo", "bar")));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -103,7 +103,7 @@ public class WindowEvaluatorFactoryTest {
     input = p.apply(Create.of(1L, 2L, 3L));
 
     bundleFactory = ImmutableListBundleFactory.create();
-    factory = new WindowEvaluatorFactory();
+    factory = new WindowEvaluatorFactory(evaluationContext);
   }
 
   @Test
@@ -308,9 +308,7 @@ public class WindowEvaluatorFactoryTest {
       throws Exception {
     TransformEvaluator<Long> evaluator =
         factory.forApplication(
-            AppliedPTransform.of("Window", input, windowed, windowTransform),
-            inputBundle,
-            evaluationContext);
+            AppliedPTransform.of("Window", input, windowed, windowTransform), inputBundle);
 
     evaluator.processElement(valueInGlobalWindow);
     evaluator.processElement(valueInGlobalAndTwoIntervalWindows);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Instead use it as a paraemmter to the Evaluator Factory. Evaluator
Factories must not be reused across pipelines, as they may be stateful.
Evaluation Contexts are representative of a single execution of a
Pipeline and thus can be passed at construction time.