### PR TITLE
[BEAM-630] Fixes wrong type name in generated code

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
@@ -397,7 +397,7 @@ public class DoFnInvokers {
     private Object describeType(Type type) {
       switch (type.getSort()) {
         case Type.OBJECT:
-          return type.getDescriptor();
+          return type.getInternalName();
         case Type.INT:
         case Type.BYTE:
         case Type.BOOLEAN:


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/BEAM-630 for details. We generated the wrong local variable type (with a semicolon - "descriptor" - rather than without a semicolon - "internal name"). It only failed when JVM was using sufficiently strict settings when verifying the bytecode.