### PR TITLE
checkstyle: enforce static import of Preconditions utilities

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/AggregatorContainer.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/AggregatorContainer.java
@@ -17,8 +17,9 @@
  */
 package org.apache.beam.runners.direct;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,7 +55,7 @@ public class AggregatorContainer {
 
     @Override
     public synchronized void addValue(InputT input) {
-      Preconditions.checkState(!committed, "Cannot addValue after committing");
+      checkState(!committed, "Cannot addValue after committing");
       if (accumulator == null) {
         accumulator = combiner.createAccumulator();
       }
@@ -132,7 +133,7 @@ public class AggregatorContainer {
     }
 
     public void commit() {
-      Preconditions.checkState(!committed, "Should not be already committed");
+      checkState(!committed, "Should not be already committed");
       committed = true;
 
       for (Map.Entry<AggregatorKey, AggregatorInfo<?, ?, ?>> entry : accumulatorDeltas.entrySet()) {
@@ -152,7 +153,7 @@ public class AggregatorContainer {
     public <InputT, AccumT, OutputT> Aggregator<InputT, OutputT> createAggregatorForDoFn(
         Class<?> fnClass, ExecutionContext.StepContext step,
         String name, CombineFn<InputT, AccumT, OutputT> combine) {
-      Preconditions.checkState(!committed, "Cannot create aggregators after committing");
+      checkState(!committed, "Cannot create aggregators after committing");
       AggregatorKey key = AggregatorKey.create(step.getStepName(), name);
       AggregatorInfo<?, ?, ?> aggregatorInfo = accumulatorDeltas.get(key);
       if (aggregatorInfo != null) {

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.Serializable;

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
@@ -192,9 +194,7 @@ public class DoFnOperator<InputT, FnOutputT, OutputT>
           .createStateBackend(operatorIdentifier,
               new GenericTypeInfo<>(ByteBuffer.class).createSerializer(new ExecutionConfig()));
 
-      Preconditions.checkState(
-          sideInputStateBackend != null,
-          "Side input state backend cannot be bull");
+      checkState(sideInputStateBackend != null, "Side input state backend cannot be null");
 
       if (restoredSideInputState != null) {
         @SuppressWarnings("unchecked,rawtypes")

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -114,6 +114,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>
     </module>
 
+    <!--
+         Require static importing from Preconditions.
+    -->
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^import com.google.common.base.Preconditions;$"/>
+      <property name="message" value="Static import functions from Guava Preconditions"/>
+    </module>
+
     <module name="UnusedImports">
       <property name="severity" value="error"/>
       <property name="processJavadoc" value="true"/>

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -17,21 +17,18 @@
  */
 package org.apache.beam.sdk.io.mongodb;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.annotation.Nullable;
-
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -43,9 +40,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
-
 import org.bson.Document;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -217,9 +212,9 @@ public class MongoDbIO {
 
     @Override
     public void validate() {
-      Preconditions.checkNotNull(uri, "uri");
-      Preconditions.checkNotNull(database, "database");
-      Preconditions.checkNotNull(collection, "collection");
+      checkNotNull(uri, "uri");
+      checkNotNull(database, "database");
+      checkNotNull(collection, "collection");
     }
 
     @Override
@@ -507,10 +502,10 @@ public class MongoDbIO {
       }
 
       public void validate() {
-        Preconditions.checkNotNull(uri, "uri");
-        Preconditions.checkNotNull(database, "database");
-        Preconditions.checkNotNull(collection, "collection");
-        Preconditions.checkNotNull(batchSize, "batchSize");
+        checkNotNull(uri, "uri");
+        checkNotNull(database, "database");
+        checkNotNull(collection, "collection");
+        checkNotNull(batchSize, "batchSize");
       }
 
       @Setup


### PR DESCRIPTION
Sample error:

```
[INFO] There is 1 error reported by Checkstyle 6.19 with beam/checkstyle.xml ruleset.
[ERROR] src/main/java/org/apache/beam/runners/direct/AggregatorContainer.java:[21] (regexp) RegexpSinglelineJava: Static import functions from Guava Preconditions
```
