### PR TITLE
Add profile_memory flag

### DIFF
--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -370,9 +370,12 @@ class ProfilingOptions(PipelineOptions):
 
   @classmethod
   def _add_argparse_args(cls, parser):
-    parser.add_argument('--profile',
+    parser.add_argument('--profile_cpu',
                         action='store_true',
-                        help='Enable work item profiling')
+                        help='Enable work item CPU profiling.')
+    parser.add_argument('--profile_memory',
+                        action='store_true',
+                        help='Enable work item heap profiling.')
     parser.add_argument('--profile_location',
                         default=None,
                         help='GCS path for saving profiler data.')

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -30,9 +30,9 @@ class PipelineOptionsTest(unittest.TestCase):
        'expected': {'num_workers': 5, 'mock_flag': False, 'mock_option': None}},
       {
           'flags': [
-              '--profile', '--profile_location', 'gs://bucket/', 'ignored'],
+              '--profile_cpu', '--profile_location', 'gs://bucket/', 'ignored'],
           'expected': {
-              'profile': True, 'profile_location': 'gs://bucket/',
+              'profile_cpu': True, 'profile_location': 'gs://bucket/',
               'mock_flag': False, 'mock_option': None}
       },
       {'flags': ['--num_workers', '5', '--mock_flag'],


### PR DESCRIPTION
Runners with memory profiling support, would use this flag to profile
the workflow for heap usage.

Renamed the profile flag to profile_cpu flag to make the distinction
clear.