### PR TITLE
Clear requirements cache directory before using it in test

### DIFF
--- a/sdks/python/apache_beam/utils/dependency.py
+++ b/sdks/python/apache_beam/utils/dependency.py
@@ -73,6 +73,8 @@ from apache_beam.utils.options import SetupOptions
 # Standard file names used for staging files.
 WORKFLOW_TARBALL_FILE = 'workflow.tar.gz'
 REQUIREMENTS_FILE = 'requirements.txt'
+REQUIREMENTS_CACHE_DIR = os.path.join(
+    tempfile.gettempdir(), 'dataflow-requirements-cache')
 EXTRA_PACKAGES_FILE = 'extra_packages.txt'
 
 GOOGLE_PACKAGE_NAME = 'google-cloud-dataflow'
@@ -256,7 +258,7 @@ def stage_job_resources(
     file_copy(setup_options.requirements_file, staged_path)
     resources.append(REQUIREMENTS_FILE)
     requirements_cache_path = (
-        os.path.join(tempfile.gettempdir(), 'dataflow-requirements-cache')
+        REQUIREMENTS_CACHE_DIR
         if setup_options.requirements_cache is None
         else setup_options.requirements_cache)
     # Populate cache with packages from requirements and stage the files

--- a/sdks/python/apache_beam/utils/dependency_test.py
+++ b/sdks/python/apache_beam/utils/dependency_test.py
@@ -105,9 +105,16 @@ class SetupTest(unittest.TestCase):
         [],
         dependency.stage_job_resources(options))
 
+  def test_default_requirements_cache_dir(self):
+    self.assertEqual(
+        os.path.join(tempfile.gettempdir(), 'dataflow-requirements-cache'),
+        dependency.REQUIREMENTS_CACHE_DIR)
+
   def test_with_requirements_file(self):
     staging_dir = tempfile.mkdtemp()
     source_dir = tempfile.mkdtemp()
+    if os.path.exists(dependency.REQUIREMENTS_CACHE_DIR):
+      shutil.rmtree(dependency.REQUIREMENTS_CACHE_DIR)
 
     options = PipelineOptions()
     options.view_as(GoogleCloudOptions).staging_location = staging_dir


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

`test_with_requirements_file` was failing locally because I had stale files in my /tmp/dataflow-requirements-cache from a previous package install. This change cleans the cache directory before validating its contents.