### PR TITLE
[BEAM-310] Refactor BundleFactory methods

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
@@ -132,7 +132,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
           source.createReader(evaluationContext.getPipelineOptions())) {
         boolean contentsRemaining = reader.start();
         UncommittedBundle<OutputT> output =
-            evaluationContext.createRootBundle(transform.getOutput());
+            evaluationContext.createBundle(transform.getOutput());
         while (contentsRemaining) {
           output.add(
               WindowedValue.timestampedValueInGlobalWindow(

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BundleFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BundleFactory.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.direct;
 
 import org.apache.beam.runners.direct.DirectGroupByKey.DirectGroupByKeyOnly;
-import org.apache.beam.runners.direct.DirectRunner.CommittedBundle;
 import org.apache.beam.runners.direct.DirectRunner.UncommittedBundle;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
@@ -28,22 +27,24 @@ import org.apache.beam.sdk.values.PCollection;
  */
 public interface BundleFactory {
   /**
-   * Create an {@link UncommittedBundle} from an empty input. Elements added to the bundle belong to
-   * the {@code output} {@link PCollection}.
+   * Create an {@link UncommittedBundle} from an empty input. Elements added to the bundle do not
+   * belong to a {@link PCollection}.
+   *
+   * <p>For use in creating inputs to root transforms.
    */
-  public <T> UncommittedBundle<T> createRootBundle(PCollection<T> output);
+  <T> UncommittedBundle<T> createRootBundle();
 
   /**
    * Create an {@link UncommittedBundle} from the specified input. Elements added to the bundle
    * belong to the {@code output} {@link PCollection}.
    */
-  public <T> UncommittedBundle<T> createBundle(CommittedBundle<?> input, PCollection<T> output);
+  <T> UncommittedBundle<T> createBundle(PCollection<T> output);
 
   /**
    * Create an {@link UncommittedBundle} with the specified keys at the specified step. For use by
    * {@link DirectGroupByKeyOnly} {@link PTransform PTransforms}. Elements added to the bundle
    * belong to the {@code output} {@link PCollection}.
    */
-  public <K, T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, StructuralKey<K> key, PCollection<T> output);
+  <K, T> UncommittedBundle<T> createKeyedBundle(
+      StructuralKey<K> key, PCollection<T> output);
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.direct.DirectGroupByKey.DirectGroupByKeyOnly;
 import org.apache.beam.runners.direct.DirectRunner.DirectPipelineResult;
 import org.apache.beam.runners.direct.TestStreamEvaluatorFactory.DirectTestStreamFactory;
@@ -90,12 +91,12 @@ public class DirectRunner
    *
    * @param <T> the type of elements that can be added to this bundle
    */
-  public static interface UncommittedBundle<T> {
+  interface UncommittedBundle<T> {
     /**
      * Returns the PCollection that the elements of this {@link UncommittedBundle} belong to.
      */
+    @Nullable
     PCollection<T> getPCollection();
-
 
     /**
      * Outputs an element to this bundle.
@@ -122,10 +123,11 @@ public class DirectRunner
    * a part of at a later point.
    * @param <T> the type of elements contained within this bundle
    */
-  public static interface CommittedBundle<T> {
+  interface CommittedBundle<T> {
     /**
      * Returns the PCollection that the elements of this bundle belong to.
      */
+    @Nullable
     PCollection<T> getPCollection();
 
     /**

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EvaluationContext.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EvaluationContext.java
@@ -226,16 +226,16 @@ class EvaluationContext {
   /**
    * Create a {@link UncommittedBundle} for use by a source.
    */
-  public <T> UncommittedBundle<T> createRootBundle(PCollection<T> output) {
-    return bundleFactory.createRootBundle(output);
+  public <T> UncommittedBundle<T> createRootBundle() {
+    return bundleFactory.createRootBundle();
   }
 
   /**
    * Create a {@link UncommittedBundle} whose elements belong to the specified {@link
    * PCollection}.
    */
-  public <T> UncommittedBundle<T> createBundle(CommittedBundle<?> input, PCollection<T> output) {
-    return bundleFactory.createBundle(input, output);
+  public <T> UncommittedBundle<T> createBundle(PCollection<T> output) {
+    return bundleFactory.createBundle(output);
   }
 
   /**
@@ -243,8 +243,8 @@ class EvaluationContext {
    * {@link DirectGroupByKeyOnly} {@link PTransform PTransforms}.
    */
   public <K, T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, StructuralKey<K> key, PCollection<T> output) {
-    return bundleFactory.createKeyedBundle(input, key, output);
+      StructuralKey<K> key, PCollection<T> output) {
+    return bundleFactory.createKeyedBundle(key, output);
   }
 
   /**

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -422,8 +422,7 @@ final class ExecutorServiceParallelExecutor implements PipelineExecutor {
               @SuppressWarnings({"unchecked", "rawtypes"})
               CommittedBundle<?> bundle =
                   evaluationContext
-                      .createKeyedBundle(
-                          null, keyTimers.getKey(), (PCollection) transform.getInput())
+                      .createKeyedBundle(keyTimers.getKey(), (PCollection) transform.getInput())
                       .add(WindowedValue.valueInEmptyWindows(work))
                       .commit(evaluationContext.now());
               scheduleConsumption(transform, bundle, new TimerIterableCompletionCallback(delivery));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/FlattenEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/FlattenEvaluatorFactory.java
@@ -64,7 +64,7 @@ class FlattenEvaluatorFactory implements TransformEvaluatorFactory {
           null, StepTransformResult.withoutHold(application).build());
     }
     final UncommittedBundle<InputT> outputBundle =
-        evaluationContext.createBundle(inputBundle, application.getOutput());
+        evaluationContext.createBundle(application.getOutput());
     final TransformResult result =
         StepTransformResult.withoutHold(application).addOutput(outputBundle).build();
     return new FlattenEvaluator<>(outputBundle, result);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
@@ -153,10 +153,9 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
         K key = groupedEntry.getKey().key;
         KeyedWorkItem<K, V> groupedKv =
             KeyedWorkItems.elementsWorkItem(key, groupedEntry.getValue());
-        UncommittedBundle<KeyedWorkItem<K, V>> bundle = evaluationContext.createKeyedBundle(
-            inputBundle,
-            StructuralKey.of(key, keyCoder),
-            application.getOutput());
+        UncommittedBundle<KeyedWorkItem<K, V>> bundle =
+            evaluationContext.createKeyedBundle(
+                StructuralKey.of(key, keyCoder), application.getOutput());
         bundle.add(WindowedValue.valueInGlobalWindow(groupedKv));
         resultBuilder.addOutput(bundle);
       }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ImmutabilityCheckingBundleFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ImmutabilityCheckingBundleFactory.java
@@ -58,20 +58,26 @@ class ImmutabilityCheckingBundleFactory implements BundleFactory {
     this.underlying = checkNotNull(underlying);
   }
 
+  /**
+   * {@inheritDoc}.
+   *
+   * @return a root bundle created by the underlying {@link PCollection}. Root bundles belong to the
+   * runner, which is required to use the contents in a way that is mutation-safe.
+   */
   @Override
-  public <T> UncommittedBundle<T> createRootBundle(PCollection<T> output) {
-    return new ImmutabilityEnforcingBundle<>(underlying.createRootBundle(output));
+  public <T> UncommittedBundle<T> createRootBundle() {
+    return underlying.createRootBundle();
   }
 
   @Override
-  public <T> UncommittedBundle<T> createBundle(CommittedBundle<?> input, PCollection<T> output) {
-    return new ImmutabilityEnforcingBundle<>(underlying.createBundle(input, output));
+  public <T> UncommittedBundle<T> createBundle(PCollection<T> output) {
+    return new ImmutabilityEnforcingBundle<>(underlying.createBundle(output));
   }
 
   @Override
   public <K, T> UncommittedBundle<T> createKeyedBundle(
-      CommittedBundle<?> input, StructuralKey<K> key, PCollection<T> output) {
-    return new ImmutabilityEnforcingBundle<>(underlying.createKeyedBundle(input, key, output));
+      StructuralKey<K> key, PCollection<T> output) {
+    return new ImmutabilityEnforcingBundle<>(underlying.createKeyedBundle(key, output));
   }
 
   private static class ImmutabilityEnforcingBundle<T> implements UncommittedBundle<T> {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -60,7 +60,7 @@ class ParDoEvaluator<T> implements TransformEvaluator<T> {
     for (Map.Entry<TupleTag<?>, PCollection<?>> outputEntry : outputs.entrySet()) {
       outputBundles.put(
           outputEntry.getKey(),
-          evaluationContext.createBundle(inputBundle, outputEntry.getValue()));
+          evaluationContext.createBundle(outputEntry.getValue()));
     }
 
     ReadyCheckingSideInputReader sideInputReader =

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StructuralKey.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StructuralKey.java
@@ -42,16 +42,6 @@ abstract class StructuralKey<K> {
       public Object getKey() {
         return this;
       }
-
-      @Override
-      public boolean equals(Object other) {
-        return other != null && getClass().isAssignableFrom(other.getClass());
-      }
-
-      @Override
-      public int hashCode() {
-        return getClass().hashCode();
-      }
     };
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StructuralKey.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StructuralKey.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.direct;
 
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.util.CoderUtils;
 
 /**
@@ -27,6 +28,21 @@ import org.apache.beam.sdk.util.CoderUtils;
  * {@link Coder#structuralValue(Object)}) to perform equality and hashing.
  */
 class StructuralKey<K> {
+  private static final StructuralKey<Object> EMPTY = createEmpty();
+
+  private static StructuralKey<Object> createEmpty() {
+    @SuppressWarnings("rawtypes")
+    StructuralKey empty = of(null, VoidCoder.of());
+    return empty;
+  }
+
+  /**
+   * Get the empty {@link StructuralKey}.
+   */
+  public static StructuralKey<?> empty() {
+    return EMPTY;
+  }
+
   /**
    * Create a new Structural Key of the provided key that can be encoded by the provided coder.
    */

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StructuralKey.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StructuralKey.java
@@ -29,20 +29,25 @@ import org.apache.beam.sdk.util.CoderUtils;
 abstract class StructuralKey<K> {
 
   private StructuralKey() {
-    // Do not extend outside of this class
+    // Prevents extending outside of this class
   }
 
+  /**
+   * Returns the key that this {@link StructuralKey} was created from.
+   */
   public abstract K getKey();
+
   /**
    * Get the empty {@link StructuralKey}. All instances of the empty key are considered equal.
    */
   static StructuralKey<?> empty() {
-    return new StructuralKey<Object>() {
+    StructuralKey<Object> emptyKey = new StructuralKey<Object>() {
       @Override
       public Object getKey() {
         return this;
       }
     };
+    return emptyKey;
   }
 
   /**
@@ -74,7 +79,7 @@ abstract class StructuralKey<K> {
         return CoderUtils.decodeFromByteArray(coder, encoded);
       } catch (CoderException e) {
         throw new IllegalArgumentException(
-            "Could not decode Key with coder of type " + coder.getClass().getSimpleName());
+            "Could not decode Key with coder of type " + coder.getClass().getSimpleName(), e);
       }
     }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
@@ -124,7 +124,7 @@ class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {
         StepTransformResult.Builder result =
             StepTransformResult.withHold(application, currentWatermark);
         if (event.getType().equals(EventType.ELEMENT)) {
-          UncommittedBundle<T> bundle = context.createRootBundle(application.getOutput());
+          UncommittedBundle<T> bundle = context.createBundle(application.getOutput());
           for (TimestampedValue<T> elem : ((ElementEvent<T>) event).getElements()) {
             bundle.add(
                 WindowedValue.timestampedValueInGlobalWindow(elem.getValue(), elem.getTimestamp()));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -171,7 +171,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
 
     @Override
     public TransformResult finishBundle() throws IOException {
-      UncommittedBundle<OutputT> output = evaluationContext.createRootBundle(transform.getOutput());
+      UncommittedBundle<OutputT> output = evaluationContext.createBundle(transform.getOutput());
       try {
         boolean elementAvailable = startReader();
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UncommittedBundleOutputManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UncommittedBundleOutputManager.java
@@ -28,7 +28,7 @@ import org.apache.beam.sdk.values.TupleTag;
  * An {@link OutputManager} that outputs to {@link CommittedBundle Bundles} used by the
  * {@link DirectRunner}.
  */
-public class UncommittedBundleOutputManager implements OutputManager {
+class UncommittedBundleOutputManager implements OutputManager {
   private final Map<TupleTag<?>, UncommittedBundle<?>> bundles;
 
   public static UncommittedBundleOutputManager create(
@@ -36,7 +36,7 @@ public class UncommittedBundleOutputManager implements OutputManager {
     return new UncommittedBundleOutputManager(outputBundles);
   }
 
-  public UncommittedBundleOutputManager(Map<TupleTag<?>, UncommittedBundle<?>> bundles) {
+  UncommittedBundleOutputManager(Map<TupleTag<?>, UncommittedBundle<?>> bundles) {
     this.bundles = bundles;
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -50,16 +50,14 @@ class WindowEvaluatorFactory implements TransformEvaluatorFactory {
       @Nullable CommittedBundle<?> inputBundle
  )
       throws Exception {
-    return createTransformEvaluator(
-        (AppliedPTransform) application, inputBundle);
+    return createTransformEvaluator((AppliedPTransform) application);
   }
 
   private <InputT> TransformEvaluator<InputT> createTransformEvaluator(
-      AppliedPTransform<PCollection<InputT>, PCollection<InputT>, Window.Bound<InputT>> transform,
-      CommittedBundle<?> inputBundle) {
+      AppliedPTransform<PCollection<InputT>, PCollection<InputT>, Window.Bound<InputT>> transform) {
     WindowFn<? super InputT, ?> fn = transform.getTransform().getWindowFn();
     UncommittedBundle<InputT> outputBundle =
-        evaluationContext.createBundle(inputBundle, transform.getOutput());
+        evaluationContext.createBundle(transform.getOutput());
     if (fn == null) {
       return PassthroughTransformEvaluator.create(transform, outputBundle);
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
@@ -77,8 +77,8 @@ public class BoundedReadEvaluatorFactoryTest {
 
   @Test
   public void boundedSourceInMemoryTransformEvaluatorProducesElements() throws Exception {
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(output);
 
     TransformEvaluator<?> evaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null);
@@ -97,8 +97,8 @@ public class BoundedReadEvaluatorFactoryTest {
    */
   @Test
   public void boundedSourceInMemoryTransformEvaluatorAfterFinishIsEmpty() throws Exception {
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(output);
 
     TransformEvaluator<?> evaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null);
@@ -111,8 +111,8 @@ public class BoundedReadEvaluatorFactoryTest {
         containsInAnyOrder(
             gw(1L), gw(2L), gw(4L), gw(8L), gw(9L), gw(7L), gw(6L), gw(5L), gw(3L), gw(0L)));
 
-    UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(secondOutput);
+    UncommittedBundle<Long> secondOutput = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null);
     assertThat(secondEvaluator, nullValue());
@@ -124,9 +124,9 @@ public class BoundedReadEvaluatorFactoryTest {
    */
   @Test
   public void boundedSourceEvaluatorSimultaneousEvaluations() throws Exception {
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(longs);
-    UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(output).thenReturn(secondOutput);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(longs);
+    UncommittedBundle<Long> secondOutput = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(output).thenReturn(secondOutput);
 
     // create both evaluators before finishing either.
     TransformEvaluator<?> evaluator =
@@ -160,8 +160,8 @@ public class BoundedReadEvaluatorFactoryTest {
     PCollection<Long> pcollection = p.apply(Read.from(source));
     AppliedPTransform<?, ?, ?> sourceTransform = pcollection.getProducingTransformInternal();
 
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
-    when(context.createRootBundle(pcollection)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(pcollection);
+    when(context.createBundle(pcollection)).thenReturn(output);
 
     TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();
@@ -178,8 +178,8 @@ public class BoundedReadEvaluatorFactoryTest {
     PCollection<Long> pcollection = p.apply(Read.from(source));
     AppliedPTransform<?, ?, ?> sourceTransform = pcollection.getProducingTransformInternal();
 
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
-    when(context.createRootBundle(pcollection)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(pcollection);
+    when(context.createBundle(pcollection)).thenReturn(output);
 
     TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CommittedResultTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CommittedResultTest.java
@@ -63,7 +63,7 @@ public class CommittedResultTest implements Serializable {
     CommittedResult result =
         CommittedResult.create(
             StepTransformResult.withoutHold(transform).build(),
-            bundleFactory.createRootBundle(created).commit(Instant.now()),
+            bundleFactory.createBundle(created).commit(Instant.now()),
             Collections.<DirectRunner.CommittedBundle<?>>emptyList(),
             EnumSet.noneOf(OutputType.class));
 
@@ -73,7 +73,7 @@ public class CommittedResultTest implements Serializable {
   @Test
   public void getUncommittedElementsEqualInput() {
     DirectRunner.CommittedBundle<Integer> bundle =
-        bundleFactory.createRootBundle(created)
+        bundleFactory.createBundle(created)
             .add(WindowedValue.valueInGlobalWindow(2))
             .commit(Instant.now());
     CommittedResult result =
@@ -102,16 +102,16 @@ public class CommittedResultTest implements Serializable {
   @Test
   public void getOutputsEqualInput() {
     List<? extends DirectRunner.CommittedBundle<?>> outputs =
-        ImmutableList.of(bundleFactory.createRootBundle(PCollection.createPrimitiveOutputInternal(p,
+        ImmutableList.of(bundleFactory.createBundle(PCollection.createPrimitiveOutputInternal(p,
             WindowingStrategy.globalDefault(),
             PCollection.IsBounded.BOUNDED)).commit(Instant.now()),
-            bundleFactory.createRootBundle(PCollection.createPrimitiveOutputInternal(p,
+            bundleFactory.createBundle(PCollection.createPrimitiveOutputInternal(p,
                 WindowingStrategy.globalDefault(),
                 PCollection.IsBounded.UNBOUNDED)).commit(Instant.now()));
     CommittedResult result =
         CommittedResult.create(
             StepTransformResult.withoutHold(transform).build(),
-            bundleFactory.createRootBundle(created).commit(Instant.now()),
+            bundleFactory.createBundle(created).commit(Instant.now()),
             outputs,
             EnumSet.of(OutputType.BUNDLE, OutputType.PCOLLECTION_VIEW));
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EncodabilityEnforcementFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EncodabilityEnforcementFactoryTest.java
@@ -110,7 +110,7 @@ public class EncodabilityEnforcementFactoryTest {
     WindowedValue<Record> record = WindowedValue.<Record>valueInGlobalWindow(new Record());
 
     CommittedBundle<Record> input =
-        bundleFactory.createRootBundle(unencodable).add(record).commit(Instant.now());
+        bundleFactory.createBundle(unencodable).add(record).commit(Instant.now());
     ModelEnforcement<Record> enforcement = factory.forBundle(input, consumer);
 
     enforcement.beforeElement(record);
@@ -127,7 +127,7 @@ public class EncodabilityEnforcementFactoryTest {
     AppliedPTransform<?, ?, ?> consumer =
         unencodable.apply(Count.<T>globally()).getProducingTransformInternal();
     CommittedBundle<T> input =
-        bundleFactory.createRootBundle(unencodable).add(record).commit(Instant.now());
+        bundleFactory.createBundle(unencodable).add(record).commit(Instant.now());
     ModelEnforcement<T> enforcement = factory.forBundle(input, consumer);
     return enforcement;
   }
@@ -142,7 +142,7 @@ public class EncodabilityEnforcementFactoryTest {
     WindowedValue<Integer> value = WindowedValue.valueInGlobalWindow(1);
 
     CommittedBundle<Integer> input =
-        bundleFactory.createRootBundle(unencodable).add(value).commit(Instant.now());
+        bundleFactory.createBundle(unencodable).add(value).commit(Instant.now());
     ModelEnforcement<Integer> enforcement = factory.forBundle(input, consumer);
 
     enforcement.beforeElement(value);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
@@ -55,17 +55,16 @@ public class FlattenEvaluatorFactoryTest {
     PCollection<Integer> flattened = list.apply(Flatten.<Integer>pCollections());
 
     CommittedBundle<Integer> leftBundle =
-        bundleFactory.createRootBundle(left).commit(Instant.now());
+        bundleFactory.createBundle(left).commit(Instant.now());
     CommittedBundle<Integer> rightBundle =
-        bundleFactory.createRootBundle(right).commit(Instant.now());
+        bundleFactory.createBundle(right).commit(Instant.now());
 
     EvaluationContext context = mock(EvaluationContext.class);
 
-    UncommittedBundle<Integer> flattenedLeftBundle = bundleFactory.createRootBundle(flattened);
-    UncommittedBundle<Integer> flattenedRightBundle = bundleFactory.createRootBundle(flattened);
+    UncommittedBundle<Integer> flattenedLeftBundle = bundleFactory.createBundle(flattened);
+    UncommittedBundle<Integer> flattenedRightBundle = bundleFactory.createBundle(flattened);
 
-    when(context.createBundle(leftBundle, flattened)).thenReturn(flattenedLeftBundle);
-    when(context.createBundle(rightBundle, flattened)).thenReturn(flattenedRightBundle);
+    when(context.createBundle(flattened)).thenReturn(flattenedLeftBundle, flattenedRightBundle);
 
     FlattenEvaluatorFactory factory = new FlattenEvaluatorFactory(context);
     TransformEvaluator<Integer> leftSideEvaluator =

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyEvaluatorFactoryTest.java
@@ -70,27 +70,27 @@ public class GroupByKeyEvaluatorFactoryTest {
         kvs.apply(new DirectGroupByKeyOnly<String, Integer>());
 
     CommittedBundle<KV<String, WindowedValue<Integer>>> inputBundle =
-        bundleFactory.createRootBundle(kvs).commit(Instant.now());
+        bundleFactory.createBundle(kvs).commit(Instant.now());
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     StructuralKey<String> fooKey = StructuralKey.of("foo", StringUtf8Coder.of());
     UncommittedBundle<KeyedWorkItem<String, Integer>> fooBundle =
-        bundleFactory.createKeyedBundle(null, fooKey, groupedKvs);
+        bundleFactory.createKeyedBundle(fooKey, groupedKvs);
 
     StructuralKey<String> barKey = StructuralKey.of("bar", StringUtf8Coder.of());
     UncommittedBundle<KeyedWorkItem<String, Integer>> barBundle =
-        bundleFactory.createKeyedBundle(null, barKey, groupedKvs);
+        bundleFactory.createKeyedBundle(barKey, groupedKvs);
 
     StructuralKey<String> bazKey = StructuralKey.of("baz", StringUtf8Coder.of());
     UncommittedBundle<KeyedWorkItem<String, Integer>> bazBundle =
-        bundleFactory.createKeyedBundle(null, bazKey, groupedKvs);
+        bundleFactory.createKeyedBundle(bazKey, groupedKvs);
 
-    when(evaluationContext.createKeyedBundle(inputBundle,
+    when(evaluationContext.createKeyedBundle(
         fooKey,
         groupedKvs)).thenReturn(fooBundle);
-    when(evaluationContext.createKeyedBundle(inputBundle,
+    when(evaluationContext.createKeyedBundle(
         barKey,
         groupedKvs)).thenReturn(barBundle);
-    when(evaluationContext.createKeyedBundle(inputBundle,
+    when(evaluationContext.createKeyedBundle(
         bazKey,
         groupedKvs)).thenReturn(bazBundle);
 
@@ -114,7 +114,7 @@ public class GroupByKeyEvaluatorFactoryTest {
     assertThat(
         fooBundle.commit(Instant.now()).getElements(),
         contains(
-            new KeyedWorkItemMatcher<String, Integer>(
+            new KeyedWorkItemMatcher<>(
                 KeyedWorkItems.elementsWorkItem(
                     "foo",
                     ImmutableSet.of(
@@ -125,7 +125,7 @@ public class GroupByKeyEvaluatorFactoryTest {
     assertThat(
         barBundle.commit(Instant.now()).getElements(),
         contains(
-            new KeyedWorkItemMatcher<String, Integer>(
+            new KeyedWorkItemMatcher<>(
                 KeyedWorkItems.elementsWorkItem(
                     "bar",
                     ImmutableSet.of(
@@ -135,7 +135,7 @@ public class GroupByKeyEvaluatorFactoryTest {
     assertThat(
         bazBundle.commit(Instant.now()).getElements(),
         contains(
-            new KeyedWorkItemMatcher<String, Integer>(
+            new KeyedWorkItemMatcher<>(
                 KeyedWorkItems.elementsWorkItem(
                     "baz",
                     ImmutableSet.of(WindowedValue.valueInGlobalWindow(Integer.MAX_VALUE))),
@@ -151,7 +151,7 @@ public class GroupByKeyEvaluatorFactoryTest {
     private final KeyedWorkItem<K, V> myWorkItem;
     private final Coder<K> keyCoder;
 
-    public KeyedWorkItemMatcher(KeyedWorkItem<K, V> myWorkItem, Coder<K> keyCoder) {
+    KeyedWorkItemMatcher(KeyedWorkItem<K, V> myWorkItem, Coder<K> keyCoder) {
       this.myWorkItem = myWorkItem;
       this.keyCoder = keyCoder;
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactoryTest.java
@@ -70,31 +70,22 @@ public class GroupByKeyOnlyEvaluatorFactoryTest {
         kvs.apply(new DirectGroupByKeyOnly<String, Integer>());
 
     CommittedBundle<KV<String, WindowedValue<Integer>>> inputBundle =
-        bundleFactory.createRootBundle(kvs).commit(Instant.now());
+        bundleFactory.createBundle(kvs).commit(Instant.now());
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
 
     StructuralKey<String> fooKey = StructuralKey.of("foo", StringUtf8Coder.of());
-    UncommittedBundle<KeyedWorkItem<String, Integer>> fooBundle = bundleFactory.createKeyedBundle(
-        null, fooKey,
-        groupedKvs);
+    UncommittedBundle<KeyedWorkItem<String, Integer>> fooBundle =
+        bundleFactory.createKeyedBundle(fooKey, groupedKvs);
     StructuralKey<String> barKey = StructuralKey.of("bar", StringUtf8Coder.of());
-    UncommittedBundle<KeyedWorkItem<String, Integer>> barBundle = bundleFactory.createKeyedBundle(
-        null, barKey,
-        groupedKvs);
+    UncommittedBundle<KeyedWorkItem<String, Integer>> barBundle =
+        bundleFactory.createKeyedBundle(barKey, groupedKvs);
     StructuralKey<String> bazKey = StructuralKey.of("baz", StringUtf8Coder.of());
-    UncommittedBundle<KeyedWorkItem<String, Integer>> bazBundle = bundleFactory.createKeyedBundle(
-        null, bazKey,
-        groupedKvs);
+    UncommittedBundle<KeyedWorkItem<String, Integer>> bazBundle =
+        bundleFactory.createKeyedBundle(bazKey, groupedKvs);
 
-    when(evaluationContext.createKeyedBundle(inputBundle,
-        fooKey,
-        groupedKvs)).thenReturn(fooBundle);
-    when(evaluationContext.createKeyedBundle(inputBundle,
-        barKey,
-        groupedKvs)).thenReturn(barBundle);
-    when(evaluationContext.createKeyedBundle(inputBundle,
-        bazKey,
-        groupedKvs)).thenReturn(bazBundle);
+    when(evaluationContext.createKeyedBundle(fooKey, groupedKvs)).thenReturn(fooBundle);
+    when(evaluationContext.createKeyedBundle(barKey, groupedKvs)).thenReturn(barBundle);
+    when(evaluationContext.createKeyedBundle(bazKey, groupedKvs)).thenReturn(bazBundle);
 
     // The input to a GroupByKey is assumed to be a KvCoder
     @SuppressWarnings("unchecked")

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutabilityEnforcementFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutabilityEnforcementFactoryTest.java
@@ -71,7 +71,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
   public void unchangedSucceeds() {
     WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes());
     CommittedBundle<byte[]> elements =
-        bundleFactory.createRootBundle(pcollection).add(element).commit(Instant.now());
+        bundleFactory.createBundle(pcollection).add(element).commit(Instant.now());
 
     ModelEnforcement<byte[]> enforcement = factory.forBundle(elements, consumer);
     enforcement.beforeElement(element);
@@ -86,7 +86,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
   public void mutatedDuringProcessElementThrows() {
     WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes());
     CommittedBundle<byte[]> elements =
-        bundleFactory.createRootBundle(pcollection).add(element).commit(Instant.now());
+        bundleFactory.createBundle(pcollection).add(element).commit(Instant.now());
 
     ModelEnforcement<byte[]> enforcement = factory.forBundle(elements, consumer);
     enforcement.beforeElement(element);
@@ -107,7 +107,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
 
     WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes());
     CommittedBundle<byte[]> elements =
-        bundleFactory.createRootBundle(pcollection).add(element).commit(Instant.now());
+        bundleFactory.createBundle(pcollection).add(element).commit(Instant.now());
 
     ModelEnforcement<byte[]> enforcement = factory.forBundle(elements, consumer);
     enforcement.beforeElement(element);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
@@ -71,9 +71,7 @@ public class ImmutableListBundleFactoryTest {
 
   @Test
   public void createRootBundleShouldCreateWithEmptyKey() {
-    PCollection<Integer> pcollection = TestPipeline.create().apply(Create.of(1));
-
-    UncommittedBundle<Integer> inFlightBundle = bundleFactory.createRootBundle(pcollection);
+    UncommittedBundle<Integer> inFlightBundle = bundleFactory.createRootBundle();
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
 
@@ -83,13 +81,12 @@ public class ImmutableListBundleFactoryTest {
 
   private <T> void createKeyedBundle(Coder<T> coder, T key) throws Exception {
     PCollection<Integer> pcollection = TestPipeline.create().apply(Create.of(1));
-    StructuralKey skey = StructuralKey.of(key, coder);
+    StructuralKey<?> skey = StructuralKey.of(key, coder);
 
-    UncommittedBundle<Integer> inFlightBundle =
-        bundleFactory.createKeyedBundle(null, skey, pcollection);
+    UncommittedBundle<Integer> inFlightBundle = bundleFactory.createKeyedBundle(skey, pcollection);
 
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
-    assertThat(bundle.getKey(), equalTo(skey));
+    assertThat(bundle.getKey(), Matchers.<StructuralKey<?>>equalTo(skey));
   }
 
   @Test
@@ -106,9 +103,7 @@ public class ImmutableListBundleFactoryTest {
 
   private <T> CommittedBundle<T>
   afterCommitGetElementsShouldHaveAddedElements(Iterable<WindowedValue<T>> elems) {
-    PCollection<T> pcollection = TestPipeline.create().apply(Create.<T>of());
-
-    UncommittedBundle<T> bundle = bundleFactory.createRootBundle(pcollection);
+    UncommittedBundle<T> bundle = bundleFactory.createRootBundle();
     Collection<Matcher<? super WindowedValue<T>>> expectations = new ArrayList<>();
     for (WindowedValue<T> elem : elems) {
       bundle.add(elem);
@@ -168,9 +163,7 @@ public class ImmutableListBundleFactoryTest {
 
   @Test
   public void addAfterCommitShouldThrowException() {
-    PCollection<Integer> pcollection = TestPipeline.create().apply(Create.<Integer>of());
-
-    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle(pcollection);
+    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle();
     bundle.add(WindowedValue.valueInGlobalWindow(1));
     CommittedBundle<Integer> firstCommit = bundle.commit(Instant.now());
     assertThat(firstCommit.getElements(), containsInAnyOrder(WindowedValue.valueInGlobalWindow(1)));
@@ -184,9 +177,7 @@ public class ImmutableListBundleFactoryTest {
 
   @Test
   public void commitAfterCommitShouldThrowException() {
-    PCollection<Integer> pcollection = TestPipeline.create().apply(Create.<Integer>of());
-
-    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle(pcollection);
+    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle();
     bundle.add(WindowedValue.valueInGlobalWindow(1));
     CommittedBundle<Integer> firstCommit = bundle.commit(Instant.now());
     assertThat(firstCommit.getElements(), containsInAnyOrder(WindowedValue.valueInGlobalWindow(1)));
@@ -198,29 +189,8 @@ public class ImmutableListBundleFactoryTest {
   }
 
   @Test
-  public void createBundleUnkeyedResultUnkeyed() {
-    CommittedBundle<KV<String, Integer>> newBundle =
-        bundleFactory
-            .createBundle(bundleFactory.createRootBundle(created).commit(Instant.now()), downstream)
-            .commit(Instant.now());
-  }
-
-  @Test
-  public void createBundleKeyedResultPropagatesKey() {
-    CommittedBundle<KV<String, Integer>> newBundle =
-        bundleFactory.createBundle(
-            bundleFactory.createKeyedBundle(
-                null,
-                StructuralKey.of("foo", StringUtf8Coder.of()),
-                created).commit(Instant.now()),
-            downstream).commit(Instant.now());
-    assertThat(newBundle.getKey().getKey(), Matchers.<Object>equalTo("foo"));
-  }
-
-  @Test
   public void createKeyedBundleKeyed() {
     CommittedBundle<KV<String, Integer>> keyedBundle = bundleFactory.createKeyedBundle(
-        bundleFactory.createRootBundle(created).commit(Instant.now()),
         StructuralKey.of("foo", StringUtf8Coder.of()),
         downstream).commit(Instant.now());
     assertThat(keyedBundle.getKey().getKey(), Matchers.<Object>equalTo("foo"));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
@@ -69,16 +69,6 @@ public class ImmutableListBundleFactoryTest {
     downstream = created.apply(WithKeys.<String, Integer>of("foo"));
   }
 
-  @Test
-  public void createRootBundleShouldCreateWithEmptyKey() {
-    UncommittedBundle<Integer> inFlightBundle = bundleFactory.createRootBundle();
-
-    CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
-
-    assertThat(bundle.getKey(),
-        Matchers.<StructuralKey<?>>equalTo(StructuralKey.empty()));
-  }
-
   private <T> void createKeyedBundle(Coder<T> coder, T key) throws Exception {
     PCollection<Integer> pcollection = TestPipeline.create().apply(Create.of(1));
     StructuralKey<?> skey = StructuralKey.of(key, coder);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
@@ -76,7 +76,7 @@ public class ImmutableListBundleFactoryTest {
     CommittedBundle<Integer> bundle = inFlightBundle.commit(Instant.now());
 
     assertThat(bundle.getKey(),
-        Matchers.<StructuralKey<?>>equalTo(StructuralKey.of(null, VoidCoder.of())));
+        Matchers.<StructuralKey<?>>equalTo(StructuralKey.empty()));
   }
 
   private <T> void createKeyedBundle(Coder<T> coder, T key) throws Exception {

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoEvaluatorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoEvaluatorTest.java
@@ -94,10 +94,9 @@ public class ParDoEvaluatorTest {
     PCollection<Integer> output = inputPc.apply(ParDo.of(fn).withSideInputs(singletonView));
 
     CommittedBundle<Integer> inputBundle =
-        bundleFactory.createRootBundle(inputPc).commit(Instant.now());
-    UncommittedBundle<Integer> outputBundle = bundleFactory.createBundle(inputBundle, output);
-    when(evaluationContext.createBundle(inputBundle, output))
-        .thenReturn(outputBundle);
+        bundleFactory.createBundle(inputPc).commit(Instant.now());
+    UncommittedBundle<Integer> outputBundle = bundleFactory.createBundle(output);
+    when(evaluationContext.createBundle(output)).thenReturn(outputBundle);
 
     ParDoEvaluator<Integer> evaluator =
         createEvaluator(singletonView, fn, inputBundle, output);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoMultiEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoMultiEvaluatorFactoryTest.java
@@ -92,7 +92,7 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     PCollectionTuple outputTuple = input.apply(pardo);
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     PCollection<KV<String, Integer>> mainOutput = outputTuple.get(mainOutputTag);
     PCollection<String> elementOutput = outputTuple.get(elementTag);
@@ -100,14 +100,13 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     UncommittedBundle<KV<String, Integer>> mainOutputBundle =
-        bundleFactory.createRootBundle(mainOutput);
-    UncommittedBundle<String> elementOutputBundle = bundleFactory.createRootBundle(elementOutput);
-    UncommittedBundle<Integer> lengthOutputBundle = bundleFactory.createRootBundle(lengthOutput);
+        bundleFactory.createBundle(mainOutput);
+    UncommittedBundle<String> elementOutputBundle = bundleFactory.createBundle(elementOutput);
+    UncommittedBundle<Integer> lengthOutputBundle = bundleFactory.createBundle(lengthOutput);
 
-    when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
-    when(evaluationContext.createBundle(inputBundle, elementOutput))
-        .thenReturn(elementOutputBundle);
-    when(evaluationContext.createBundle(inputBundle, lengthOutput)).thenReturn(lengthOutputBundle);
+    when(evaluationContext.createBundle(mainOutput)).thenReturn(mainOutputBundle);
+    when(evaluationContext.createBundle(elementOutput)).thenReturn(elementOutputBundle);
+    when(evaluationContext.createBundle(lengthOutput)).thenReturn(lengthOutputBundle);
 
     DirectExecutionContext executionContext =
         new DirectExecutionContext(null, null, null, null);
@@ -182,19 +181,18 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     PCollectionTuple outputTuple = input.apply(pardo);
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     PCollection<KV<String, Integer>> mainOutput = outputTuple.get(mainOutputTag);
     PCollection<String> elementOutput = outputTuple.get(elementTag);
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     UncommittedBundle<KV<String, Integer>> mainOutputBundle =
-        bundleFactory.createRootBundle(mainOutput);
-    UncommittedBundle<String> elementOutputBundle = bundleFactory.createRootBundle(elementOutput);
+        bundleFactory.createBundle(mainOutput);
+    UncommittedBundle<String> elementOutputBundle = bundleFactory.createBundle(elementOutput);
 
-    when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
-    when(evaluationContext.createBundle(inputBundle, elementOutput))
-        .thenReturn(elementOutputBundle);
+    when(evaluationContext.createBundle(mainOutput)).thenReturn(mainOutputBundle);
+    when(evaluationContext.createBundle(elementOutput)).thenReturn(elementOutputBundle);
 
     DirectExecutionContext executionContext =
         new DirectExecutionContext(null, null, null, null);
@@ -274,19 +272,18 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     PCollectionTuple outputTuple = input.apply(pardo);
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     PCollection<KV<String, Integer>> mainOutput = outputTuple.get(mainOutputTag);
     PCollection<String> elementOutput = outputTuple.get(elementTag);
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     UncommittedBundle<KV<String, Integer>> mainOutputBundle =
-        bundleFactory.createRootBundle(mainOutput);
-    UncommittedBundle<String> elementOutputBundle = bundleFactory.createRootBundle(elementOutput);
+        bundleFactory.createBundle(mainOutput);
+    UncommittedBundle<String> elementOutputBundle = bundleFactory.createBundle(elementOutput);
 
-    when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
-    when(evaluationContext.createBundle(inputBundle, elementOutput))
-        .thenReturn(elementOutputBundle);
+    when(evaluationContext.createBundle(mainOutput)).thenReturn(mainOutputBundle);
+    when(evaluationContext.createBundle(elementOutput)).thenReturn(elementOutputBundle);
 
     DirectExecutionContext executionContext = new DirectExecutionContext(null,
         StructuralKey.of("myKey", StringUtf8Coder.of()),
@@ -388,19 +385,18 @@ public class ParDoMultiEvaluatorFactoryTest implements Serializable {
     PCollectionTuple outputTuple = input.apply(pardo);
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     PCollection<KV<String, Integer>> mainOutput = outputTuple.get(mainOutputTag);
     PCollection<String> elementOutput = outputTuple.get(elementTag);
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     UncommittedBundle<KV<String, Integer>> mainOutputBundle =
-        bundleFactory.createRootBundle(mainOutput);
-    UncommittedBundle<String> elementOutputBundle = bundleFactory.createRootBundle(elementOutput);
+        bundleFactory.createBundle(mainOutput);
+    UncommittedBundle<String> elementOutputBundle = bundleFactory.createBundle(elementOutput);
 
-    when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
-    when(evaluationContext.createBundle(inputBundle, elementOutput))
-        .thenReturn(elementOutputBundle);
+    when(evaluationContext.createBundle(mainOutput)).thenReturn(mainOutputBundle);
+    when(evaluationContext.createBundle(elementOutput)).thenReturn(elementOutputBundle);
 
     DirectExecutionContext executionContext = new DirectExecutionContext(null,
         StructuralKey.of("myKey", StringUtf8Coder.of()),

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoSingleEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoSingleEvaluatorFactoryTest.java
@@ -80,11 +80,11 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
                   }
                 }));
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
-    UncommittedBundle<Integer> outputBundle = bundleFactory.createRootBundle(collection);
-    when(evaluationContext.createBundle(inputBundle, collection)).thenReturn(outputBundle);
+    UncommittedBundle<Integer> outputBundle = bundleFactory.createBundle(collection);
+    when(evaluationContext.createBundle(collection)).thenReturn(outputBundle);
     DirectExecutionContext executionContext =
         new DirectExecutionContext(null, null, null, null);
     when(evaluationContext.getExecutionContext(collection.getProducingTransformInternal(),
@@ -134,11 +134,11 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
                   }
                 }));
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
-    UncommittedBundle<Integer> outputBundle = bundleFactory.createRootBundle(collection);
-    when(evaluationContext.createBundle(inputBundle, collection)).thenReturn(outputBundle);
+    UncommittedBundle<Integer> outputBundle = bundleFactory.createBundle(collection);
+    when(evaluationContext.createBundle(collection)).thenReturn(outputBundle);
     DirectExecutionContext executionContext =
         new DirectExecutionContext(null, null, null, null);
     when(evaluationContext.getExecutionContext(collection.getProducingTransformInternal(),
@@ -197,13 +197,13 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
     PCollection<KV<String, Integer>> mainOutput = input.apply(pardo);
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     UncommittedBundle<KV<String, Integer>> mainOutputBundle =
-        bundleFactory.createRootBundle(mainOutput);
+        bundleFactory.createBundle(mainOutput);
 
-    when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
+    when(evaluationContext.createBundle(mainOutput)).thenReturn(mainOutputBundle);
 
     DirectExecutionContext executionContext = new DirectExecutionContext(null,
         StructuralKey.of("myKey", StringUtf8Coder.of()),
@@ -299,13 +299,13 @@ public class ParDoSingleEvaluatorFactoryTest implements Serializable {
 
     StructuralKey<?> key = StructuralKey.of("myKey", StringUtf8Coder.of());
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     UncommittedBundle<KV<String, Integer>> mainOutputBundle =
-        bundleFactory.createRootBundle(mainOutput);
+        bundleFactory.createBundle(mainOutput);
 
-    when(evaluationContext.createBundle(inputBundle, mainOutput)).thenReturn(mainOutputBundle);
+    when(evaluationContext.createBundle(mainOutput)).thenReturn(mainOutputBundle);
 
     DirectExecutionContext executionContext = new DirectExecutionContext(null,
         key,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StepTransformResultTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StepTransformResultTest.java
@@ -55,7 +55,7 @@ public class StepTransformResultTest {
 
   @Test
   public void producedBundlesProducedOutputs() {
-    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle(pc);
+    UncommittedBundle<Integer> bundle = bundleFactory.createBundle(pc);
     TransformResult result = StepTransformResult.withoutHold(transform).addOutput(bundle)
         .build();
 
@@ -74,7 +74,7 @@ public class StepTransformResultTest {
   @Test
   public void producedBundlesAndAdditionalOutputProducedOutputs() {
     TransformResult result = StepTransformResult.withoutHold(transform)
-        .addOutput(bundleFactory.createRootBundle(pc))
+        .addOutput(bundleFactory.createBundle(pc))
         .withAdditionalOutput(OutputType.PCOLLECTION_VIEW)
         .build();
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StructuralKeyTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StructuralKeyTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertThat;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -50,6 +51,14 @@ public class StructuralKeyTest {
     StructuralKey<byte[]> key = StructuralKey.of(original, ByteArrayCoder.of());
 
     assertThat(key.getKey(), not(theInstance(original)));
+  }
+
+  @Test
+  public void emptyKeysEqual() {
+    StructuralKey<?> empty = StructuralKey.empty();
+
+    assertThat(empty, Matchers.<StructuralKey<?>>equalTo(StructuralKey.empty()));
+    assertThat(empty, not(Matchers.<StructuralKey<?>>theInstance(StructuralKey.empty())));
   }
 
   @Test

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StructuralKeyTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StructuralKeyTest.java
@@ -58,7 +58,7 @@ public class StructuralKeyTest {
     StructuralKey<?> empty = StructuralKey.empty();
 
     assertThat(empty, not(Matchers.<StructuralKey<?>>equalTo(StructuralKey.empty())));
-    assertThat(empty, equalTo(empty));
+    assertThat(empty, Matchers.<StructuralKey<?>>equalTo(empty));
   }
 
   @Test

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StructuralKeyTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StructuralKeyTest.java
@@ -54,11 +54,11 @@ public class StructuralKeyTest {
   }
 
   @Test
-  public void emptyKeysEqual() {
+  public void emptyKeysNotEqual() {
     StructuralKey<?> empty = StructuralKey.empty();
 
-    assertThat(empty, Matchers.<StructuralKey<?>>equalTo(StructuralKey.empty()));
-    assertThat(empty, not(Matchers.<StructuralKey<?>>theInstance(StructuralKey.empty())));
+    assertThat(empty, not(Matchers.<StructuralKey<?>>equalTo(StructuralKey.empty())));
+    assertThat(empty, equalTo(empty));
   }
 
   @Test

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactoryTest.java
@@ -65,9 +65,8 @@ public class TestStreamEvaluatorFactoryTest {
                 .addElements(4, 5, 6)
                 .advanceWatermarkToInfinity());
 
-    when(context.createRootBundle(streamVals))
-        .thenReturn(
-            bundleFactory.createRootBundle(streamVals), bundleFactory.createRootBundle(streamVals));
+    when(context.createBundle(streamVals))
+        .thenReturn(bundleFactory.createBundle(streamVals), bundleFactory.createBundle(streamVals));
 
     TransformEvaluator<Object> firstEvaluator =
         factory.forApplication(streamVals.getProducingTransformInternal(), null);
@@ -134,9 +133,8 @@ public class TestStreamEvaluatorFactoryTest {
     PCollection<Integer> firstVals = p.apply("Stream One", stream);
     PCollection<Integer> secondVals = p.apply("Stream A", stream);
 
-    when(context.createRootBundle(firstVals)).thenReturn(bundleFactory.createRootBundle(firstVals));
-    when(context.createRootBundle(secondVals))
-        .thenReturn(bundleFactory.createRootBundle(secondVals));
+    when(context.createBundle(firstVals)).thenReturn(bundleFactory.createBundle(firstVals));
+    when(context.createBundle(secondVals)).thenReturn(bundleFactory.createBundle(secondVals));
 
     TransformEvaluator<Object> firstEvaluator =
         factory.forApplication(firstVals.getProducingTransformInternal(), null);
@@ -181,9 +179,8 @@ public class TestStreamEvaluatorFactoryTest {
                 .addElements("Two")
                 .advanceWatermarkToInfinity());
 
-    when(context.createRootBundle(firstVals)).thenReturn(bundleFactory.createRootBundle(firstVals));
-    when(context.createRootBundle(secondVals))
-        .thenReturn(bundleFactory.createRootBundle(secondVals));
+    when(context.createBundle(firstVals)).thenReturn(bundleFactory.createBundle(firstVals));
+    when(context.createBundle(secondVals)).thenReturn(bundleFactory.createBundle(secondVals));
 
     TransformEvaluator<Object> firstEvaluator =
         factory.forApplication(firstVals.getProducingTransformInternal(), null);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
@@ -171,7 +171,7 @@ public class TransformExecutorTest {
     WindowedValue<String> spam = WindowedValue.valueInGlobalWindow("spam");
     WindowedValue<String> third = WindowedValue.valueInGlobalWindow("third");
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(created).add(foo).add(spam).add(third).commit(Instant.now());
+        bundleFactory.createBundle(created).add(foo).add(spam).add(third).commit(Instant.now());
     when(registry.<String>forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
@@ -213,7 +213,7 @@ public class TransformExecutorTest {
 
     WindowedValue<String> foo = WindowedValue.valueInGlobalWindow("foo");
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(created).add(foo).commit(Instant.now());
+        bundleFactory.createBundle(created).add(foo).commit(Instant.now());
     when(registry.<String>forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
@@ -248,7 +248,7 @@ public class TransformExecutorTest {
         };
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(created).commit(Instant.now());
+        bundleFactory.createBundle(created).commit(Instant.now());
     when(registry.<String>forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
@@ -328,7 +328,7 @@ public class TransformExecutorTest {
     WindowedValue<String> fooElem = WindowedValue.valueInGlobalWindow("foo");
     WindowedValue<String> barElem = WindowedValue.valueInGlobalWindow("bar");
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(created).add(fooElem).add(barElem).commit(Instant.now());
+        bundleFactory.createBundle(created).add(fooElem).add(barElem).commit(Instant.now());
     when(registry.forApplication(downstream.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
@@ -386,7 +386,7 @@ public class TransformExecutorTest {
 
     WindowedValue<byte[]> fooBytes = WindowedValue.valueInGlobalWindow("foo".getBytes());
     CommittedBundle<byte[]> inputBundle =
-        bundleFactory.createRootBundle(pcBytes).add(fooBytes).commit(Instant.now());
+        bundleFactory.createBundle(pcBytes).add(fooBytes).commit(Instant.now());
     when(registry.forApplication(pcBytes.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 
@@ -442,7 +442,7 @@ public class TransformExecutorTest {
 
     WindowedValue<byte[]> fooBytes = WindowedValue.valueInGlobalWindow("foo".getBytes());
     CommittedBundle<byte[]> inputBundle =
-        bundleFactory.createRootBundle(pcBytes).add(fooBytes).commit(Instant.now());
+        bundleFactory.createBundle(pcBytes).add(fooBytes).commit(Instant.now());
     when(registry.forApplication(pcBytes.getProducingTransformInternal(), inputBundle))
         .thenReturn(evaluator);
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
@@ -83,8 +83,8 @@ public class UnboundedReadEvaluatorFactoryTest {
 
     context = mock(EvaluationContext.class);
     factory = new UnboundedReadEvaluatorFactory(context);
-    output = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(output);
+    output = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(output);
   }
 
   @Test
@@ -120,8 +120,8 @@ public class UnboundedReadEvaluatorFactoryTest {
             tgw(1L), tgw(2L), tgw(4L), tgw(8L), tgw(9L), tgw(7L), tgw(6L), tgw(5L), tgw(3L),
             tgw(0L)));
 
-    UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(secondOutput);
+    UncommittedBundle<Long> secondOutput = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator =
         factory.forApplication(longs.getProducingTransformInternal(), null);
     TransformResult secondResult = secondEvaluator.finishBundle();
@@ -148,8 +148,8 @@ public class UnboundedReadEvaluatorFactoryTest {
     PCollection<Long> pcollection = p.apply(Read.from(source));
     AppliedPTransform<?, ?, ?> sourceTransform = pcollection.getProducingTransformInternal();
 
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
-    when(context.createRootBundle(pcollection)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(pcollection);
+    when(context.createBundle(pcollection)).thenReturn(output);
     TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
 
     evaluator.finishBundle();
@@ -157,8 +157,8 @@ public class UnboundedReadEvaluatorFactoryTest {
         output.commit(Instant.now()).getElements(),
         containsInAnyOrder(tgw(1L), tgw(2L), tgw(4L), tgw(3L), tgw(0L)));
 
-    UncommittedBundle<Long> secondOutput = bundleFactory.createRootBundle(longs);
-    when(context.createRootBundle(longs)).thenReturn(secondOutput);
+    UncommittedBundle<Long> secondOutput = bundleFactory.createBundle(longs);
+    when(context.createBundle(longs)).thenReturn(secondOutput);
     TransformEvaluator<?> secondEvaluator = factory.forApplication(sourceTransform, null);
     secondEvaluator.finishBundle();
     assertThat(
@@ -178,8 +178,8 @@ public class UnboundedReadEvaluatorFactoryTest {
     PCollection<Long> pcollection = p.apply(Read.from(source));
     AppliedPTransform<?, ?, ?> sourceTransform = pcollection.getProducingTransformInternal();
 
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
-    when(context.createRootBundle(pcollection)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(pcollection);
+    when(context.createBundle(pcollection)).thenReturn(output);
 
     for (int i = 0; i < UnboundedReadEvaluatorFactory.MAX_READER_REUSE_COUNT + 1; i++) {
       TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
@@ -197,8 +197,8 @@ public class UnboundedReadEvaluatorFactoryTest {
     PCollection<Long> pcollection = p.apply(Read.from(source));
     AppliedPTransform<?, ?, ?> sourceTransform = pcollection.getProducingTransformInternal();
 
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
-    when(context.createRootBundle(pcollection)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(pcollection);
+    when(context.createBundle(pcollection)).thenReturn(output);
 
     TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);
     evaluator.finishBundle();
@@ -222,8 +222,8 @@ public class UnboundedReadEvaluatorFactoryTest {
     PCollection<Long> pcollection = p.apply(Read.from(source));
     AppliedPTransform<?, ?, ?> sourceTransform = pcollection.getProducingTransformInternal();
 
-    UncommittedBundle<Long> output = bundleFactory.createRootBundle(pcollection);
-    when(context.createRootBundle(pcollection)).thenReturn(output);
+    UncommittedBundle<Long> output = bundleFactory.createBundle(pcollection);
+    when(context.createBundle(pcollection)).thenReturn(output);
 
     for (int i = 0; i < 2 * UnboundedReadEvaluatorFactory.MAX_READER_REUSE_COUNT; i++) {
       TransformEvaluator<?> evaluator = factory.forApplication(sourceTransform, null);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
@@ -72,7 +72,7 @@ public class ViewEvaluatorFactoryTest {
     when(context.createPCollectionViewWriter(concat, view)).thenReturn(viewWriter);
 
     CommittedBundle<String> inputBundle =
-        bundleFactory.createRootBundle(input).commit(Instant.now());
+        bundleFactory.createBundle(input).commit(Instant.now());
     TransformEvaluator<Iterable<String>> evaluator =
         new ViewEvaluatorFactory(context)
             .forApplication(view.getProducingTransformInternal(), inputBundle);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WatermarkManagerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WatermarkManagerTest.java
@@ -276,7 +276,7 @@ public class WatermarkManagerTest implements Serializable {
     assertThat(withBufferedElements.getOutputWatermark(), equalTo(firstCollectionTimestamp));
 
     CommittedBundle<?> completedFlattenBundle =
-        bundleFactory.createRootBundle(flattened).commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
+        bundleFactory.createBundle(flattened).commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
     manager.updateWatermarks(firstPcollectionBundle,
         TimerUpdate.empty(),
         result(flattened.getProducingTransformInternal(),
@@ -399,14 +399,14 @@ public class WatermarkManagerTest implements Serializable {
    */
   @Test
   public void updateWatermarkWithKeyedWatermarkHolds() {
-    CommittedBundle<Integer> firstKeyBundle = bundleFactory.createKeyedBundle(null,
+    CommittedBundle<Integer> firstKeyBundle = bundleFactory.createKeyedBundle(
         StructuralKey.of("Odd", StringUtf8Coder.of()),
         createdInts)
         .add(WindowedValue.timestampedValueInGlobalWindow(1, new Instant(1_000_000L)))
         .add(WindowedValue.timestampedValueInGlobalWindow(3, new Instant(-1000L)))
         .commit(clock.now());
 
-    CommittedBundle<Integer> secondKeyBundle = bundleFactory.createKeyedBundle(null,
+    CommittedBundle<Integer> secondKeyBundle = bundleFactory.createKeyedBundle(
         StructuralKey.of("Even", StringUtf8Coder.of()),
         createdInts)
         .add(WindowedValue.timestampedValueInGlobalWindow(2, new Instant(1234L)))
@@ -439,7 +439,7 @@ public class WatermarkManagerTest implements Serializable {
         not(earlierThan(BoundedWindow.TIMESTAMP_MAX_VALUE)));
     assertThat(filteredWatermarks.getOutputWatermark(), not(laterThan(new Instant(-1000L))));
 
-    CommittedBundle<Integer> fauxFirstKeyTimerBundle = bundleFactory.createKeyedBundle(null,
+    CommittedBundle<Integer> fauxFirstKeyTimerBundle = bundleFactory.createKeyedBundle(
         StructuralKey.of("Odd", StringUtf8Coder.of()),
         createdInts).commit(clock.now());
     manager.updateWatermarks(fauxFirstKeyTimerBundle,
@@ -452,7 +452,7 @@ public class WatermarkManagerTest implements Serializable {
 
     assertThat(filteredWatermarks.getOutputWatermark(), equalTo(new Instant(1234L)));
 
-    CommittedBundle<Integer> fauxSecondKeyTimerBundle = bundleFactory.createKeyedBundle(null,
+    CommittedBundle<Integer> fauxSecondKeyTimerBundle = bundleFactory.createKeyedBundle(
         StructuralKey.of("Even", StringUtf8Coder.of()),
         createdInts).commit(clock.now());
     manager.updateWatermarks(fauxSecondKeyTimerBundle,
@@ -482,7 +482,7 @@ public class WatermarkManagerTest implements Serializable {
   @Test
   public void updateOutputWatermarkShouldBeMonotonic() {
     CommittedBundle<?> firstInput =
-        bundleFactory.createRootBundle(createdInts).commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
+        bundleFactory.createBundle(createdInts).commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
     manager.updateWatermarks(null,  TimerUpdate.empty(),
         result(createdInts.getProducingTransformInternal(),
             null,
@@ -494,7 +494,7 @@ public class WatermarkManagerTest implements Serializable {
     assertThat(firstWatermarks.getOutputWatermark(), equalTo(new Instant(0L)));
 
     CommittedBundle<?> secondInput =
-        bundleFactory.createRootBundle(createdInts).commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
+        bundleFactory.createBundle(createdInts).commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
     manager.updateWatermarks(null,
         TimerUpdate.empty(),
         result(createdInts.getProducingTransformInternal(),
@@ -558,7 +558,7 @@ public class WatermarkManagerTest implements Serializable {
         WindowedValue.timestampedValueInGlobalWindow(2, new Instant(-1000L));
     WindowedValue<Integer> third =
         WindowedValue.timestampedValueInGlobalWindow(3, new Instant(1234L));
-    CommittedBundle<Integer> createdBundle = bundleFactory.createRootBundle(createdInts)
+    CommittedBundle<Integer> createdBundle = bundleFactory.createBundle(createdInts)
         .add(first)
         .add(second)
         .add(third)
@@ -657,12 +657,12 @@ public class WatermarkManagerTest implements Serializable {
         TimerUpdate.empty(), result(createdInts.getProducingTransformInternal(), null,
         Collections.<CommittedBundle<?>>singleton(
             bundleFactory
-                .createRootBundle(createdInts)
+                .createBundle(createdInts)
                 .add(WindowedValue.valueInGlobalWindow(1))
                 .commit(Instant.now()))),
         BoundedWindow.TIMESTAMP_MAX_VALUE);
 
-    CommittedBundle<Integer> createdBundle = bundleFactory.createRootBundle(createdInts)
+    CommittedBundle<Integer> createdBundle = bundleFactory.createBundle(createdInts)
         .add(WindowedValue.valueInGlobalWindow(1))
         .commit(Instant.now());
     manager.updateWatermarks(createdBundle,
@@ -778,7 +778,7 @@ public class WatermarkManagerTest implements Serializable {
         not(laterThan(BoundedWindow.TIMESTAMP_MIN_VALUE)));
 
     CommittedBundle<Integer> createOutput =
-        bundleFactory.createRootBundle(createdInts).commit(new Instant(1250L));
+        bundleFactory.createBundle(createdInts).commit(new Instant(1250L));
 
     manager.updateWatermarks(null,
         TimerUpdate.empty(),
@@ -810,7 +810,7 @@ public class WatermarkManagerTest implements Serializable {
         not(laterThan(new Instant(1250L))));
 
     CommittedBundle<?> filterOutputBundle =
-        bundleFactory.createRootBundle(intsToFlatten).commit(new Instant(1250L));
+        bundleFactory.createBundle(intsToFlatten).commit(new Instant(1250L));
     manager.updateWatermarks(createOutput,
         TimerUpdate.empty(),
         result(filtered.getProducingTransformInternal(),
@@ -892,10 +892,10 @@ public class WatermarkManagerTest implements Serializable {
 
     CommittedBundle<Integer> filteredTimerBundle =
         bundleFactory
-            .createKeyedBundle(null, key, filtered)
+            .createKeyedBundle(key, filtered)
             .commit(BoundedWindow.TIMESTAMP_MAX_VALUE);
     CommittedBundle<Integer> filteredTimerResult =
-        bundleFactory.createKeyedBundle(null, key, filteredTimesTwo)
+        bundleFactory.createKeyedBundle(key, filteredTimesTwo)
             .commit(filteredWms.getSynchronizedProcessingOutputTime());
     // Complete the processing time timer
     manager.updateWatermarks(filteredTimerBundle,
@@ -951,7 +951,7 @@ public class WatermarkManagerTest implements Serializable {
         not(laterThan(BoundedWindow.TIMESTAMP_MIN_VALUE)));
 
     CommittedBundle<Integer> createOutput =
-        bundleFactory.createRootBundle(createdInts).commit(new Instant(1250L));
+        bundleFactory.createBundle(createdInts).commit(new Instant(1250L));
 
     manager.updateWatermarks(null,
         TimerUpdate.empty(),
@@ -967,7 +967,7 @@ public class WatermarkManagerTest implements Serializable {
         not(laterThan(clock.now())));
 
     CommittedBundle<Integer> createSecondOutput =
-        bundleFactory.createRootBundle(createdInts).commit(new Instant(750L));
+        bundleFactory.createBundle(createdInts).commit(new Instant(750L));
     manager.updateWatermarks(null,
         TimerUpdate.empty(),
         result(createdInts.getProducingTransformInternal(),
@@ -1041,7 +1041,7 @@ public class WatermarkManagerTest implements Serializable {
         new Instant(29_919_235L));
 
     Instant upstreamHold = new Instant(2048L);
-    CommittedBundle<Integer> filteredBundle = bundleFactory.createKeyedBundle(created,
+    CommittedBundle<Integer> filteredBundle = bundleFactory.createKeyedBundle(
         StructuralKey.of("key", StringUtf8Coder.of()),
         filtered).commit(upstreamHold);
     manager.updateWatermarks(
@@ -1394,7 +1394,7 @@ public class WatermarkManagerTest implements Serializable {
   @SafeVarargs
   private final <T> CommittedBundle<T> timestampedBundle(
       PCollection<T> pc, TimestampedValue<T>... values) {
-    UncommittedBundle<T> bundle = bundleFactory.createRootBundle(pc);
+    UncommittedBundle<T> bundle = bundleFactory.createBundle(pc);
     for (TimestampedValue<T> value : values) {
       bundle.add(
           WindowedValue.timestampedValueInGlobalWindow(value.getValue(), value.getTimestamp()));
@@ -1404,7 +1404,7 @@ public class WatermarkManagerTest implements Serializable {
 
   @SafeVarargs
   private final <T> CommittedBundle<T> multiWindowedBundle(PCollection<T> pc, T... values) {
-    UncommittedBundle<T> bundle = bundleFactory.createRootBundle(pc);
+    UncommittedBundle<T> bundle = bundleFactory.createBundle(pc);
     Collection<BoundedWindow> windows =
         ImmutableList.of(
             GlobalWindow.INSTANCE,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -286,7 +286,7 @@ public class WindowEvaluatorFactoryTest {
   private CommittedBundle<Long> createInputBundle() {
     CommittedBundle<Long> inputBundle =
         bundleFactory
-            .createRootBundle(input)
+            .createBundle(input)
             .add(valueInGlobalWindow)
             .add(valueInGlobalAndTwoIntervalWindows)
             .add(valueInIntervalWindow)
@@ -296,8 +296,8 @@ public class WindowEvaluatorFactoryTest {
 
   private UncommittedBundle<Long> createOutputBundle(
       PCollection<Long> output, CommittedBundle<Long> inputBundle) {
-    UncommittedBundle<Long> outputBundle = bundleFactory.createBundle(inputBundle, output);
-    when(evaluationContext.createBundle(inputBundle, output)).thenReturn(outputBundle);
+    UncommittedBundle<Long> outputBundle = bundleFactory.createBundle(output);
+    when(evaluationContext.createBundle(output)).thenReturn(outputBundle);
     return outputBundle;
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Remove the inputBundle parameter to createBundle and createKeyedBundle.
This parameter is unless the model is capable of propagating keys
between PTransforms.

Remove the PCollection parameter to createRootBundle. createRootBundle
should be a par

Make [Un]CommmittedBundle#getPCollection nullable. Bundles are utilized
by the runner to control the processing of elements, but may not always
belong to a PCollection. Update ImmutabilityCheckingBundleFactory to
return an underlying bundle as the result of createRootBundle.

Use createBundle in Root transform evaluators.