### PR TITLE
[BEAM-674] Gridfs Source refactoring

### DIFF
--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.io.mongodb;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
 import com.mongodb.DB;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
@@ -162,7 +162,7 @@ public class MongoDbGridFSIO {
       return withParser(f, null);
     }
     public <X> Read<X> withParser(Parser<X> f, Coder<X> coder) {
-      Preconditions.checkNotNull(f, "Parser cannot be null");
+      checkNotNull(f, "Parser cannot be null");
       //coder can be null as it can be set on the output directly
       return new Read<X>(new BoundedGridFSSource(options.uri, options.database,
           options.bucket, options.filterJson, null), f, coder, allowedTimestampSkew);
@@ -222,7 +222,7 @@ public class MongoDbGridFSIO {
               parser.parse(file, new ParserCallback<T>() {
                 @Override
                 public void output(T output, Instant timestamp) {
-                  Preconditions.checkNotNull(timestamp);
+                  checkNotNull(timestamp);
                   c.outputWithTimestamp(output, timestamp);
                 }
 

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -129,43 +129,43 @@ public class MongoDbGridFSIO {
     public Read<T> withUri(String uri) {
       return new Read<T>(new BoundedGridFSSource(uri, options.database,
                                            options.bucket, options.filterJson,
-                                           null), parser, maxSkew);
+                                           null), parser, allowedTimestampSkew);
     }
 
     public Read<T> withDatabase(String database) {
       return new Read<T>(new BoundedGridFSSource(options.uri, database,
                                            options.bucket, options.filterJson,
-                                           null), parser, maxSkew);
+                                           null), parser, allowedTimestampSkew);
     }
 
     public Read<T> withBucket(String bucket) {
       return new Read<T>(new BoundedGridFSSource(options.uri, options.database, bucket,
-          options.filterJson, null), parser, maxSkew);
+          options.filterJson, null), parser, allowedTimestampSkew);
     }
 
     public <X> Read<X> withParser(Parser<X> f) {
       Preconditions.checkNotNull(f, "Parser cannot be null");
       return new Read<X>(new BoundedGridFSSource(options.uri, options.database,
-          options.bucket, options.filterJson, null), f, maxSkew);
+          options.bucket, options.filterJson, null), f, allowedTimestampSkew);
     }
-    public Read<T> maxSkew(Duration skew) {
+    public Read<T> allowedTimestampSkew(Duration skew) {
       return new Read<T>(new BoundedGridFSSource(options.uri, options.database,
           options.bucket, options.filterJson, null), parser, skew == null ? Duration.ZERO : skew);
     }
 
     public Read<T> withQueryFilter(String filterJson) {
       return new Read<T>(new BoundedGridFSSource(options.uri, options.database,
-          options.bucket, filterJson, null), parser, maxSkew);
+          options.bucket, filterJson, null), parser, allowedTimestampSkew);
     }
 
     private final BoundedGridFSSource options;
     private final Parser<T> parser;
-    private final Duration maxSkew;
+    private final Duration allowedTimestampSkew;
 
