### PR TITLE
Deprecate TeardownPolicy for Dataflow service

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.java
@@ -192,7 +192,10 @@ public interface DataflowPipelineWorkerPoolOptions extends PipelineOptions {
 
   /**
    * The policy for tearing down the workers spun up by the service.
+   *
+   * @deprecated Dataflow Service will only support TEARDOWN_ALWAYS policy in the future.
    */
+  @Deprecated
   public enum TeardownPolicy {
     /**
      * All VMs created for a Dataflow job are deleted when the job finishes, regardless of whether


### PR DESCRIPTION
We are moving towards supporting only TEARDOWN_ALWAYS.

(This is a clone of https://github.com/pjesa/DataflowJavaSDK/commit/657ce1ff85caf44f7cf16d67b973055657980c2e on behalf of @pjesa)

R: @dhalperi 