### PR TITLE
[BEAM-551] Add ValueProvider class (Take 2)

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -326,6 +326,7 @@ public interface PipelineOptions extends HasDisplayData {
       return String.format("%s-%s-%s-%s",
           normalizedAppName, normalizedUserName, datePart, randomPart);
     }
+  }
 
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -328,7 +328,6 @@ public interface PipelineOptions extends HasDisplayData {
     }
   }
 
-
   /**
    * Provides a unique ID for this {@link PipelineOptions} object, assigned at graph
    * construction time.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -26,6 +26,7 @@ import com.google.common.base.MoreObjects;
 import java.lang.reflect.Proxy;
 import java.util.ServiceLoader;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.GoogleApiDebugOptions.GoogleApiTracer;
@@ -324,6 +325,28 @@ public interface PipelineOptions extends HasDisplayData {
       String randomPart = Integer.toHexString(ThreadLocalRandom.current().nextInt());
       return String.format("%s-%s-%s-%s",
           normalizedAppName, normalizedUserName, datePart, randomPart);
+    }
+
+
+  /**
+   * Provides a unique ID for this Options object, assigned at graph construction
+   * time.
+   */
+  @Hidden
+  @Default.InstanceFactory(AtomicLongFactory.class)
+  Long getOptionsId();
+  void setOptionsId(Long id);
+
+  /**
+   * ValueFactory which supplies an ID that is guaranteed to be unique within the given
+   * process.
+   */
+  class AtomicLongFactory implements DefaultValueFactory<Long> {
+    private static final AtomicLong NEXT_ID = new AtomicLong(0);
+
+    @Override
+    public Long create(PipelineOptions options) {
+      return NEXT_ID.getAndIncrement();
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -330,8 +330,8 @@ public interface PipelineOptions extends HasDisplayData {
 
 
   /**
-   * Provides a unique ID for this Options object, assigned at graph construction
-   * time.
+   * Provides a unique ID for this {@link PipelineOptions} object, assigned at graph
+   * construction time.
    */
   @Hidden
   @Default.InstanceFactory(AtomicLongFactory.class)
@@ -339,8 +339,8 @@ public interface PipelineOptions extends HasDisplayData {
   void setOptionsId(Long id);
 
   /**
-   * ValueFactory which supplies an ID that is guaranteed to be unique within the given
-   * process.
+   * {@link DefaultValueFactory} which supplies an ID that is guaranteed to be unique
+   * within the given process.
    */
   class AtomicLongFactory implements DefaultValueFactory<Long> {
     private static final AtomicLong NEXT_ID = new AtomicLong(0);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -873,9 +873,6 @@ public class PipelineOptionsFactory {
       if (getterMethod != null) {
         Type getterPropertyType = getterMethod.getGenericReturnType();
         Type setterPropertyType = method.getGenericParameterTypes()[0];
-        if (getterPropertyType.equals(ValueProvider.class)) {
-          continue;
-        }
         if (!getterPropertyType.equals(setterPropertyType)) {
           TypeMismatch mismatch = new TypeMismatch();
           mismatch.propertyName = propertyName;
@@ -1465,7 +1462,7 @@ public class PipelineOptionsFactory {
           }
           convertedOptions.put(entry.getKey(), MAPPER.convertValue(values, type));
         } else if (SIMPLE_TYPES.contains(returnType) || returnType.isEnum()
-          || returnType.equals(ValueProvider.class)) {
+                   || returnType.equals(ValueProvider.class)) {
           String value = Iterables.getOnlyElement(entry.getValue());
           checkArgument(returnType.equals(String.class) || !value.isEmpty(),
                "Empty argument value is only allowed for String, String Array, "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -873,6 +873,9 @@ public class PipelineOptionsFactory {
       if (getterMethod != null) {
         Type getterPropertyType = getterMethod.getGenericReturnType();
         Type setterPropertyType = method.getGenericParameterTypes()[0];
+        if (getterPropertyType.equals(ValueProvider.class)) {
+          continue;
+        }
         if (!getterPropertyType.equals(setterPropertyType)) {
           TypeMismatch mismatch = new TypeMismatch();
           mismatch.propertyName = propertyName;
@@ -1461,7 +1464,8 @@ public class PipelineOptionsFactory {
             }
           }
           convertedOptions.put(entry.getKey(), MAPPER.convertValue(values, type));
-        } else if (SIMPLE_TYPES.contains(returnType) || returnType.isEnum()) {
+        } else if (SIMPLE_TYPES.contains(returnType) || returnType.isEnum()
+          || returnType.equals(ValueProvider.class)) {
           String value = Iterables.getOnlyElement(entry.getValue());
           checkArgument(returnType.equals(String.class) || !value.isEmpty(),
                "Empty argument value is only allowed for String, String Array, "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -54,6 +54,7 @@ import java.io.PrintStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -1440,8 +1441,12 @@ public class PipelineOptionsFactory {
             }
           }
         } else if ((returnType.isArray() && (SIMPLE_TYPES.contains(returnType.getComponentType())
-                || returnType.getComponentType().isEnum()))
-            || Collection.class.isAssignableFrom(returnType)) {
+                   || returnType.getComponentType().isEnum()))
+                   || Collection.class.isAssignableFrom(returnType)
+                   || (returnType.equals(ValueProvider.class)
+                       && MAPPER.getTypeFactory().constructType(
+                         ((ParameterizedType) method.getGenericReturnType())
+                         .getActualTypeArguments()[0]).isCollectionLikeType())) {
           // Split any strings with ","
           List<String> values = FluentIterable.from(entry.getValue())
               .transformAndConcat(new Function<String, Iterable<String>>() {
@@ -1452,7 +1457,8 @@ public class PipelineOptionsFactory {
           }).toList();
 
           if (returnType.isArray() && !returnType.getComponentType().equals(String.class)
-              || Collection.class.isAssignableFrom(returnType)) {
+              || Collection.class.isAssignableFrom(returnType)
+              || returnType.equals(ValueProvider.class)) {
             for (String value : values) {
               checkArgument(!value.isEmpty(),
                   "Empty argument value is only allowed for String, String Array, "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -676,6 +676,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
       PipelineOptions options =
           new ProxyInvocationHandler(Maps.<String, BoundValue>newHashMap(), fields)
               .as(PipelineOptions.class);
+      ValueProvider.RuntimeValueProvider.setRuntimeOptions(options);
       return options;
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -48,7 +48,6 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -66,6 +65,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.sdk.options.PipelineOptionsFactory.JsonIgnorePredicate;
 import org.apache.beam.sdk.options.PipelineOptionsFactory.Registration;
+import org.apache.beam.sdk.options.ValueProvider.RuntimeValueProvider;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.util.InstanceBuilder;
@@ -462,7 +462,8 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
         }
       }
       return new RuntimeValueProvider(
-        method.getName(), (Class<? extends PipelineOptions>) method.getDeclaringClass(), proxy.getOptionsId());
+        method.getName(), (Class<? extends PipelineOptions>) method.getDeclaringClass(),
+        proxy.getOptionsId());
     }
     for (Annotation annotation : method.getAnnotations()) {
       Object o = returnDefaultHelper(annotation, proxy, method);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -204,7 +204,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
    */
   synchronized <T extends PipelineOptions> T as(Class<T> iface) {
     checkNotNull(iface);
-    checkArgument(iface.isInterface(), "Not an interface: %s", iface.toString());
+    checkArgument(iface.isInterface(), "Not an interface: %s", iface);
     if (!interfaceToProxyCache.containsKey(iface)) {
       Registration<T> registration =
           PipelineOptionsFactory.validateWellFormed(iface, knownInterfaces);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.options;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** {@link ValueProvider} is an interface which abstracts the notion of
+ * fetching a value that may or may not be currently available.  This can be
+ * used to parameterize transforms that only read values in at runtime, for
+ * example.
+ */
+@JsonSerialize(using = ValueProvider.Serializer.class)
+@JsonDeserialize(using = ValueProvider.Deserializer.class)
+public interface ValueProvider<T> {  
+  T get();
+
+  /** Whether the contents of this ValueProvider is available to validation
+   * routines that run at graph construction time.
+   */
+  boolean shouldValidate();
+
+  /** {@link StaticValueProvider} is an implementation of ValueProvider that
+   * allows for a static value to be provided.
+   */
+  public static class StaticValueProvider<T> implements ValueProvider<T>, Serializable {
+    private final T value;
+
+    StaticValueProvider(T value) {
+      this.value = value;
+    }
+
+    public static <T> StaticValueProvider<T> of(T value) {
+      StaticValueProvider<T> factory = new StaticValueProvider<>(value);
+      return factory;
+    }
+
+    @Override
+    public T get() {
+      return value;
+    }
+
+    @Override
+    public boolean shouldValidate() {
+      return true;
+    }
+  }
+
+  /** {@link RuntimeValueProvider} is an implementation of ValueProvider that
+   * allows for a value to be provided at execution time rather than at graph
+   * construction time.
+   *
+   * <p>To enforce this contract, if there is no default, users must only call
+   * get() on the worker, which will provide the value of OPTIONS.
+   */
+  public static class RuntimeValueProvider<T> implements ValueProvider<T>, Serializable {
+    private static ConcurrentHashMap<Long, PipelineOptions> optionsMap =
+      new ConcurrentHashMap<>();
+
+    private final Class<? extends PipelineOptions> klass;
+    private final String methodName;
+    private final T defaultValue;
+    private final Long optionsId;
+
+    RuntimeValueProvider(String methodName, Class<? extends PipelineOptions> klass, Long optionsId) {
+      this.methodName = methodName;
+      this.klass = klass;
+      this.defaultValue = null;
+      this.optionsId = optionsId;
+    }
+
+    RuntimeValueProvider(String methodName, Class<? extends PipelineOptions> klass,
+      T defaultValue, Long optionsId) {
+      this.methodName = methodName;
+      this.klass = klass;
+      this.defaultValue = defaultValue;
+      this.optionsId = optionsId;
+    }
+
+    static void setRuntimeOptions(PipelineOptions runtimeOptions) {
+      optionsMap.put(runtimeOptions.getOptionsId(), runtimeOptions);
+    }
+
+    @Override
+    public T get() {
+      PipelineOptions options = optionsMap.get(optionsId);
+      if (options == null) {
+        if (defaultValue != null) {
+          return defaultValue;
+        }
+        throw new RuntimeException("Not called from a runtime context.");
+      }
+      try {
+        Method method = klass.getMethod(methodName);
+        PipelineOptions methodOptions = options.as(klass);
+        InvocationHandler handler = Proxy.getInvocationHandler(methodOptions);
+        return ((StaticValueProvider<T>) handler.invoke(methodOptions, method, null)).get();
+      } catch (Throwable e) {
+        throw new RuntimeException("Unable to load runtime value.", e);
+      }
+    }
+
+    @Override
+    public boolean shouldValidate() {
+      return defaultValue != null;
+    }
+  }
+
+  
+  static class Serializer extends JsonSerializer<ValueProvider<?>> {
+    @Override
+    public void serialize(ValueProvider<?> value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+      if (value.shouldValidate()) {
+        jgen.writeStartObject();
+        jgen.writeObject(value.get());
+        jgen.writeEndObject();
+      }
+    }
+  }
+
+  static class Deserializer extends JsonDeserializer<ValueProvider<?>>
+    implements ContextualDeserializer {
+    
+    final private JavaType innerType;
+
+    // A 0-arg constructor is required.
+    Deserializer() {
+      this.innerType = null;
+    }
+
+    Deserializer(JavaType innerType) {
+      this.innerType = innerType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
+                                                BeanProperty property)
+      throws JsonMappingException {
+      checkNotNull(ctxt);
+      JavaType type = checkNotNull(ctxt.getContextualType());
+      JavaType[] params = type.findTypeParameters(ValueProvider.class);
+      if (params.length != 1) {
+        throw new RuntimeException(
+          "Unable to derive type for ValueProvider: " + type.toString());
+      }
+      JavaType param = params[0];
+      return new Deserializer(param);
+    }
+    
+    @Override
+    public ValueProvider<?> deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException, JsonProcessingException {
+      JsonDeserializer dser = ctxt.findRootValueDeserializer(
+        checkNotNull(innerType));
+      Object o = dser.deserialize(jp, ctxt);
+      return StaticValueProvider.of(o);
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -202,7 +202,7 @@ public interface ValueProvider<T> {
     @Override
     public JsonDeserializer<?> createContextual(DeserializationContext ctxt,
                                                 BeanProperty property)
-      throws JsonMappingException {
+        throws JsonMappingException {
       checkNotNull(ctxt);
       JavaType type = checkNotNull(ctxt.getContextualType());
       JavaType[] params = type.findTypeParameters(ValueProvider.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -175,9 +175,7 @@ public interface ValueProvider<T> {
     public void serialize(ValueProvider<?> value, JsonGenerator jgen,
                           SerializerProvider provider) throws IOException {
       if (value.shouldValidate()) {
-        jgen.writeStartObject();
         jgen.writeObject(value.get());
-        jgen.writeEndObject();
       } else {
         jgen.writeNull();
       }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -244,12 +244,14 @@ public class ProxyInvocationHandlerTest {
   public void testToStringAfterDeserializationContainsJsonEntries() throws Exception {
     ProxyInvocationHandler handler = new ProxyInvocationHandler(Maps.<String, Object>newHashMap());
     Simple proxy = handler.as(Simple.class);
+    Long optionsId = proxy.getOptionsId();
     proxy.setString("stringValue");
     DefaultAnnotations proxy2 = proxy.as(DefaultAnnotations.class);
     proxy2.setLong(57L);
-    assertEquals("Current Settings:\n"
+    assertEquals(String.format("Current Settings:\n"
         + "  long: 57\n"
-        + "  string: \"stringValue\"\n",
+        + "  optionsId: %d\n"
+        + "  string: \"stringValue\"\n", optionsId),
         serializeDeserialize(PipelineOptions.class, proxy2).toString());
   }
 
@@ -257,14 +259,16 @@ public class ProxyInvocationHandlerTest {
   public void testToStringAfterDeserializationContainsOverriddenEntries() throws Exception {
     ProxyInvocationHandler handler = new ProxyInvocationHandler(Maps.<String, Object>newHashMap());
     Simple proxy = handler.as(Simple.class);
+    Long optionsId = proxy.getOptionsId();
     proxy.setString("stringValue");
     DefaultAnnotations proxy2 = proxy.as(DefaultAnnotations.class);
     proxy2.setLong(57L);
     Simple deserializedOptions = serializeDeserialize(Simple.class, proxy2);
     deserializedOptions.setString("overriddenValue");
-    assertEquals("Current Settings:\n"
+    assertEquals(String.format("Current Settings:\n"
         + "  long: 57\n"
-        + "  string: overriddenValue\n",
+        + "  optionsId: %d\n"
+        + "  string: overriddenValue\n", optionsId),
         deserializedOptions.toString());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -179,9 +179,9 @@ public class ValueProviderTest {
     // This is the expected behavior of the runner: deserialize and set the
     // the runtime options.
     String anchor = "\"appName\":\"ValueProviderTest\"";
-    assertThat(serializedOptions, containsString(anchor));
+    assertThat(serializedOptions, containsString("\"foo\":null"));
     String runnerString = serializedOptions.replaceAll(
-      anchor, anchor + ",\"foo\":\"quux\"");
+      "\"foo\":null", "\"foo\":\"quux\"");
     TestOptions runtime = mapper.readValue(runnerString, PipelineOptions.class)
       .as(TestOptions.class);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.options;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.beam.sdk.options.ValueProvider.RuntimeValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ValueProvider}. */
+@RunWith(JUnit4.class)
+public class ValueProviderTest {
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  /** A test interface. */
+  public static interface TestOptions extends PipelineOptions {
+    @Default.String("bar")
+    ValueProvider<String> getBar();
+    void setBar(ValueProvider<String> bar);
+
+    ValueProvider<String> getFoo();
+    void setFoo(ValueProvider<String> foo);
+  }
+
+  @Test
+  public void testCommandLineNoDefault() {
+    TestOptions options = PipelineOptionsFactory.fromArgs(
+      new String[]{"--foo=baz"}).as(TestOptions.class);
+    ValueProvider<String> provider = options.getFoo();
+    assertEquals("baz", provider.get());
+    assertTrue(provider.shouldValidate());
+  }
+
+  @Test
+  public void testCommandLineWithDefault() {
+    TestOptions options = PipelineOptionsFactory.fromArgs(
+      new String[]{"--bar=baz"}).as(TestOptions.class);
+    ValueProvider<String> provider = options.getBar();
+    assertEquals("baz", provider.get());
+    assertTrue(provider.shouldValidate());
+  }
+
+  @Test
+  public void testStaticValueProvider() {
+    ValueProvider<String> provider = StaticValueProvider.of("foo");
+    assertEquals("foo", provider.get());
+    assertTrue(provider.shouldValidate());
+  }
+
+  @Test
+  public void testNoDefaultRuntimeProvider() {
+    TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
+    ValueProvider<String> provider = options.getFoo();
+    assertFalse(provider.shouldValidate());
+
+    expectedException.expect(RuntimeException.class);
+    expectedException.expectMessage("Not called from a runtime context");
+    provider.get();
+  }
+
+  @Test
+  public void testDefaultRuntimeProvider() {
+    TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
+    ValueProvider<String> provider = options.getBar();
+    assertTrue(provider.shouldValidate());
+    assertEquals("bar", provider.get());
+  }
+
+  @Test
+  public void testNoDefaultRuntimeProviderWithOverride() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    TestOptions runtime = mapper.readValue(
+      "{ \"options\": { \"foo\": \"quux\" }}", PipelineOptions.class)
+      .as(TestOptions.class);
+
+    TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
+    runtime.setOptionsId(options.getOptionsId());
+    RuntimeValueProvider.setRuntimeOptions(runtime);
+
+    ValueProvider<String> provider = options.getFoo();
+    assertFalse(provider.shouldValidate());
+    assertEquals("quux", provider.get());
+  }
+
+  @Test
+  public void testDefaultRuntimeProviderWithOverride() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    TestOptions runtime = mapper.readValue(
+      "{ \"options\": { \"bar\": \"quux\" }}", PipelineOptions.class)
+      .as(TestOptions.class);
+
+    TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
+    runtime.setOptionsId(options.getOptionsId());
+    RuntimeValueProvider.setRuntimeOptions(runtime);
+
+    ValueProvider<String> provider = options.getBar();
+    assertTrue(provider.shouldValidate());
+    assertEquals("quux", provider.get());
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.options.ValueProvider.RuntimeValueProvider;
@@ -60,13 +61,12 @@ public class ValueProviderTest {
     assertTrue(provider.shouldValidate());
   }
 
-  @Ignore
   @Test
   public void testListValueProvider() {
     TestOptions options = PipelineOptionsFactory.fromArgs(
       new String[]{"--list=1,2,3"}).as(TestOptions.class);
     ValueProvider<List<Integer>> provider = options.getList();
-    assertEquals("baz", provider.get());
+    assertEquals(ImmutableList.of(1, 2, 3), provider.get());
     assertTrue(provider.shouldValidate());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -21,11 +21,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.beam.sdk.options.ValueProvider.RuntimeValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -58,7 +58,7 @@ public class ValueProviderTest {
       new String[]{"--foo=baz"}).as(TestOptions.class);
     ValueProvider<String> provider = options.getFoo();
     assertEquals("baz", provider.get());
-    assertTrue(provider.shouldValidate());
+    assertTrue(provider.isAccessible());
   }
 
   @Test
@@ -67,7 +67,7 @@ public class ValueProviderTest {
       new String[]{"--list=1,2,3"}).as(TestOptions.class);
     ValueProvider<List<Integer>> provider = options.getList();
     assertEquals(ImmutableList.of(1, 2, 3), provider.get());
-    assertTrue(provider.shouldValidate());
+    assertTrue(provider.isAccessible());
   }
 
   @Test
@@ -76,21 +76,21 @@ public class ValueProviderTest {
       new String[]{"--bar=baz"}).as(TestOptions.class);
     ValueProvider<String> provider = options.getBar();
     assertEquals("baz", provider.get());
-    assertTrue(provider.shouldValidate());
+    assertTrue(provider.isAccessible());
   }
 
   @Test
   public void testStaticValueProvider() {
     ValueProvider<String> provider = StaticValueProvider.of("foo");
     assertEquals("foo", provider.get());
-    assertTrue(provider.shouldValidate());
+    assertTrue(provider.isAccessible());
   }
 
   @Test
   public void testNoDefaultRuntimeProvider() {
     TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
     ValueProvider<String> provider = options.getFoo();
-    assertFalse(provider.shouldValidate());
+    assertFalse(provider.isAccessible());
 
     expectedException.expect(RuntimeException.class);
     expectedException.expectMessage("Not called from a runtime context");
@@ -101,7 +101,7 @@ public class ValueProviderTest {
   public void testDefaultRuntimeProvider() {
     TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
     ValueProvider<String> provider = options.getBar();
-    assertTrue(provider.shouldValidate());
+    assertTrue(provider.isAccessible());
     assertEquals("bar", provider.get());
   }
 
@@ -117,7 +117,7 @@ public class ValueProviderTest {
     RuntimeValueProvider.setRuntimeOptions(runtime);
 
     ValueProvider<String> provider = options.getFoo();
-    assertFalse(provider.shouldValidate());
+    assertFalse(provider.isAccessible());
     assertEquals("quux", provider.get());
   }
 
@@ -133,7 +133,7 @@ public class ValueProviderTest {
     RuntimeValueProvider.setRuntimeOptions(runtime);
 
     ValueProvider<String> provider = options.getBar();
-    assertTrue(provider.shouldValidate());
+    assertTrue(provider.isAccessible());
     assertEquals("quux", provider.get());
   }
 
@@ -172,7 +172,7 @@ public class ValueProviderTest {
   @Test
   public void testSerializeDeserializeNoArg() throws Exception {
     TestOptions submitOptions = PipelineOptionsFactory.as(TestOptions.class);
-    assertFalse(submitOptions.getFoo().shouldValidate());
+    assertFalse(submitOptions.getFoo().isAccessible());
     ObjectMapper mapper = new ObjectMapper();
     String serializedOptions = mapper.writeValueAsString(submitOptions);
 
@@ -186,7 +186,7 @@ public class ValueProviderTest {
       .as(TestOptions.class);
 
     ValueProvider<String> vp = runtime.getFoo();
-    assertTrue(vp.shouldValidate());
+    assertTrue(vp.isAccessible());
     assertEquals("quux", vp.get());
     assertEquals(vp.getClass(), StaticValueProvider.class);
   }
@@ -196,7 +196,7 @@ public class ValueProviderTest {
     TestOptions submitOptions = PipelineOptionsFactory.fromArgs(
       new String[]{"--foo=baz"}).as(TestOptions.class);
     assertEquals("baz", submitOptions.getFoo().get());
-    assertTrue(submitOptions.getFoo().shouldValidate());
+    assertTrue(submitOptions.getFoo().isAccessible());
     ObjectMapper mapper = new ObjectMapper();
     String serializedOptions = mapper.writeValueAsString(submitOptions);
 
@@ -208,7 +208,7 @@ public class ValueProviderTest {
       .as(TestOptions.class);
 
     ValueProvider<String> vp = runtime.getFoo();
-    assertTrue(vp.shouldValidate());
+    assertTrue(vp.isAccessible());
     assertEquals("quux", vp.get());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -101,8 +101,7 @@ public class ValueProviderTest {
   public void testDefaultRuntimeProvider() {
     TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
     ValueProvider<String> provider = options.getBar();
-    assertTrue(provider.isAccessible());
-    assertEquals("bar", provider.get());
+    assertFalse(provider.isAccessible());
   }
 
   @Test
@@ -117,7 +116,7 @@ public class ValueProviderTest {
     RuntimeValueProvider.setRuntimeOptions(runtime);
 
     ValueProvider<String> provider = options.getFoo();
-    assertFalse(provider.isAccessible());
+    assertTrue(provider.isAccessible());
     assertEquals("quux", provider.get());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ApiSurfaceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ApiSurfaceTest.java
@@ -88,6 +88,7 @@ public class ApiSurfaceTest {
           inPackage("com.google.rpc"),
           inPackage("com.google.type"),
           inPackage("com.fasterxml.jackson.annotation"),
+          inPackage("com.fasterxml.jackson.deser"),
           inPackage("io.grpc"),
           inPackage("org.apache.avro"),
           inPackage("org.apache.commons.logging"), // via BigTable

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ApiSurfaceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/ApiSurfaceTest.java
@@ -88,6 +88,8 @@ public class ApiSurfaceTest {
           inPackage("com.google.rpc"),
           inPackage("com.google.type"),
           inPackage("com.fasterxml.jackson.annotation"),
+          inPackage("com.fasterxml.jackson.core"),
+          inPackage("com.fasterxml.jackson.databind"),
           inPackage("com.fasterxml.jackson.deser"),
           inPackage("io.grpc"),
           inPackage("org.apache.avro"),


### PR DESCRIPTION
My branch had become a dumpster fire, so I'm opening a fresh PR (history is here: https://github.com/apache/incubator-beam/pull/827).

Add a basic implementation of StaticValueProvider and DynamicValueProvider.

@dhalperi , could you please take a look?  Hoping the jackson API surface test failures are easy to fix. 