### PR TITLE
[BEAM-561] Add Streaming IT to Jenkins Pre-commit

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -244,6 +244,69 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>jenkins-precommit-streaming</id>
+      <properties>
+        <it.test>WindowedWordCountIT</it.test>
+        <skipITs>false</skipITs>
+        <skipDefaultIT>true</skipDefaultIT>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <useManifestOnlyJar>false</useManifestOnlyJar>
+              <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            </configuration>
+            <executions>
+              <execution>
+                <id>direct-runner-integration-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <parallel>all</parallel>
+                  <threadCount>4</threadCount>
+                  <systemPropertyVariables>
+                    <beamTestPipelineOptions>
+                      [
+                      "--project=apache-beam-testing",
+                      "--tempLocation=gs://temp-storage-for-end-to-end-tests",
+                      "--runner=org.apache.beam.runners.direct.DirectRunner"
+                      ]
+                    </beamTestPipelineOptions>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>dataflow-runner-integration-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <parallel>all</parallel>
+                  <threadCount>4</threadCount>
+                  <systemPropertyVariables>
+                    <beamTestPipelineOptions>
+                      [
+                      "--project=apache-beam-testing",
+                      "--tempRoot=gs://temp-storage-for-end-to-end-tests",
+                      "--runner=org.apache.beam.runners.dataflow.testing.TestDataflowRunner"
+                      ]
+                    </beamTestPipelineOptions>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Jenkins can add this profile to precommit and WindowedWordCountIT will run in both batch and streaming mode in each build. This change increases the coverage of streaming pipeline as well as BigQuery. Currently, only DirectRunner and TestDataflowRunner is applied. TestSparkRunner and TestFlinkRunner will be added later once they fully support streaming integration tests.

Test is done by running following command with different project configs:
```
mvn clean verify -P jenkins-precommit-streaming,include-runners
```

TODO:
Jenkins pre-commit command need to be updated by adding "jenkins-precommit-streaming" flag.