### PR TITLE
[BEAM-618] Disallow NAN, INF and -INF invalid JSON values in bigquery exporter

### DIFF
--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -138,6 +138,7 @@ __all__ = [
 
 JSON_COMPLIANCE_ERROR = 'NAN, INF and -INF values are not JSON compliant.'
 
+
 class RowAsDictJsonCoder(coders.Coder):
   """A coder for a table row (represented as a dict) to/from a JSON string.
 

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -40,26 +40,21 @@ class TestRowAsDictJsonCoder(unittest.TestCase):
     test_value = {'s': 'abc', 'i': 123, 'f': 123.456, 'b': True}
     self.assertEqual(test_value, coder.decode(coder.encode(test_value)))
 
-  def test_invalid_json_nan(self):
+  def json_compliance_exception(self, value):
     with self.assertRaises(ValueError) as exn:
       coder = RowAsDictJsonCoder()
-      test_value = {'s': float('nan')}
+      test_value = {'s': value}
       self.assertEqual(test_value, coder.decode(coder.encode(test_value)))
       self.assertTrue(bigquery.JSON_COMPLIANCE_ERROR in exn.exception.message)
+
+  def test_invalid_json_nan(self):
+    self.json_compliance_exception(float('nan'))
 
   def test_invalid_json_inf(self):
-    with self.assertRaises(ValueError) as exn:
-      coder = RowAsDictJsonCoder()
-      test_value = {'s': float('inf')}
-      self.assertEqual(test_value, coder.decode(coder.encode(test_value)))
-      self.assertTrue(bigquery.JSON_COMPLIANCE_ERROR in exn.exception.message)
+    self.json_compliance_exception(float('inf'))
 
   def test_invalid_json_neg_inf(self):
-    with self.assertRaises(ValueError) as exn:
-      coder = RowAsDictJsonCoder()
-      test_value = {'s': float('-inf')}
-      self.assertEqual(test_value, coder.decode(coder.encode(test_value)))
-      self.assertTrue(bigquery.JSON_COMPLIANCE_ERROR in exn.exception.message)
+    self.json_compliance_exception(float('-inf'))
 
 
 class TestTableRowJsonCoder(unittest.TestCase):
@@ -92,7 +87,7 @@ class TestTableRowJsonCoder(unittest.TestCase):
     self.assertTrue(
         ctx.exception.message.startswith('The TableRowJsonCoder requires'))
 
-  def test_invalid_json_nan(self):
+  def json_compliance_exception(self, value):
     with self.assertRaises(ValueError) as exn:
       schema_definition = [('f', 'FLOAT')]
       schema = bigquery.TableSchema(
@@ -100,36 +95,18 @@ class TestTableRowJsonCoder(unittest.TestCase):
                   for k, v in schema_definition])
       coder = TableRowJsonCoder(table_schema=schema)
       test_row = bigquery.TableRow(
-          f=[bigquery.TableCell(v=to_json_value(e))
-             for e in [float('nan')]])
+          f=[bigquery.TableCell(v=to_json_value(value))])
       coder.encode(test_row)
       self.assertTrue(bigquery.JSON_COMPLIANCE_ERROR in exn.exception.message)
+
+  def test_invalid_json_nan(self):
+    self.json_compliance_exception(float('nan'))
 
   def test_invalid_json_inf(self):
-    with self.assertRaises(ValueError) as exn:
-      schema_definition = [('f', 'FLOAT')]
-      schema = bigquery.TableSchema(
-          fields=[bigquery.TableFieldSchema(name=k, type=v)
-                  for k, v in schema_definition])
-      coder = TableRowJsonCoder(table_schema=schema)
-      test_row = bigquery.TableRow(
-          f=[bigquery.TableCell(v=to_json_value(e))
-             for e in [float('inf')]])
-      coder.encode(test_row)
-      self.assertTrue(bigquery.JSON_COMPLIANCE_ERROR in exn.exception.message)
+    self.json_compliance_exception(float('inf'))
 
   def test_invalid_json_neg_inf(self):
-    with self.assertRaises(ValueError) as exn:
-      schema_definition = [('f', 'FLOAT')]
-      schema = bigquery.TableSchema(
-          fields=[bigquery.TableFieldSchema(name=k, type=v)
-                  for k, v in schema_definition])
-      coder = TableRowJsonCoder(table_schema=schema)
-      test_row = bigquery.TableRow(
-          f=[bigquery.TableCell(v=to_json_value(e))
-             for e in [float('-inf')]])
-      coder.encode(test_row)
-      self.assertTrue(bigquery.JSON_COMPLIANCE_ERROR in exn.exception.message)
+    self.json_compliance_exception(float('-inf'))
 
 
 class TestBigQuerySource(unittest.TestCase):

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -83,7 +83,6 @@ class TestTableRowJsonCoder(unittest.TestCase):
         test_row, TableRowJsonCoder().decode(coder.encode(test_row)))
 
   def test_row_and_no_schema(self):
-    schema_definition = [('f', 'FLOAT')]
     coder = TableRowJsonCoder()
     test_row = bigquery.TableRow(
         f=[bigquery.TableCell(v=to_json_value(e))

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -175,33 +175,6 @@ class TestBigQuerySink(unittest.TestCase):
             {'name': 'n', 'type': 'INTEGER', 'mode': 'NULLABLE'}]}),
         sink.schema_as_json())
 
-  def test_schema_as_json_invalid_nan(self):
-    sink = beam.io.BigQuerySink(
-        'dataset.table', schema='s:STRING, n:INTEGER')
-    self.assertEqual(
-        json.dumps({'fields': [
-            {'name': 's', 'type': 'STRING', 'mode': 'NULLABLE'},
-            {'name': 'n', 'type': 'INTEGER', 'mode': 'NULLABLE'}]}),
-        sink.schema_as_json())
-
-  def test_schema_as_json_invalid_inf(self):
-    sink = beam.io.BigQuerySink(
-        'dataset.table', schema='s:STRING, n:INTEGER')
-    self.assertEqual(
-        json.dumps({'fields': [
-            {'name': 's', 'type': 'STRING', 'mode': 'NULLABLE'},
-            {'name': 'n', 'type': 'INTEGER', 'mode': 'NULLABLE'}]}),
-        sink.schema_as_json())
-
-  def test_schema_as_json_invalid_n(self):
-    sink = beam.io.BigQuerySink(
-        'dataset.table', schema='s:STRING, n:INTEGER')
-    self.assertEqual(
-        json.dumps({'fields': [
-            {'name': 's', 'type': 'STRING', 'mode': 'NULLABLE'},
-            {'name': 'n', 'type': 'INTEGER', 'mode': 'NULLABLE'}]}),
-        sink.schema_as_json())
-
   def test_nested_schema_as_json(self):
     string_field = bigquery.TableFieldSchema(
         name='s', type='STRING', mode='NULLABLE', description='s description')


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Now exporting JSON will fail with invalid NAN, INF or -INF values.