### PR TITLE
[BEAM-625] Making Dataflow Python Materialized PCollection representation more efficient (5 of several).

### DIFF
--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -24,6 +24,7 @@ import unittest
 
 import apache_beam as beam
 
+from apache_beam import coders
 from apache_beam.io import iobase
 from apache_beam.io import range_trackers
 from apache_beam.transforms.util import assert_that
@@ -76,7 +77,7 @@ class LineSource(iobase.BoundedSource):
     return range_trackers.OffsetRangeTracker(start_position, stop_position)
 
   def default_output_coder(self):
-    return beam.coders.ToStringCoder()
+    return coders.BytesCoder()
 
 
 class SourcesTest(unittest.TestCase):


### PR DESCRIPTION
Changing ToStringCoder to BytesCoder since the former can't be used with sources (it can only be used with Sinks). Since we are opening files as 'rb', using BytesCoder makes sense.