### PR TITLE
BEAM-682-Invoker Class should be created in Thread Context Classloader

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
@@ -167,7 +167,8 @@ public class DoFnInvokers {
     Class<? extends DoFnInvoker<?, ?>> res =
         (Class<? extends DoFnInvoker<?, ?>>)
             unloaded
-                .load(Thread.currentThread().getContextClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+                .load(Thread.currentThread().getContextClassLoader(),
+                        ClassLoadingStrategy.Default.INJECTION)
                 .getLoaded();
     return res;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
@@ -167,7 +167,7 @@ public class DoFnInvokers {
     Class<? extends DoFnInvoker<?, ?>> res =
         (Class<? extends DoFnInvoker<?, ?>>)
             unloaded
-                .load(DoFnInvokers.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+                .load(Thread.currentThread().getContextClassLoader(), ClassLoadingStrategy.Default.INJECTION)
                 .getLoaded();
     return res;
   }


### PR DESCRIPTION
As of now the InvokerClass is being loaded in wrong classloader. It should be loaded into Thread.currentThread.getContextClassLoader()
https://github.com/apache/incubator-beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java#L167

```
 Class<? extends DoFnInvoker<?, ?>> res =
        (Class<? extends DoFnInvoker<?, ?>>)
            unloaded
                .load(DoFnInvokers.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
                .getLoaded();
```

Fix

```
 Class<? extends DoFnInvoker<?, ?>> res =
        (Class<? extends DoFnInvoker<?, ?>>)
            unloaded
                .load(Thread.currentThread().getContextClassLoader(),
                        ClassLoadingStrategy.Default.INJECTION)
                .getLoaded();
```
