### PR TITLE
[BEAM-643] Updates lint configurations to ignore generated files.

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -23,9 +23,6 @@ envlist = py27
 # pylint does not check the number of blank lines.
 select = E3
 
-# Skip auto generated files (windmill_pb2.py, windmill_service_pb2.py)
-exclude = windmill_pb2.py, windmill_service_pb2.py
-
 [testenv:py27]
 deps=
   pep8


### PR DESCRIPTION
Adds ability to ignore certain generated files when running pylint and pep8.
