### PR TITLE
Adds __all__ tags to source modules.

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -28,6 +28,8 @@ from apache_beam.io import filebasedsource
 from apache_beam.io.iobase import Read
 from apache_beam.transforms import PTransform
 
+__all__ = ['ReadFromAvro']
+
 
 class ReadFromAvro(PTransform):
   """A ``PTransform`` for reading avro files."""

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -26,6 +26,8 @@ from apache_beam.io.iobase import Read
 from apache_beam.io.iobase import Write
 from apache_beam.transforms import PTransform
 
+__all__ = ['ReadFromText', 'WriteToText']
+
 
 class _TextSource(filebasedsource.FileBasedSource):
   """A source for reading text files.


### PR DESCRIPTION
I added following to apache_beam/io/__init__.py recently.

from apache_beam.io.avroio import *
from apache_beam.io.textio import *

This seems to have broken following import pattern which might be used by some users.
from apache_beam.io import avroio

Adding __all_ tags to modules fixes this.

