### PR TITLE
[Beam-517] Check versions of pip and cython

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -40,6 +40,7 @@ from the Python programming language.
           * [Create and activate virtual environment](#create-and-activate-virtual-environment)
           * [Download and install](#download-and-install)
           * [Notes on installing with ``setup.py install``](#notes-on-installing-with-setuppy-install)
+      * [Getting Apache Beam](#getting-apache-beam)
   * [Local execution of a pipeline](#local-execution-of-a-pipeline)
   * [A Quick Tour of the Source Code](#a-quick-tour-of-the-source-code)
   * [Simple Examples](#simple-examples)
@@ -118,7 +119,7 @@ set up your machine's Python development environment.
 #### Install ``pip``
 
 `pip` is Python's package manager.  If you already have `pip` installed
-(type `pip -V` to check), skip this step.
+(type `pip -V` to check), please make sure to have at least version 7.0.0.
 
 There are several ways to install `pip`; use whichever works for you.
 
@@ -222,6 +223,43 @@ uninstall the package:
     pip uninstall python-dataflow
 
 and use the ``pip install`` method described above to re-install it.
+
+### Getting Apache Beam
+
+In order to run the examples, you will need Apache Beam. This can be installed
+locally by using a virtual environment.
+
+#### Create and activate virtual environment
+
+A virtual environment is a directory tree containing its own Python
+distribution.  To create a virtual environment:
+
+    virtualenv /path/to/directory
+
+A virtual environment needs to be activated for each shell that is to use it;
+activating sets some environment variables that point to the virtual
+environment's directories.  To activate a virtual environment in Bash:
+
+    . /path/to/directory/bin/activate
+
+That is, source the script `bin/activate` under the virtual environment
+directory you created.
+
+#### Download and install
+
+The best way to run Apache Beam with the Python SDK is to clone the git 
+repository:
+    
+    git clone https://github.com/apache/incubator-beam.git
+    cd incubator-beam/sdks/python/
+    pip install -e .
+     
+
+In addition to the pure Python implementation, the Python SDK supports 
+Cython as well. If you want to use it, run the following command:
+
+    pip install -e .[cython]
+
 
 ## Local execution of a pipeline
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -40,9 +40,6 @@ from the Python programming language.
           * [Create and activate virtual environment](#create-and-activate-virtual-environment)
           * [Download and install](#download-and-install)
           * [Notes on installing with ``setup.py install``](#notes-on-installing-with-setuppy-install)
-      * [Getting Apache Beam](#getting-apache-beam)
-          * [Create virtual environment](#create-virtual-environment)
-          * [Clone and install](#clone-and-install)
   * [Local execution of a pipeline](#local-execution-of-a-pipeline)
   * [A Quick Tour of the Source Code](#a-quick-tour-of-the-source-code)
   * [Simple Examples](#simple-examples)
@@ -225,43 +222,6 @@ uninstall the package:
     pip uninstall python-dataflow
 
 and use the ``pip install`` method described above to re-install it.
-
-### Getting Apache Beam
-
-In order to run the examples, you will need Apache Beam. This can be installed
-locally by using a virtual environment.
-
-#### Create virtual environment
-
-A virtual environment is a directory tree containing its own Python
-distribution.  To create a virtual environment:
-
-    virtualenv /path/to/directory
-
-A virtual environment needs to be activated for each shell that is to use it;
-activating sets some environment variables that point to the virtual
-environment's directories.  To activate a virtual environment in Bash:
-
-    . /path/to/directory/bin/activate
-
-That is, source the script `bin/activate` under the virtual environment
-directory you created.
-
-#### Clone and install
-
-The best way to run Apache Beam with the Python SDK is by cloning the git 
-repository:
-    
-    git clone https://github.com/apache/incubator-beam.git
-    cd incubator-beam/sdks/python/
-    pip install -e .
-     
-
-In addition to the pure Python implementation, the Python SDK supports 
-Cython as well. If you want to use it, run the following command:
-
-    pip install -e .[cython]
-
 
 ## Local execution of a pipeline
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -249,7 +249,7 @@ directory you created.
 
 #### Clone and install
 
-The best way to run Apache Beam with the Python SDK is to clone the git 
+The best way to run Apache Beam with the Python SDK is by cloning the git 
 repository:
     
     git clone https://github.com/apache/incubator-beam.git

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -41,6 +41,8 @@ from the Python programming language.
           * [Download and install](#download-and-install)
           * [Notes on installing with ``setup.py install``](#notes-on-installing-with-setuppy-install)
       * [Getting Apache Beam](#getting-apache-beam)
+          * [Create virtual environment](#create-virtual-environment)
+          * [Clone and install](#clone-and-install)
   * [Local execution of a pipeline](#local-execution-of-a-pipeline)
   * [A Quick Tour of the Source Code](#a-quick-tour-of-the-source-code)
   * [Simple Examples](#simple-examples)
@@ -229,7 +231,7 @@ and use the ``pip install`` method described above to re-install it.
 In order to run the examples, you will need Apache Beam. This can be installed
 locally by using a virtual environment.
 
-#### Create and activate virtual environment
+#### Create virtual environment
 
 A virtual environment is a directory tree containing its own Python
 distribution.  To create a virtual environment:
@@ -245,7 +247,7 @@ environment's directories.  To activate a virtual environment in Bash:
 That is, source the script `bin/activate` under the virtual environment
 directory you created.
 
-#### Download and install
+#### Clone and install
 
 The best way to run Apache Beam with the Python SDK is to clone the git 
 repository:

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -21,6 +21,8 @@ from distutils.version import StrictVersion
 
 import os
 import platform
+import warnings
+
 import setuptools
 
 from pkg_resources import get_distribution, DistributionNotFound
@@ -46,19 +48,28 @@ TBD
 
 REQUIRED_PIP_VERSION = '7.0.0'
 _PIP_VERSION = get_distribution('pip').version
-assert StrictVersion(_PIP_VERSION) >= StrictVersion(REQUIRED_PIP_VERSION), \
-  "This SDK requires 'pip' >= {0}".format(REQUIRED_PIP_VERSION)
+if StrictVersion(_PIP_VERSION) <= StrictVersion(REQUIRED_PIP_VERSION):
+  warnings.warn(
+      "You are using version {0} of pip. " \
+      "However, version {1} is recommended.".format(
+          _PIP_VERSION, REQUIRED_PIP_VERSION
+      )
+  )
+
 
 REQUIRED_CYTHON_VERSION = '0.23.2'
 try:
   _CYTHON_VERSION = get_distribution('cython').version
-  assert StrictVersion(_CYTHON_VERSION) >= \
-         StrictVersion(REQUIRED_CYTHON_VERSION), \
-  "This SDK requires 'cython' >= {0}".format(REQUIRED_CYTHON_VERSION)
+  if StrictVersion(_CYTHON_VERSION) <= StrictVersion(REQUIRED_CYTHON_VERSION):
+    warnings.warn(
+        "You are using version {0} of cython. " \
+        "However, version {1} is recommended.".format(
+            _CYTHON_VERSION, REQUIRED_CYTHON_VERSION
+        )
+    )
 except DistributionNotFound:
   # do nothing if Cython is not installed
   pass
-
 
 # Currently all compiled modules are optional  (for performance only).
 if platform.system() == 'Windows':

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -82,7 +82,7 @@ REQUIRED_PACKAGES = [
     ]
 
 EXTRA_PACKAGES = {
-    'cython': ['cython>=0.23.2'],
+    'cython': ['cython>={0}'.format(REQUIRED_CYTHON_VERSION)],
 }
 
 setuptools.setup(

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -44,7 +44,7 @@ PACKAGE_LONG_DESCRIPTION = '''
 TBD
 '''
 
-REQUIRED_PIP_VERSION = '0.7.0'
+REQUIRED_PIP_VERSION = '7.0.0'
 _PIP_VERSION = get_distribution('pip').version
 assert StrictVersion(_PIP_VERSION) >= StrictVersion(REQUIRED_PIP_VERSION), \
   "This SDK requires 'pip' >= {0}".format(REQUIRED_PIP_VERSION)

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -18,11 +18,12 @@
 """Apache Beam SDK for Python setup file."""
 
 from distutils.version import StrictVersion
-from pkg_resources import get_distribution, DistributionNotFound
 
 import os
 import platform
 import setuptools
+
+from pkg_resources import get_distribution, DistributionNotFound
 
 
 def get_version():
@@ -46,16 +47,17 @@ TBD
 REQUIRED_PIP_VERSION = '0.7.0'
 _PIP_VERSION = get_distribution('pip').version
 assert StrictVersion(_PIP_VERSION) >= StrictVersion(REQUIRED_PIP_VERSION), \
-    "This SDK requires 'pip' >= {0}".format(REQUIRED_PIP_VERSION)
+  "This SDK requires 'pip' >= {0}".format(REQUIRED_PIP_VERSION)
 
 REQUIRED_CYTHON_VERSION = '0.23.2'
 try:
-    _CYTHON_VERSION = get_distribution('cython').version
-    assert StrictVersion(_CYTHON_VERSION) >= StrictVersion(REQUIRED_CYTHON_VERSION), \
-    "This SDK requires 'cython' >= {0}".format(REQUIRED_CYTHON_VERSION)
+  _CYTHON_VERSION = get_distribution('cython').version
+  assert StrictVersion(_CYTHON_VERSION) >= \
+         StrictVersion(REQUIRED_CYTHON_VERSION), \
+  "This SDK requires 'cython' >= {0}".format(REQUIRED_CYTHON_VERSION)
 except DistributionNotFound:
-    # do nothing if Cython is not installed
-    pass
+  # do nothing if Cython is not installed
+  pass
 
 
 # Currently all compiled modules are optional  (for performance only).

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -84,10 +84,6 @@ REQUIRED_PACKAGES = [
     'pyyaml>=3.10',
     ]
 
-EXTRA_PACKAGES = {
-    'cython': ['cython>={0}'.format(REQUIRED_CYTHON_VERSION)],
-}
-
 setuptools.setup(
     name=PACKAGE_NAME,
     version=PACKAGE_VERSION,
@@ -109,7 +105,6 @@ setuptools.setup(
     ]),
     setup_requires=['nose>=1.0'],
     install_requires=REQUIRED_PACKAGES,
-    extras_require=EXTRA_PACKAGES,
     test_suite='nose.collector',
     zip_safe=False,
     # PyPI package information.

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -18,8 +18,11 @@
 """Apache Beam SDK for Python setup file."""
 
 import os
+import pkg_resources
 import platform
 import setuptools
+
+from distutils.version import StrictVersion
 
 
 def get_version():
@@ -40,6 +43,8 @@ PACKAGE_LONG_DESCRIPTION = '''
 TBD
 '''
 
+assert StrictVersion(pkg_resources.get_distribution('pip').version) >= StrictVersion('0.7.0'), \
+    "This SDK requires 'pip' >= 7.0.0"
 
 # Currently all compiled modules are optional  (for performance only).
 if platform.system() == 'Windows':
@@ -65,6 +70,9 @@ REQUIRED_PACKAGES = [
     'pyyaml>=3.10',
     ]
 
+EXTRA_PACKAGES = {
+    'cython': ['cython>=0.23.2'],
+}
 
 setuptools.setup(
     name=PACKAGE_NAME,
@@ -87,6 +95,7 @@ setuptools.setup(
     ]),
     setup_requires=['nose>=1.0'],
     install_requires=REQUIRED_PACKAGES,
+    extras_require=EXTRA_PACKAGES,
     test_suite='nose.collector',
     zip_safe=False,
     # PyPI package information.

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -18,11 +18,11 @@
 """Apache Beam SDK for Python setup file."""
 
 from distutils.version import StrictVersion
+from pkg_resources import get_distribution, DistributionNotFound
 
 import os
 import platform
 import setuptools
-import pkg_resources
 
 
 def get_version():
@@ -43,9 +43,19 @@ PACKAGE_LONG_DESCRIPTION = '''
 TBD
 '''
 
-_PIP_VERSION = pkg_resources.get_distribution('pip').version
+_PIP_VERSION = get_distribution('pip').version
 assert StrictVersion(_PIP_VERSION) >= StrictVersion('0.7.0'), \
     "This SDK requires 'pip' >= 7.0.0"
+
+REQUIRED_CYTHON_VERSION = '0.23.2'
+try:
+    _CYTHON_VERSION = get_distribution('cython').version
+    assert StrictVersion(_CYTHON_VERSION) >= StrictVersion(REQUIRED_CYTHON_VERSION), \
+    "This SDK requires 'cython' >= 0.23.2"
+except DistributionNotFound:
+    # do nothing if Cython is not installed
+    pass
+
 
 # Currently all compiled modules are optional  (for performance only).
 if platform.system() == 'Windows':

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -17,12 +17,12 @@
 
 """Apache Beam SDK for Python setup file."""
 
+from distutils.version import StrictVersion
+
 import os
-import pkg_resources
 import platform
 import setuptools
-
-from distutils.version import StrictVersion
+import pkg_resources
 
 
 def get_version():
@@ -43,7 +43,8 @@ PACKAGE_LONG_DESCRIPTION = '''
 TBD
 '''
 
-assert StrictVersion(pkg_resources.get_distribution('pip').version) >= StrictVersion('0.7.0'), \
+_PIP_VERSION = pkg_resources.get_distribution('pip').version
+assert StrictVersion(_PIP_VERSION) >= StrictVersion('0.7.0'), \
     "This SDK requires 'pip' >= 7.0.0"
 
 # Currently all compiled modules are optional  (for performance only).

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -43,15 +43,16 @@ PACKAGE_LONG_DESCRIPTION = '''
 TBD
 '''
 
+REQUIRED_PIP_VERSION = '0.7.0'
 _PIP_VERSION = get_distribution('pip').version
-assert StrictVersion(_PIP_VERSION) >= StrictVersion('0.7.0'), \
-    "This SDK requires 'pip' >= 7.0.0"
+assert StrictVersion(_PIP_VERSION) >= StrictVersion(REQUIRED_PIP_VERSION), \
+    "This SDK requires 'pip' >= {0}".format(REQUIRED_PIP_VERSION)
 
 REQUIRED_CYTHON_VERSION = '0.23.2'
 try:
     _CYTHON_VERSION = get_distribution('cython').version
     assert StrictVersion(_CYTHON_VERSION) >= StrictVersion(REQUIRED_CYTHON_VERSION), \
-    "This SDK requires 'cython' >= 0.23.2"
+    "This SDK requires 'cython' >= {0}".format(REQUIRED_CYTHON_VERSION)
 except DistributionNotFound:
     # do nothing if Cython is not installed
     pass

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -48,7 +48,7 @@ TBD
 
 REQUIRED_PIP_VERSION = '7.0.0'
 _PIP_VERSION = get_distribution('pip').version
-if StrictVersion(_PIP_VERSION) <= StrictVersion(REQUIRED_PIP_VERSION):
+if StrictVersion(_PIP_VERSION) < StrictVersion(REQUIRED_PIP_VERSION):
   warnings.warn(
       "You are using version {0} of pip. " \
       "However, version {1} is recommended.".format(
@@ -60,7 +60,7 @@ if StrictVersion(_PIP_VERSION) <= StrictVersion(REQUIRED_PIP_VERSION):
 REQUIRED_CYTHON_VERSION = '0.23.2'
 try:
   _CYTHON_VERSION = get_distribution('cython').version
-  if StrictVersion(_CYTHON_VERSION) <= StrictVersion(REQUIRED_CYTHON_VERSION):
+  if StrictVersion(_CYTHON_VERSION) < StrictVersion(REQUIRED_CYTHON_VERSION):
     warnings.warn(
         "You are using version {0} of cython. " \
         "However, version {1} is recommended.".format(


### PR DESCRIPTION
I have added a check so that the setup fails if pip <= 0.7.0 is not installed. 

In addition, I have added cython as an optional dependency, so that it's installed only if the user decides to do so, e.g., via 

`pip install -e .[cython]`

The Readme file has also been updated, although I think that it may need some refactoring in the future, when/if the project is packaged and deployed on pypi as apache-beam. In that case, it would be possible to execute something like:

`pip install apache-beam[cython]`

---
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

For more details about the issue, see the jira issue: https://issues.apache.org/jira/browse/BEAM-517