-    Read(BoundedGridFSSource options, Parser<T> parser, Duration maxSkew) {
+    Read(BoundedGridFSSource options, Parser<T> parser, Duration allowedTimestampSkew) {
       this.options = options;
       this.parser = parser;
-      this.maxSkew = maxSkew;
+      this.allowedTimestampSkew = allowedTimestampSkew;
     }
 
     public BoundedGridFSSource getSource() {
@@ -199,7 +199,7 @@ public class MongoDbGridFSIO {
 
             @Override
             public Duration getAllowedTimestampSkew() {
-              return maxSkew;
+              return allowedTimestampSkew;
             }
           }));
       if (parser == StringParser.INSTANCE) {

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -166,6 +166,10 @@ public class MongoDbGridFSIO {
       this.maxSkew = maxSkew;
     }
 
+    public BoundedGridFSSource<T> getSource() {
+      return options;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public PCollection<T> apply(PBegin input) {

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -365,6 +365,12 @@ public class MongoDbGridFSIO {
 
       static class GridFSReader extends BoundedSource.BoundedReader<ObjectId> {
         final BoundedGridFSSource source;
+
+        /* When split into bundles, this records the ObjectId's of the files for
+         * this bundle.  Otherwise, this is null.  When null, a DBCursor of the
+         * files is used directly to avoid having the ObjectId's queried and
+         * loaded ahead of time saving time and memory.
+         */
         @Nullable
         final List<ObjectId> objects;
 
@@ -416,6 +422,7 @@ public class MongoDbGridFSIO {
           }
           return current;
         }
+
         public Instant getCurrentTimestamp() throws NoSuchElementException {
           if (current == null) {
             throw new NoSuchElementException();

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.bson.types.ObjectId;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 
@@ -180,6 +181,12 @@ public class MongoDbGridFSIO {
               GridFSDBFile file = gridfs.find(oid);
               options.parser.parse(file, c);
             }
+            /*
+            @Override
+            public Duration getAllowedTimestampSkew() {
+              return Duration.millis(Long.MAX_VALUE);
+            }
+            */
           }));
       if (options.parser == StringParser.INSTANCE) {
         output.setCoder((Coder<T>) StringUtf8Coder.of());
@@ -361,7 +368,9 @@ public class MongoDbGridFSIO {
           if (current == null) {
             throw new NoSuchElementException();
           }
-          return Instant.now();
+          long time = current.getTimestamp();
+          time *= 1000L;
+          return new Instant(time);
         }
 
         @Override

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -82,8 +82,8 @@ import org.joda.time.Instant;
  * <p>There is also an optional {@code Parser} that can be specified that can be used to
  * parse the InputStream into objects usable with Beam.  By default, MongoDbGridFSIO will parse
  * into Strings, splitting on line breaks and using the uploadDate of the file as the timestamp.
- * When using a parser that outputs via outputWithTimestamp, you may also need to specify
- * the maxSkew option.
+ * When using a parser that outputs with custom timestamps, you may also need to specify
+ * the allowedTimestampSkew option.
  */
 public class MongoDbGridFSIO {
 
@@ -91,6 +91,8 @@ public class MongoDbGridFSIO {
    * Callback for the parser to use to submit data.
    */
   public interface ParserCallback<T> extends Serializable {
+    public void output(T output);
+
     public void output(T output, @Nullable Instant timestamp);
   }
 
@@ -217,6 +219,11 @@ public class MongoDbGridFSIO {
                   } else {
                     c.outputWithTimestamp(output, timestamp);
                   }
+                }
+
+                @Override
+                public void output(T output) {
+                  c.output(output);
                 }
               });
             }

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -97,7 +97,7 @@ public class MongoDbGridFSIO {
   }
 
   /**
-   * For the default Read<String> case, this is the parser that is used to
+   * For the default Read&lt;String&gt; case, this is the parser that is used to
    * split the input file into Strings. It uses the timestamp of the file
    * for the event timestamp.
    */

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -60,6 +60,7 @@ import org.apache.beam.sdk.transforms.Max;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.Before;
@@ -195,6 +196,7 @@ public class MongoDBGridFSIOTest implements Serializable {
             .withUri("mongodb://localhost:" + PORT)
             .withDatabase(DATABASE)
             .withBucket("mapBucket")
+            .maxSkew(new Duration(Long.MAX_VALUE))
             .withParser(new MongoDbGridFSIO.Parser<KV<String, Integer>>() {
               @Override
               public void parse(GridFSDBFile input,
@@ -229,6 +231,7 @@ public class MongoDBGridFSIOTest implements Serializable {
         return null;
       }
     });
+
     pipeline.run();
   }
 

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -61,7 +61,6 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.SourceTestUtils;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
-import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Max;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
@@ -207,7 +206,7 @@ public class MongoDBGridFSIOTest implements Serializable {
             .withParser(new MongoDbGridFSIO.Parser<KV<String, Integer>>() {
               @Override
               public void parse(GridFSDBFile input,
-                  DoFn<?, KV<String, Integer>>.ProcessContext result) throws IOException {
+                  MongoDbGridFSIO.ParserCallback<KV<String, Integer>> callback) throws IOException {
                 try (final BufferedReader reader =
                     new BufferedReader(new InputStreamReader(input.getInputStream()))) {
                   String line = reader.readLine();
@@ -217,7 +216,7 @@ public class MongoDBGridFSIOTest implements Serializable {
                       long timestamp = scanner.nextLong();
                       String name = scanner.next();
                       int score = scanner.nextInt();
-                      result.outputWithTimestamp(KV.of(name, score), new Instant(timestamp));
+                      callback.output(KV.of(name, score), new Instant(timestamp));
                     }
                     line = reader.readLine();
                   }

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -249,7 +249,7 @@ public class MongoDBGridFSIOTest implements Serializable {
         .withUri("mongodb://localhost:" + PORT)
         .withDatabase(DATABASE);
 
-    BoundedGridFSSource<String> src = read.getSource();
+    BoundedGridFSSource src = read.getSource();
 
     // make sure 2 files can fit in
     long desiredBundleSizeBytes = src.getEstimatedSizeBytes(options) * 2L / 5L + 1000;

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -253,7 +253,7 @@ public class MongoDBGridFSIOTest implements Serializable {
     BoundedGridFSSource src = read.getSource();
 
     // make sure 2 files can fit in
-    long desiredBundleSizeBytes = src.getEstimatedSizeBytes(options) * 2L / 5L + 1000;
+    long desiredBundleSizeBytes = (src.getEstimatedSizeBytes(options) * 2L) / 5L + 1000;
     List<? extends BoundedSource<ObjectId>> splits = src.splitIntoBundles(
         desiredBundleSizeBytes, options);
 

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -155,6 +155,7 @@ public class MongoDBGridFSIOTest implements Serializable {
       writer.flush();
       writer.close();
     }
+    client.close();
   }
 
   @AfterClass
@@ -203,7 +204,6 @@ public class MongoDBGridFSIOTest implements Serializable {
             .withUri("mongodb://localhost:" + PORT)
             .withDatabase(DATABASE)
             .withBucket("mapBucket")
-            .maxSkew(new Duration(Long.MAX_VALUE))
             .withParser(new MongoDbGridFSIO.Parser<KV<String, Integer>>() {
               @Override
               public void parse(GridFSDBFile input,
@@ -223,7 +223,9 @@ public class MongoDBGridFSIOTest implements Serializable {
                   }
                 }
               }
-            })).setCoder(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
+            })
+            .allowedTimestampSkew(new Duration(3601000L)))
+            .setCoder(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
 
     PAssert.thatSingleton(output.apply("Count All", Count.<KV<String, Integer>>globally()))
         .isEqualTo(50100L);


### PR DESCRIPTION
Refactor of the GridFS based Source based on feedback from @jkff 

BoundedSource is now a source of ObjectID's and a separate DoFn is used to convert/parse the GridFSDBFile into usable chunks.   

Testcase for splitting added.

Variables not needed by the Source are pulled out and stuck on the transform instead.

Optimized the non-split case a bit by not querying all the ObjectIds up front.  

Optimize unit tests by setting up test data per class instead of per test.
