### PR TITLE
BEAM-724 - Null pointer fix

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -349,7 +349,7 @@ public class UnboundedSourceWrapper<
   @Override
   public byte[] snapshotState(long checkpointId, long checkpointTimestamp) throws Exception {
 
-    if (checkpointCoder == null) {
+    if (checkpointCoder == null || localSplitSources == null || localReaders == null) {
       // no checkpoint coder available in this source
       return null;
     }


### PR DESCRIPTION
This seems like a timing Issue. Its reproducible in case where Kafka topic does not exist yet. The UDF operator run is not called yet, but other thread calls snapshot before that:

```
java.lang.RuntimeException: Error while triggering checkpoint for Source: Read(UnboundedKafkaSource) -> ParDo(KafkaRecordToCTuple) -> ParDo(NetFlowToFlowContentTransformation) -> ParDo(FlowContentToRelationsTransformation) -> ParDo(GraphToJsonTransformation) -> AnonymousParDo -> ParDo(KafkaWriter) (1/1)
	at org.apache.flink.runtime.taskmanager.Task$2.run(Task.java:949)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Exception: Failed to draw state snapshot from function: null
	at org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator.snapshotOperatorState(AbstractUdfStreamOperator.java:132)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.performCheckpoint(StreamTask.java:598)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.triggerCheckpoint(StreamTask.java:565)
	at org.apache.flink.runtime.taskmanager.Task$2.run(Task.java:941)
	... 5 more
Caused by: java.lang.NullPointerException
	at org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper.snapshotState(UnboundedSourceWrapper.java:340)
	at org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper.snapshotState(UnboundedSourceWrapper.java:54)
	at org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator.snapshotOperatorState(AbstractUdfStreamOperator.java:129)
	... 8 more
```