### PR TITLE
Fixes a bug in avroio_test.py

### DIFF
--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -213,7 +213,7 @@ class TestAvro(unittest.TestCase):
 
   def test_corrupted_file(self):
     file_name = self._write_data()
-    with open(file_name, 'r') as f:
+    with open(file_name, 'rb') as f:
       data = bytearray(f.read())
 
     # Corrupt the last character of the file which is also the last character of


### PR DESCRIPTION
Fixes a bug in avroio_test.py where we open a binary file without 'b' mode. Without this, file can get corrupted in Windows and the test becomes flaky.