### PR TITLE
[BEAM-57] Makes FileBasedSink use a temporary directory

### DIFF
--- a/examples/java8/src/test/java/org/apache/beam/examples/MinimalWordCountJava8Test.java
+++ b/examples/java8/src/test/java/org/apache/beam/examples/MinimalWordCountJava8Test.java
@@ -68,7 +68,7 @@ public class MinimalWordCountJava8Test implements Serializable {
      .apply(MapElements
          .via((KV<String, Long> wordCount) -> wordCount.getKey() + ": " + wordCount.getValue())
          .withOutputType(TypeDescriptors.strings()))
-     .apply(TextIO.Write.to("gs://YOUR_OUTPUT_BUCKET/AND_OUTPUT_PREFIX"));
+     .apply(TextIO.Write.to("gs://your-output-bucket/and-output-prefix"));
   }
 
   private GcsUtil buildMockGcsUtil() throws IOException {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FileIOChannelFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/FileIOChannelFactory.java
@@ -148,7 +148,11 @@ public class FileIOChannelFactory implements IOChannelFactory {
 
   @Override
   public String resolve(String path, String other) throws IOException {
-    Path p = specToFile(path).toPath();
-    return p.resolve(other).toString();
+    return toPath(path).resolve(other).toString();
+  }
+
+  @Override
+  public Path toPath(String path) {
+    return specToFile(path).toPath();
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/GcsIOChannelFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/GcsIOChannelFactory.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -81,6 +82,11 @@ public class GcsIOChannelFactory implements IOChannelFactory {
 
   @Override
   public String resolve(String path, String other) throws IOException {
-    return GcsPath.fromUri(path).resolve(other).toString();
+    return toPath(path).resolve(other).toString();
+  }
+
+  @Override
+  public Path toPath(String path) {
+    return GcsPath.fromUri(path);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IOChannelFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IOChannelFactory.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 import java.util.Collection;
 
 /**
@@ -99,4 +100,7 @@ public interface IOChannelFactory {
    * dependent and therefore unspecified.
    */
   String resolve(String path, String other) throws IOException;
+
+  /** Converts the given string to a {@link Path}. */
+  Path toPath(String path);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/gcsfs/GcsPath.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/gcsfs/GcsPath.java
@@ -261,7 +261,7 @@ public class GcsPath implements Path {
 
   @Override
   public GcsPath getFileName() {
-    throw new UnsupportedOperationException();
+    return getName(getNameCount() - 1);
   }
 
   /**
@@ -431,12 +431,14 @@ public class GcsPath implements Path {
 
   @Override
   public Path resolveSibling(Path other) {
-    throw new UnsupportedOperationException();
+    GcsPath parent = getParent();
+    return (parent == null) ? other : parent.resolve(other);
   }
 
   @Override
   public Path resolveSibling(String other) {
-    throw new UnsupportedOperationException();
+    GcsPath parent = getParent();
+    return (parent == null) ? fromUri(other) : parent.resolve(other);
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/gcsfs/GcsPath.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/gcsfs/GcsPath.java
@@ -261,7 +261,12 @@ public class GcsPath implements Path {
 
   @Override
   public GcsPath getFileName() {
-    return getName(getNameCount() - 1);
+    int nameCount = getNameCount();
+    if (nameCount < 2) {
+      throw new UnsupportedOperationException(
+          "Can't get filename from root path in the bucket: " + this);
+    }
+    return getName(nameCount - 1);
   }
 
   /**
@@ -431,12 +436,14 @@ public class GcsPath implements Path {
 
   @Override
   public Path resolveSibling(Path other) {
-    GcsPath parent = getParent();
-    return (parent == null) ? other : parent.resolve(other);
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public Path resolveSibling(String other) {
+    if (getNameCount() < 2) {
+      throw new UnsupportedOperationException("Can't resolve the sibling of a root path: " + this);
+    }
     GcsPath parent = getParent();
     return (parent == null) ? fromUri(other) : parent.resolve(other);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
@@ -89,7 +89,7 @@ public class FileBasedSinkTest {
   public void testWriter() throws Exception {
     String testUid = "testId";
     String expectedFilename =
-        getBaseTempFilename() + FileBasedWriteOperation.TEMPORARY_FILENAME_SEPARATOR + testUid;
+        getBaseTempFilename() + "/" + testUid;
     SimpleSink.SimpleWriter writer = buildWriter();
 
     List<String> values = Arrays.asList("sympathetic vulture", "boresome hummingbird");
@@ -193,8 +193,7 @@ public class FileBasedSinkTest {
     runFinalize(writeOp, files, false);
 
     // create a temporary file
-    tmpFolder.newFile(
-        baseTemporaryFilename + FileBasedWriteOperation.TEMPORARY_FILENAME_SEPARATOR + "1");
+    tmpFolder.newFile(baseTemporaryFilename + "/1");
 
     runFinalize(writeOp, files, false);
   }
@@ -217,7 +216,9 @@ public class FileBasedSinkTest {
     for (int i = 0; i < numFiles; i++) {
       String temporaryFilename =
           FileBasedWriteOperation.buildTemporaryFilename(baseTemporaryFilename, "" + i);
-      File tmpFile = tmpFolder.newFile(temporaryFilename);
+      File tmpFile = new File(tmpFolder.getRoot(), temporaryFilename);
+      tmpFile.getParentFile().mkdirs();
+      assertTrue(tmpFile.createNewFile());
       temporaryFiles.add(tmpFile);
     }
 
@@ -263,8 +264,10 @@ public class FileBasedSinkTest {
     List<File> temporaryFiles = new ArrayList<>();
     List<File> outputFiles = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
-      File tmpFile = tmpFolder.newFile(
+      File tmpFile = new File(tmpFolder.getRoot(),
           FileBasedWriteOperation.buildTemporaryFilename(baseTemporaryFilename, "" + i));
+      tmpFile.getParentFile().mkdirs();
+      assertTrue(tmpFile.createNewFile());
       temporaryFiles.add(tmpFile);
       File outputFile = tmpFolder.newFile(baseOutputFilename + i);
       outputFiles.add(outputFile);
@@ -496,11 +499,13 @@ public class FileBasedSinkTest {
   @Test
   public void testFileBasedWriterWithWritableByteChannelFactory() throws Exception {
     final String testUid = "testId";
-    final String expectedFilename =
-        getBaseOutputFilename() + FileBasedWriteOperation.TEMPORARY_FILENAME_SEPARATOR + testUid;
-    final FileBasedWriter<String> writer =
+    SimpleSink.SimpleWriteOperation writeOp =
         new SimpleSink(getBaseOutputFilename(), "txt", new DrunkWritableByteChannelFactory())
-            .createWriteOperation(null).createWriter(null);
+            .createWriteOperation(null);
+    final FileBasedWriter<String> writer =
+        writeOp.createWriter(null);
+    final String expectedFilename =
+        writeOp.baseTemporaryFilename + "/" + testUid;
 
     final List<String> expected = new ArrayList<>();
     expected.add("header");

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/XmlSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/XmlSinkTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io;
 
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -28,6 +29,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -59,7 +61,7 @@ public class XmlSinkTest {
 
   private Class<Bird> testClass = Bird.class;
   private String testRootElement = "testElement";
-  private String testFilePrefix = "testPrefix";
+  private String testFilePrefix = "/path/to/testPrefix";
 
   /**
    * An XmlWriter correctly writes objects as Xml elements with an enclosing root element.
@@ -143,7 +145,11 @@ public class XmlSinkTest {
     assertEquals(testFilePrefix, writeOp.getSink().baseOutputFilename);
     assertEquals(testRootElement, writeOp.getSink().rootElementName);
     assertEquals(XmlSink.XML_EXTENSION, writeOp.getSink().extension);
-    assertEquals(testFilePrefix, writeOp.baseTemporaryFilename);
+    Path outputPath = new File(testFilePrefix).toPath();
+    Path tempPath = new File(writeOp.baseTemporaryFilename).toPath();
+    assertEquals(outputPath.getParent(), tempPath.getParent());
+    assertThat(
+        tempPath.getFileName().toString(), containsString("temp-beam-" + outputPath.getFileName()));
   }
 
   /**
@@ -156,7 +162,11 @@ public class XmlSinkTest {
         XmlSink.writeOf(testClass, testRootElement, testFilePrefix)
             .createWriteOperation(options);
     XmlWriter<Bird> writer = writeOp.createWriter(options);
-    assertEquals(testFilePrefix, writer.getWriteOperation().baseTemporaryFilename);
+    Path outputPath = new File(testFilePrefix).toPath();
+    Path tempPath = new File(writer.getWriteOperation().baseTemporaryFilename).toPath();
+    assertEquals(outputPath.getParent(), tempPath.getParent());
+    assertThat(
+        tempPath.getFileName().toString(), containsString("temp-beam-" + outputPath.getFileName()));
     assertEquals(testRootElement, writer.getWriteOperation().getSink().rootElementName);
     assertNotNull(writer.marshaller);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/gcsfs/GcsPathTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/gcsfs/GcsPathTest.java
@@ -31,7 +31,9 @@ import java.util.Iterator;
 import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -72,6 +74,9 @@ public class GcsPathTest {
       new TestCase("gs://bucket/then/object//", "bucket", "then", "object/", ""),
       new TestCase("gs://bucket/", "bucket")
   );
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testGcsPathParsing() throws Exception {
@@ -234,6 +239,26 @@ public class GcsPathTest {
     GcsPath a = GcsPath.fromComponents("bucket", "a");
     GcsPath b = a.resolve(Paths.get("b"));
     assertEquals("a/b", b.getObject());
+  }
+
+  @Test
+  public void testGetFileName() {
+    assertEquals("foo", GcsPath.fromUri("gs://bucket/bar/foo").getFileName().toString());
+    assertEquals("foo", GcsPath.fromUri("gs://bucket/foo").getFileName().toString());
+    thrown.expect(UnsupportedOperationException.class);
+    GcsPath.fromUri("gs://bucket/").getFileName();
+  }
+
+  @Test
+  public void testResolveSibling() {
+    assertEquals(
+        "gs://bucket/bar/moo",
+        GcsPath.fromUri("gs://bucket/bar/foo").resolveSibling("moo").toString());
+    assertEquals(
+        "gs://bucket/moo",
+        GcsPath.fromUri("gs://bucket/foo").resolveSibling("moo").toString());
+    thrown.expect(UnsupportedOperationException.class);
+    GcsPath.fromUri("gs://bucket/").resolveSibling("moo");
   }
 
   @Test


### PR DESCRIPTION
When writing to `/path/to/foo`, temporary files would be written to `/path/to/foo-temp-$uid` (or something like that), i.e. as siblings of the final output. That could lead to issues like http://stackoverflow.com/q/39822859/278042

Now, temporary files are written to a path like: `/path/to/temp-beam-foo-$date/$uid`. This way, the temporary files won't match the same glob as the final output files (even though they may still fail to be deleted due to eventual consistency issues).
