### PR TITLE
[BEAM-55] Add abstract support for writing compressed/decorated/transformed files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ bin/
 .project
 .factorypath
 .checkstyle
+.fbExcludeFilterFile
+.apt_generated/
 .settings/
 
 # The build process generates the dependency-reduced POM, but it shouldn't be
@@ -26,6 +28,9 @@ dependency-reduced-pom.xml
 # Ignore files that end with '~', since they are most likely auto-save files
 # produced by a text editor.
 *~
+
+# Ignore MacOSX files.
+.DS_Store
 
 # NOTE: if you modify this file, you probably need to modify the file set that
 # is an input to 'maven-assembly-plugin' that generates source distribution.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/DrunkWritableByteChannelFactory.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/DrunkWritableByteChannelFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+import org.apache.beam.sdk.io.FileBasedSink.WritableByteChannelFactory;
+import org.apache.beam.sdk.util.MimeTypes;
+
+/**
+ * {@link WritableByteChannelFactory} implementation useful for testing that creates a
+ * {@link WritableByteChannel} that writes everything twice.
+ */
+public class DrunkWritableByteChannelFactory implements WritableByteChannelFactory {
+  @Override
+  public WritableByteChannel create(WritableByteChannel channel) throws IOException {
+    return new DrunkWritableByteChannel(channel);
+  }
+
+  @Override
+  public String getMimeType() {
+    return MimeTypes.TEXT;
+  }
+
+  @Override
+  public String getFilenameSuffix() {
+    return ".drunk";
+  }
+
+  @Override
+  public String toString() {
+    return "DRUNK";
+  }
+
+  /**
+   * WritableByteChannel that writes everything twice.
+   */
+  private static class DrunkWritableByteChannel implements WritableByteChannel {
+    protected final WritableByteChannel channel;
+
+    public DrunkWritableByteChannel(final WritableByteChannel channel) {
+      this.channel = channel;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return channel.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+      channel.close();
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+      final int w1 = channel.write(src);
+      src.rewind();
+      final int w2 = channel.write(src);
+      return w1 + w2;
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io;
 
 import static org.apache.beam.sdk.TestUtils.INTS_ARRAY;
+import static org.apache.beam.sdk.TestUtils.LINES2_ARRAY;
 import static org.apache.beam.sdk.TestUtils.LINES_ARRAY;
 import static org.apache.beam.sdk.TestUtils.NO_INTS_ARRAY;
 import static org.apache.beam.sdk.TestUtils.NO_LINES_ARRAY;
@@ -47,6 +48,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -70,13 +72,16 @@ import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
 import javax.annotation.Nullable;
+
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.TextualIntegerCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
+import org.apache.beam.sdk.io.FileBasedSink.WritableByteChannelFactory;
 import org.apache.beam.sdk.io.TextIO.CompressionType;
 import org.apache.beam.sdk.io.TextIO.TextSource;
 import org.apache.beam.sdk.options.GcsOptions;
@@ -170,7 +175,7 @@ public class TextIOTest {
   @BeforeClass
   public static void setupClass() throws IOException {
     IOChannelUtils.registerStandardIOFactories(TestPipeline.testingPipelineOptions());
-    tempFolder =  Files.createTempDirectory("TextIOTest");
+    tempFolder = Files.createTempDirectory("TextIOTest");
     // empty files
     emptyTxt = writeToFile(EMPTY, "empty.txt", CompressionType.UNCOMPRESSED);
     emptyGz = writeToFile(EMPTY, "empty.gz", GZIP);
@@ -261,7 +266,7 @@ public class TextIOTest {
   @Test
   @Category(NeedsRunner.class)
   public void testReadNulls() throws Exception {
-    runTestRead(new Void[]{null, null, null}, VoidCoder.of());
+    runTestRead(new Void[] {null, null, null}, VoidCoder.of());
   }
 
   @Test
@@ -342,6 +347,7 @@ public class TextIOTest {
     } else if (numShards > 0) {
       write = write.withNumShards(numShards).withShardNameTemplate(ShardNameTemplate.INDEX_OF_MAX);
     }
+
     input.apply(write);
 
     p.run();
@@ -413,7 +419,7 @@ public class TextIOTest {
   }
 
   private static Function<List<String>, List<String>> removeHeaderAndFooter(final String header,
-                                                                            final String footer) {
+      final String footer) {
     return new Function<List<String>, List<String>>() {
       @Nullable
       @Override
@@ -498,6 +504,36 @@ public class TextIOTest {
   }
 
   @Test
+  @Category(NeedsRunner.class)
+  public void testWriteWithWritableByteChannelFactory() throws Exception {
+    Coder<String> coder = StringUtf8Coder.of();
+    String outputName = "file.txt";
+    Path baseDir = Files.createTempDirectory(tempFolder, "testwrite");
+    Pipeline p = TestPipeline.create();
+
+    PCollection<String> input = p.apply(Create.of(Arrays.asList(LINES2_ARRAY)).withCoder(coder));
+
+    final WritableByteChannelFactory writableByteChannelFactory =
+        new DrunkWritableByteChannelFactory();
+    TextIO.Write.Bound<String> write = TextIO.Write.to(baseDir.resolve(outputName).toString())
+        .withoutSharding().withWritableByteChannelFactory(writableByteChannelFactory);
+    DisplayData displayData = DisplayData.from(write);
+    assertThat(displayData, hasDisplayItem("writableByteChannelFactory", "DRUNK"));
+
+    input.apply(write);
+
+    p.run();
+
+    final List<String> drunkElems = new ArrayList<>(LINES2_ARRAY.length * 2 + 2);
+    for (String elem : LINES2_ARRAY) {
+      drunkElems.add(elem + elem);
+      drunkElems.add("");
+    }
+    assertOutputFiles(drunkElems.toArray(new String[0]), null, null, coder, 1, baseDir,
+        outputName + writableByteChannelFactory.getFilenameSuffix(), write.getShardNameTemplate());
+  }
+
+  @Test
   public void testWriteDisplayData() {
     TextIO.Write.Bound<?> write = TextIO.Write
         .to("foo")
@@ -517,6 +553,7 @@ public class TextIOTest {
     assertThat(displayData, hasDisplayItem("shardNameTemplate", "-SS-of-NN-"));
     assertThat(displayData, hasDisplayItem("numShards", 100));
     assertThat(displayData, hasDisplayItem("validation", false));
+    assertThat(displayData, hasDisplayItem("writableByteChannelFactory", "UNCOMPRESSED"));
   }
 
   @Test
@@ -638,9 +675,9 @@ public class TextIOTest {
   }
 
   /**
-   * Tests reading from a small, uncompressed file with .gz extension.
-   * This must work in AUTO or GZIP modes. This is needed because some network file systems / HTTP
-   * clients will transparently decompress gzipped content.
+   * Tests reading from a small, uncompressed file with .gz extension. This must work in AUTO or
+   * GZIP modes. This is needed because some network file systems / HTTP clients will transparently
+   * decompress gzipped content.
    */
   @Test
   @Category(NeedsRunner.class)
@@ -672,9 +709,7 @@ public class TextIOTest {
    * @return The zip filename.
    * @throws Exception In case of a failure during zip file creation.
    */
-  private String createZipFile(List<String> expected, String filename, String[]
-      ...
-      fieldsEntries)
+  private String createZipFile(List<String> expected, String filename, String[]... fieldsEntries)
       throws Exception {
     File tmpFile = tempFolder.resolve(filename).toFile();
     String tmpFileName = tmpFile.getPath();
@@ -703,7 +738,7 @@ public class TextIOTest {
   @Category(NeedsRunner.class)
   public void testTxtRead() throws Exception {
     // Files with non-compressed extensions should work in AUTO and UNCOMPRESSED modes.
-    for (CompressionType type : new CompressionType[] { AUTO, UNCOMPRESSED }) {
+    for (CompressionType type : new CompressionType[]{AUTO, UNCOMPRESSED}) {
       assertReadingCompressedFileMatchesExpected(emptyTxt, type, EMPTY);
       assertReadingCompressedFileMatchesExpected(tinyTxt, type, TINY);
       assertReadingCompressedFileMatchesExpected(largeTxt, type, LARGE);
@@ -714,7 +749,7 @@ public class TextIOTest {
   @Category(NeedsRunner.class)
   public void testGzipCompressedRead() throws Exception {
     // Files with the right extensions should work in AUTO and GZIP modes.
-    for (CompressionType type : new CompressionType[] { AUTO, GZIP }) {
+    for (CompressionType type : new CompressionType[]{AUTO, GZIP}) {
       assertReadingCompressedFileMatchesExpected(emptyGz, type, EMPTY);
       assertReadingCompressedFileMatchesExpected(tinyGz, type, TINY);
       assertReadingCompressedFileMatchesExpected(largeGz, type, LARGE);
@@ -732,7 +767,7 @@ public class TextIOTest {
   @Category(NeedsRunner.class)
   public void testBzip2CompressedRead() throws Exception {
     // Files with the right extensions should work in AUTO and BZIP2 modes.
-    for (CompressionType type : new CompressionType[] { AUTO, BZIP2 }) {
+    for (CompressionType type : new CompressionType[]{AUTO, BZIP2}) {
       assertReadingCompressedFileMatchesExpected(emptyBzip2, type, EMPTY);
       assertReadingCompressedFileMatchesExpected(tinyBzip2, type, TINY);
       assertReadingCompressedFileMatchesExpected(largeBzip2, type, LARGE);


### PR DESCRIPTION
Essentially, this adds customizable file-based output support through DecoratedFileSink and concrete Gzip file-based output support through WriterOutputGzipDecoratorFactory.  I realize that the test coverage might be a little light for Apache Beam standards and have no problem expanding that if needed.

The DecoratedFileSink class provides a hook for decorating/transforming data output at the WritableByteChannel/OutputStream level to enable things like Gzip compression during shard file writes. I included a concrete implementation, WriterOutputGzipDecoratorFactory, of the hook interface, which enables Gzip output, and is currently in use by us at Bombora. My thinking was that a hook at this level would enable any file level transformation that could be done via wrapping an OutputStream (as opposed to field or record level handled elsewhere in the existing API).

P.S. Not sure how large the PR needs to be to require an ICLA...

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

Thanks!