### PR TITLE
[BEAM-<Jira issue #>] Use sys.executable and "-m pip" to ensure we use the same Python and …

### DIFF
--- a/sdks/python/apache_beam/utils/dependency.py
+++ b/sdks/python/apache_beam/utils/dependency.py
@@ -57,6 +57,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
 
 
@@ -194,7 +195,7 @@ def _populate_requirements_cache(requirements_file, cache_dir):
   # It will get the packages downloaded in the order they are presented in
   # the requirements file and will not download package dependencies.
   cmd_args = [
-      'pip', 'install', '--download', cache_dir,
+      sys.executable, '-m', 'pip', 'install', '--download', cache_dir,
       '-r', requirements_file,
       # Download from PyPI source distributions.
       '--no-binary', ':all:']
@@ -374,7 +375,7 @@ def _build_setup_package(setup_file, temp_dir, build_setup_args=None):
     os.chdir(os.path.dirname(setup_file))
     if build_setup_args is None:
       build_setup_args = [
-          'python', os.path.basename(setup_file),
+          sys.executable, os.path.basename(setup_file),
           'sdist', '--dist-dir', temp_dir]
     logging.info('Executing command: %s', build_setup_args)
     processes.check_call(build_setup_args)
@@ -460,7 +461,7 @@ def _download_pypi_sdk_package(temp_dir):
   version = pkg.get_distribution(GOOGLE_PACKAGE_NAME).version
   # Get a source distribution for the SDK package from PyPI.
   cmd_args = [
-      'pip', 'install', '--download', temp_dir,
+      sys.executable, '-m', 'pip', 'install', '--download', temp_dir,
       '%s==%s' % (GOOGLE_PACKAGE_NAME, version),
       '--no-binary', ':all:', '--no-deps']
   logging.info('Executing command: %s', cmd_args)


### PR DESCRIPTION
The current Python codebase runs subprocesses to call Python and pip. This is fine when not running in a virtualenv, or in a virtualenv that was activated through modifying the PATH. But it fails if running in a virtualenv either via an IDE (I use IntelliJ) or simply when invoking the Python from the virtualenv directly (which is a supported way of using a virtualenv).

Instead of relying on the PATH to invoke a Python and hope it's the same python executable as the one currently running, Python provides a `sys.executable` variable (which gives the full path of the currently running python) just for that purpose. Using that, the code will work in all the cases described above.

Also, the recommended way of calling `pip` is now `python -m pip`, which makes explicit which Python is being used. Switching over to that at the same time.