### PR TITLE
KafkaIO reader should set consumedOffset even before reading the first record

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCheckpointMark.java
@@ -56,19 +56,19 @@ public class KafkaCheckpointMark implements UnboundedSource.CheckpointMark, Seri
    */
   public static class PartitionMark implements Serializable {
     private final TopicPartition topicPartition;
-    private final long offset;
+    private final long nextOffset;
 
     public PartitionMark(TopicPartition topicPartition, long offset) {
       this.topicPartition = topicPartition;
-      this.offset = offset;
+      this.nextOffset = offset;
     }
 
     public TopicPartition getTopicPartition() {
       return topicPartition;
     }
 
-    public long getOffset() {
-      return offset;
+    public long getNextOffset() {
+      return nextOffset;
     }
   }
 }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -830,7 +830,7 @@ public class KafkaIO {
         if (latestOffset < 0 || nextOffset < 0) {
           return UnboundedReader.BACKLOG_UNKNOWN;
         }
-        return (long) ((latestOffset - nextOffset) * avgRecordSize);
+        return Math.max(0, (long) ((latestOffset - nextOffset) * avgRecordSize));
       }
     }
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -927,12 +927,12 @@ public class KafkaIO {
         if (p.nextOffset >= 0) {
           consumer.seek(p.topicPartition, p.nextOffset);
         } else {
-          // set consumed offset to (next offset - 1), otherwise checkpoint would contain invalid
-          // offset until we read first record from this partition.
+          // Set nextOffset to current position, otherwise checkpoint would contain invalid
+          // offset (making checkpoints incorrect) until we read first record from this partition.
           p.nextOffset = consumer.position(p.topicPartition);
         }
 
-        LOG.info("{}: reading from {} at offset {}", name, p.topicPartition, p.nextOffset);
+        LOG.info("{}: reading from {} starting at offset {}", name, p.topicPartition, p.nextOffset);
       }
 
       // Start consumer read loop.

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -130,7 +130,7 @@ public class KafkaIOTest {
               tp.topic(),
               tp.partition(),
               offsets[pIdx]++,
-              ByteBuffer.wrap(new byte[8]).putInt(i).array(),    // key is 4 byte record id
+              ByteBuffer.wrap(new byte[4]).putInt(i).array(),    // key is 4 byte record id
               ByteBuffer.wrap(new byte[8]).putLong(i).array())); // value is 8 byte record id
     }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.kafka;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -35,6 +36,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
