### PR TITLE
[BEAM-695] PipelineOptions display data needs to handle array types

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -338,7 +338,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
       return value.toString();
     }
     if (!value.getClass().getComponentType().isPrimitive()) {
-      return Arrays.deepToString((Object[])value);
+      return Arrays.deepToString((Object[]) value);
     }
 
     // At this point, we have some type of primitive array. Arrays.deepToString(..) requires an

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -292,7 +292,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
           builder.add(DisplayData.item(option.getKey(), type, value)
               .withNamespace(pipelineInterface));
         } else {
-          builder.add(DisplayData.item(option.getKey(), value.toString())
+          builder.add(DisplayData.item(option.getKey(), displayDataString(value))
               .withNamespace(pipelineInterface));
         }
       }
@@ -321,11 +321,22 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
             builder.add(DisplayData.item(jsonOption.getKey(), type, value)
                 .withNamespace(spec.getDefiningInterface()));
           } else {
-            builder.add(DisplayData.item(jsonOption.getKey(), value.toString())
+            builder.add(DisplayData.item(jsonOption.getKey(), displayDataString(value))
                 .withNamespace(spec.getDefiningInterface()));
           }
         }
       }
+    }
+  }
+
+  /**
+   * {@link Object#toString()} wrapper to extract display data values for various types.
+   */
+  private String displayDataString(Object value) {
+    if (value instanceof Object[]) {
+      return Arrays.deepToString((Object[])value);
+    } else {
+      return value.toString();
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -333,10 +333,16 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
    * {@link Object#toString()} wrapper to extract display data values for various types.
    */
   private String displayDataString(Object value) {
-    if (value instanceof Object[]) {
+    checkNotNull(value, "value cannot be null");
+    if (!value.getClass().isArray()) {
+      return value.toString();
+    }
+    if (!value.getClass().getComponentType().isPrimitive()) {
       return Arrays.deepToString((Object[])value);
     } else {
-      return value.toString();
+      // Arrays.deepToString requires an Object array, but will unwrap internal primitive arrays.
+      String wrapped = Arrays.deepToString(new Object[] {value});
+      return wrapped.substring(1, wrapped.length() - 1);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -340,7 +340,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
     if (!value.getClass().getComponentType().isPrimitive()) {
       return Arrays.deepToString((Object[])value);
     } else {
-      // Arrays.deepToString requires an Object array, but will unwrap internal primitive arrays.
+      // Arrays.deepToString requires an Object array, but will unwrap nested primitive arrays.
       String wrapped = Arrays.deepToString(new Object[] {value});
       return wrapped.substring(1, wrapped.length() - 1);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -339,11 +339,12 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
     }
     if (!value.getClass().getComponentType().isPrimitive()) {
       return Arrays.deepToString((Object[])value);
-    } else {
-      // Arrays.deepToString requires an Object array, but will unwrap nested primitive arrays.
-      String wrapped = Arrays.deepToString(new Object[] {value});
-      return wrapped.substring(1, wrapped.length() - 1);
     }
+
+    // At this point, we have some type of primitive array. Arrays.deepToString(..) requires an
+    // Object array, but will unwrap nested primitive arrays.
+    String wrapped = Arrays.deepToString(new Object[] {value});
+    return wrapped.substring(1, wrapped.length() - 1);
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.avro.generic.GenericData;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
@@ -851,6 +852,29 @@ public class ProxyInvocationHandlerTest {
     FooOptions deserializedOptions = serializeDeserialize(FooOptions.class, options);
     DisplayData deserializedData = DisplayData.from(deserializedOptions);
     assertThat(deserializedData, hasDisplayItem("foo", ""));
+  }
+
+  @Test
+  public void testDisplayDataArrayValue() throws Exception {
+    ArrayOptions options = PipelineOptionsFactory.as(ArrayOptions.class);
+    options.setArrayOption(new String[]{"foo", "bar"});
+    options.setDeepArrayOption(new Long[][] {new Long[] {1L, 2L}, new Long[] {3L}});
+
+    DisplayData data = DisplayData.from(options);
+    assertThat(data, hasDisplayItem("arrayOption", "[foo, bar]"));
+    assertThat(data, hasDisplayItem("deepArrayOption", "[[1, 2], [3]]"));
+
+    ArrayOptions deserializedOptions = serializeDeserialize(ArrayOptions.class, options);
+    DisplayData deserializedData = DisplayData.from(deserializedOptions);
+    assertThat(deserializedData, hasDisplayItem("arrayOption", "[foo, bar]"));
+  }
+
+  private interface ArrayOptions extends PipelineOptions {
+    String[] getArrayOption();
+    void setArrayOption(String[] value);
+
+    Long[][] getDeepArrayOption();
+    void setDeepArrayOption(Long[][] value);
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import org.apache.avro.generic.GenericData;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
@@ -857,24 +856,24 @@ public class ProxyInvocationHandlerTest {
   @Test
   public void testDisplayDataArrayValue() throws Exception {
     ArrayOptions options = PipelineOptionsFactory.as(ArrayOptions.class);
-    options.setArrayOption(new String[]{"foo", "bar"});
-    options.setDeepArrayOption(new Long[][] {new Long[] {1L, 2L}, new Long[] {3L}});
+    options.setPrimitiveArrayOption(new long[]{1L, 2L});
+    options.setDeepArrayOption(new String[][] {new String[] {"a", "b"}, new String[] {"c"}});
 
     DisplayData data = DisplayData.from(options);
-    assertThat(data, hasDisplayItem("arrayOption", "[foo, bar]"));
-    assertThat(data, hasDisplayItem("deepArrayOption", "[[1, 2], [3]]"));
+    assertThat(data, hasDisplayItem("primitiveArrayOption", "[1, 2]"));
+    assertThat(data, hasDisplayItem("deepArrayOption", "[[a, b], [c]]"));
 
     ArrayOptions deserializedOptions = serializeDeserialize(ArrayOptions.class, options);
     DisplayData deserializedData = DisplayData.from(deserializedOptions);
-    assertThat(deserializedData, hasDisplayItem("arrayOption", "[foo, bar]"));
+    assertThat(deserializedData, hasDisplayItem("primitiveArrayOption", "[1, 2]"));
   }
 
   private interface ArrayOptions extends PipelineOptions {
-    String[] getArrayOption();
-    void setArrayOption(String[] value);
+    long[] getPrimitiveArrayOption();
+    void setPrimitiveArrayOption(long[] value);
 
-    Long[][] getDeepArrayOption();
-    void setDeepArrayOption(Long[][] value);
+    String[][] getDeepArrayOption();
+    void setDeepArrayOption(String[][] value);
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -856,7 +856,7 @@ public class ProxyInvocationHandlerTest {
   @Test
   public void testDisplayDataArrayValue() throws Exception {
     ArrayOptions options = PipelineOptionsFactory.as(ArrayOptions.class);
-    options.setPrimitiveArrayOption(new long[]{1L, 2L});
+    options.setPrimitiveArrayOption(new long[] {1L, 2L});
     options.setDeepArrayOption(new String[][] {new String[] {"a", "b"}, new String[] {"c"}});
 
     DisplayData data = DisplayData.from(options);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -856,24 +856,24 @@ public class ProxyInvocationHandlerTest {
   @Test
   public void testDisplayDataArrayValue() throws Exception {
     ArrayOptions options = PipelineOptionsFactory.as(ArrayOptions.class);
-    options.setPrimitiveArrayOption(new long[] {1L, 2L});
-    options.setDeepArrayOption(new String[][] {new String[] {"a", "b"}, new String[] {"c"}});
+    options.setDeepArray(new String[][] {new String[] {"a", "b"}, new String[] {"c"}});
+    options.setDeepPrimitiveArray(new int[][] {new int[] {1, 2}, new int[] {3}});
 
     DisplayData data = DisplayData.from(options);
-    assertThat(data, hasDisplayItem("primitiveArrayOption", "[1, 2]"));
-    assertThat(data, hasDisplayItem("deepArrayOption", "[[a, b], [c]]"));
+    assertThat(data, hasDisplayItem("deepArray", "[[a, b], [c]]"));
+    assertThat(data, hasDisplayItem("deepPrimitiveArray", "[[1, 2], [3]]"));
 
     ArrayOptions deserializedOptions = serializeDeserialize(ArrayOptions.class, options);
     DisplayData deserializedData = DisplayData.from(deserializedOptions);
-    assertThat(deserializedData, hasDisplayItem("primitiveArrayOption", "[1, 2]"));
+    assertThat(deserializedData, hasDisplayItem("deepPrimitiveArray", "[[1, 2], [3]]"));
   }
 
   private interface ArrayOptions extends PipelineOptions {
-    long[] getPrimitiveArrayOption();
-    void setPrimitiveArrayOption(long[] value);
+    String[][] getDeepArray();
+    void setDeepArray(String[][] value);
 
-    String[][] getDeepArrayOption();
-    void setDeepArrayOption(String[][] value);
+    int[][] getDeepPrimitiveArray();
+    void setDeepPrimitiveArray(int[][] value);
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

PipelineOptions generates display data for arbitrary option types
using #toString(). For array types, this gives an message like
[Ljava.lang.String;@fc25934b]. Instead, we detect array types
and use Arrays.deepString to build a string based on array values.