@@ -69,6 +72,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,7 +82,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Tests of {@link KafkaSource}.
+ * Tests of {@link KafkaIO}.
  */
 @RunWith(JUnit4.class)
 public class KafkaIOTest {
@@ -96,7 +100,8 @@ public class KafkaIOTest {
   // Update mock consumer with records distributed among the given topics, each with given number
   // of partitions. Records are assigned in round-robin order among the partitions.
   private static MockConsumer<byte[], byte[]> mkMockConsumer(
-      List<String> topics, int partitionsPerTopic, int numElements) {
+      List<String> topics, int partitionsPerTopic, int numElements,
+      OffsetResetStrategy offsetResetStrategy) {
 
     final List<TopicPartition> partitions = new ArrayList<>();
     final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
@@ -105,8 +110,10 @@ public class KafkaIOTest {
     for (String topic : topics) {
       List<PartitionInfo> partIds = new ArrayList<>(partitionsPerTopic);
       for (int i = 0; i < partitionsPerTopic; i++) {
-        partitions.add(new TopicPartition(topic, i));
+        TopicPartition tp = new TopicPartition(topic, i);
+        partitions.add(tp);
         partIds.add(new PartitionInfo(topic, i, null, null, null));
+        records.put(tp, new ArrayList<ConsumerRecord<byte[], byte[]>>());
       }
       partitionMap.put(topic, partIds);
     }
@@ -118,11 +125,8 @@ public class KafkaIOTest {
       int pIdx = i % numPartitions;
       TopicPartition tp = partitions.get(pIdx);
 
-      if (!records.containsKey(tp)) {
-        records.put(tp, new ArrayList<ConsumerRecord<byte[], byte[]>>());
-      }
       records.get(tp).add(
-          new ConsumerRecord<byte[], byte[]>(
+          new ConsumerRecord<>(
               tp.topic(),
               tp.partition(),
               offsets[pIdx]++,
@@ -130,18 +134,19 @@ public class KafkaIOTest {
               ByteBuffer.wrap(new byte[8]).putLong(i).array())); // value is 8 byte record id
     }
 
-    MockConsumer<byte[], byte[]> consumer =
-        new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
-          // override assign() to add records that belong to the assigned partitions.
-          public void assign(List<TopicPartition> assigned) {
+    // This is updated when reader assigns partitions.
+    final AtomicReference<List<TopicPartition>> assignedPartitions =
+        new AtomicReference<>(Collections.<TopicPartition>emptyList());
+
+    final MockConsumer<byte[], byte[]> consumer =
+        new MockConsumer<byte[], byte[]>(offsetResetStrategy) {
+          // override assign() in order to set offset limits & to save assigned partitions.
+          public void assign(final List<TopicPartition> assigned) {
             super.assign(assigned);
+            assignedPartitions.set(ImmutableList.copyOf(assigned));
             for (TopicPartition tp : assigned) {
-              for (ConsumerRecord<byte[], byte[]> r : records.get(tp)) {
-                addRecord(r);
-              }
               updateBeginningOffsets(ImmutableMap.of(tp, 0L));
               updateEndOffsets(ImmutableMap.of(tp, (long) records.get(tp).size()));
-              seek(tp, 0);
             }
           }
         };
@@ -150,6 +155,29 @@ public class KafkaIOTest {
       consumer.updatePartitions(topic, partitionMap.get(topic));
     }
 
+    // MockConsumer does not maintain any relationship between partition seek position and the
+    // records added. e.g. if we add 10 records to a partition and then seek to end of the
+    // partition, MockConsumer is still going to return the 10 records in next poll. It is
+    // our responsibility to make sure currently enqueued records sync with partition offsets.
+    // The following task will be called inside each invocation to MockConsumer.poll().
+    // We enqueue only the records with the offset >= partition's current position.
+    Runnable recordEnquerTask = new Runnable() {
+      @Override
+      public void run() {
+        // add all the records with offset >= current partition position.
+        for (TopicPartition tp : assignedPartitions.get()) {
+          long curPos = consumer.position(tp);
+          for (ConsumerRecord<byte[], byte[]> r : records.get(tp)) {
+            if (r.offset() >= curPos) {
+              consumer.addRecord(r);
+            }
+          }
+        }
+        consumer.schedulePollTask(this);
+      }
+    };
+
+    consumer.schedulePollTask(recordEnquerTask);
     return consumer;
   }
 
@@ -158,15 +186,24 @@ public class KafkaIOTest {
     private final List<String> topics;
     private final int partitionsPerTopic;
     private final int numElements;
+    private final OffsetResetStrategy offsetResetStrategy;
 
-    public ConsumerFactoryFn(List<String> topics, int partitionsPerTopic, int numElements) {
+    public ConsumerFactoryFn(List<String> topics,
+                             int partitionsPerTopic,
+                             int numElements,
+                             OffsetResetStrategy offsetResetStrategy) {
       this.topics = topics;
       this.partitionsPerTopic = partitionsPerTopic;
       this.numElements = numElements;
+      this.offsetResetStrategy = offsetResetStrategy;
+    }
+
+    public ConsumerFactoryFn(List<String> topics, int partitionsPerTopic, int numElements) {
+      this(topics, partitionsPerTopic, numElements, OffsetResetStrategy.EARLIEST);
     }
 
     public Consumer<byte[], byte[]> apply(Map<String, Object> config) {
-      return mkMockConsumer(topics, partitionsPerTopic, numElements);
+      return mkMockConsumer(topics, partitionsPerTopic, numElements, offsetResetStrategy);
     }
   }
 
@@ -373,14 +410,11 @@ public class KafkaIOTest {
           .get(0);
 
     UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
-    final int numToSkip = 3;
+    final int numToSkip = 20; // one from each partition.
 
     // advance numToSkip elements
-    if (!reader.start()) {
-      advanceOnce(reader);
-    }
-
-    for (long l = 0; l < numToSkip - 1; ++l) {
+    reader.start();
+    for (int l = 1; l < numToSkip; ++l) {
       advanceOnce(reader);
     }
 
@@ -396,10 +430,7 @@ public class KafkaIOTest {
     // Confirm that we get the next elements in sequence.
     // This also confirms that Reader interleaves records from each partitions by the reader.
 
-    if (!reader.start()) {
-      advanceOnce(reader);
-    }
-
+    reader.start();
     for (int i = numToSkip; i < numElements; i++) {
       assertEquals(i, (long) reader.getCurrent().getKV().getValue());
       assertEquals(i, reader.getCurrentTimestamp().getMillis());
@@ -407,6 +438,68 @@ public class KafkaIOTest {
         advanceOnce(reader);
       }
     }
+  }
+
+  @Test
+  public void testUnboundedSourceCheckpointMarkWithEmptyPartitions() throws Exception {
+    // Similar to testUnboundedSourceCheckpointMark(), but verifies that source resumes
+    // properly from empty partitions, without missing messages added since checkpoint.
+
+    // Initialize consumer with than number of partitions so that some of them are empty.
+    int initialNumElements = 5;
+    UnboundedSource<KafkaRecord<Integer, Long>, KafkaCheckpointMark> source =
+        mkKafkaReadTransform(initialNumElements, new ValueAsTimestampFn())
+            .makeSource()
+            .generateInitialSplits(1, PipelineOptionsFactory.fromArgs(new String[0]).create())
+            .get(0);
+
+    UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
+
+    reader.start();
+    for (int l = 1; l < initialNumElements; ++l) {
+      advanceOnce(reader);
+    }
+
+    // Checkpoint and restart, and confirm that the source continues correctly.
+    KafkaCheckpointMark mark = CoderUtils.clone(
+        source.getCheckpointMarkCoder(), (KafkaCheckpointMark) reader.getCheckpointMark());
+
+    // Create another source with MockConsumer with OffsetResetStrategy.LATEST. This insures that
+    // the reader need to explicitly need to seek to first offset for partitions that were empty.
+
+    int numElements = 100; // all the 20 partitions will have elements
+    List<String> topics = ImmutableList.of("topic_a", "topic_b");
+
+    source = KafkaIO.read()
+        .withBootstrapServers("none")
+        .withTopics(topics)
+        .withConsumerFactoryFn(new ConsumerFactoryFn(
+            topics, 10, numElements, OffsetResetStrategy.LATEST))
+        .withKeyCoder(BigEndianIntegerCoder.of())
+        .withValueCoder(BigEndianLongCoder.of())
+        .withMaxNumRecords(numElements)
+        .withTimestampFn(new ValueAsTimestampFn())
+        .makeSource()
+        .generateInitialSplits(1, PipelineOptionsFactory.fromArgs(new String[0]).create())
+        .get(0);
+
+    reader = source.createReader(null, mark);
+
+    reader.start();
+
+    // Verify in any order. As the partitions are unevenly read, the returned records are not in a
+    // simple order. Note that testUnboundedSourceCheckpointMark() verifies round robin consumption.
+
+    List<Long> expected = new ArrayList<>();
+    List<Long> actual = new ArrayList<>();
+    for (long i = initialNumElements; i < numElements; i++) {
+      expected.add(i);
+      actual.add(reader.getCurrent().getKV().getValue());
+      if ((i + 1) < numElements) {
+        advanceOnce(reader);
+      }
+    }
+    assertThat(actual, IsIterableContainingInAnyOrder.containsInAnyOrder(expected.toArray()));
   }
 
   @Test
@@ -440,7 +533,7 @@ public class KafkaIOTest {
       completionThread.shutdown();
 
       verifyProducerRecords(topic, numElements, false);
-     }
+    }
   }
 
   @Test

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -392,7 +392,14 @@ public class KafkaIOTest {
   private static void advanceOnce(UnboundedReader<?> reader) throws IOException {
     while (!reader.advance()) {
       // very rarely will there be more than one attempts.
-      // in case of a bug we might end up looping forever, and test will fail with a timeout.
+      // In case of a bug we might end up looping forever, and test will fail with a timeout.
+
+      // Avoid hard cpu spinning in case of a test failure.
+      try {
+        Thread.sleep(1);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -486,7 +486,7 @@ public class KafkaIOTest {
     reader.start();
 
     // Verify in any order. As the partitions are unevenly read, the returned records are not in a
-    // simple order. Note that testUnboundedSourceCheckpointMark() verifies round robin consumption.
+    // simple order. Note that testUnboundedSourceCheckpointMark() verifies round-robin oder.
 
     List<Long> expected = new ArrayList<>();
     List<Long> actual = new ArrayList<>();


### PR DESCRIPTION
KafkaIO reader should set consumedOffset even before reading the first record. This matters in cases where one of the partition might not have any records since the start. Without this fix, when the job is 'updated' (in Spark runner this happens frequently for each micro batch), the reader for such a partition could lose messages that are sent during the update.

Another option discussed is fetching these offsets insider `generateInitialSplits()` for better consistency. I don't think we need to do that yet : 
  -  I don't it provides better consistency. AFIK, there is no concept of 'consistent set of offsets' across different partitions. 
  - Increases start up latency.
  - If we are starting a streaming job from scratch (and using default 'latest offset'), expectation on 'starting point' is fuzzy anyway. 
  - This policy does not matter for updates as the offset comes from checkpoint stored.
  - readers will take even more responsibility of managing splits when we add support for handing change in Kafka partitions. This does not help there. 

R: @amitsela, @dhalperi 

TODO:
- [x] Add a unit test.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
