### PR TITLE
[BEAM-701] AvroIO.Write: minor doc and test fixes

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -110,6 +110,10 @@ import org.apache.beam.sdk.values.PDone;
  *     .withSuffix(".avro"));
  * } </pre>
  *
+ * <p>By default, {@link AvroIO.Write} produces output files that are compressed using the
+ * {@link org.apache.avro.file.DeflateCodec CodecFactory.deflateCodec(6)}. This default can
+ * be changed or overridden using {@link AvroIO.Write#withCodec}.
+ *
  * <p><h3>Permissions</h3>
  * Permission requirements depend on the {@link PipelineRunner} that is used to execute the
  * Dataflow job. Please refer to the documentation of corresponding {@link PipelineRunner}s for

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/SerializableAvroCodecFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/SerializableAvroCodecFactory.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 import org.apache.avro.file.CodecFactory;
 
 /**
- * A wrapper allows  {@link org.apache.avro.file.CodecFactory}s to be serialized using Java's
+ * A wrapper that allows {@link org.apache.avro.file.CodecFactory}s to be serialized using Java's
  * standard serialization mechanisms.
  */
 class SerializableAvroCodecFactory implements Externalizable {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -178,7 +178,7 @@ public class AvroIOTest {
     p.run();
     DataFileStream dataFileStream = new DataFileStream(new FileInputStream(outputFile),
         new GenericDatumReader());
-    assertEquals(dataFileStream.getMetaString("avro.codec"), "deflate");
+    assertEquals("deflate", dataFileStream.getMetaString("avro.codec"));
   }
 
   @Test
@@ -207,7 +207,7 @@ public class AvroIOTest {
     p.run();
     DataFileStream dataFileStream = new DataFileStream(new FileInputStream(outputFile),
         new GenericDatumReader());
-    assertEquals(dataFileStream.getMetaString("avro.codec"), "null");
+    assertEquals("null", dataFileStream.getMetaString("avro.codec"));
   }
 
   @DefaultCoder(AvroCoder.class)
@@ -280,7 +280,7 @@ public class AvroIOTest {
   public void testWriteWithDefaultCodec() throws Exception {
     AvroIO.Write.Bound<GenericRecord> write = AvroIO.Write
         .to("gs://bucket/foo/baz");
-    assertEquals(write.getCodec().toString(), CodecFactory.deflateCodec(6).toString());
+    assertEquals(CodecFactory.deflateCodec(6).toString(), write.getCodec().toString());
   }
 
   @Test
@@ -288,7 +288,7 @@ public class AvroIOTest {
     AvroIO.Write.Bound<GenericRecord> write = AvroIO.Write
         .to("gs://bucket/foo/baz")
         .withCodec(CodecFactory.snappyCodec());
-    assertEquals(write.getCodec().toString(), SNAPPY_CODEC);
+    assertEquals(SNAPPY_CODEC, write.getCodec().toString());
   }
 
   @Test
@@ -300,7 +300,7 @@ public class AvroIOTest {
 
     AvroIO.Write.Bound<GenericRecord> serdeWrite = SerializableUtils.clone(write);
 
-    assertEquals(serdeWrite.getCodec().toString(), CodecFactory.deflateCodec(9).toString());
+    assertEquals(CodecFactory.deflateCodec(9).toString(), serdeWrite.getCodec().toString());
   }
 
   @Test
@@ -312,7 +312,7 @@ public class AvroIOTest {
 
     AvroIO.Write.Bound<GenericRecord> serdeWrite = SerializableUtils.clone(write);
 
-    assertEquals(serdeWrite.getCodec().toString(), CodecFactory.xzCodec(9).toString());
+    assertEquals(CodecFactory.xzCodec(9).toString(), serdeWrite.getCodec().toString());
   }
 
   @SuppressWarnings("deprecation") // using AvroCoder#createDatumReader for tests.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SerializableAvroCodecFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SerializableAvroCodecFactoryTest.java
@@ -50,7 +50,7 @@ public class SerializableAvroCodecFactoryTest {
       SerializableAvroCodecFactory codecFactory = new SerializableAvroCodecFactory(
           CodecFactory.fromString(codec));
 
-      assertEquals(codecFactory.getCodec().toString(), (CodecFactory.fromString(codec).toString()));
+      assertEquals((CodecFactory.fromString(codec).toString()), codecFactory.getCodec().toString());
     }
   }
 
@@ -62,7 +62,7 @@ public class SerializableAvroCodecFactoryTest {
 
       SerializableAvroCodecFactory serdeC = SerializableUtils.clone(codecFactory);
 
-      assertEquals(serdeC.getCodec().toString(), CodecFactory.fromString(codec).toString());
+      assertEquals(CodecFactory.fromString(codec).toString(), serdeC.getCodec().toString());
     }
   }
 
@@ -74,7 +74,7 @@ public class SerializableAvroCodecFactoryTest {
 
       SerializableAvroCodecFactory serdeC = SerializableUtils.clone(codecFactory);
 
-      assertEquals(serdeC.getCodec().toString(), CodecFactory.deflateCodec(i).toString());
+      assertEquals(CodecFactory.deflateCodec(i).toString(), serdeC.getCodec().toString());
     }
   }
 
@@ -86,7 +86,7 @@ public class SerializableAvroCodecFactoryTest {
 
       SerializableAvroCodecFactory serdeC = SerializableUtils.clone(codecFactory);
 
-      assertEquals(serdeC.getCodec().toString(), CodecFactory.xzCodec(i).toString());
+      assertEquals(CodecFactory.xzCodec(i).toString(), serdeC.getCodec().toString());
     }
   }
 


### PR DESCRIPTION
* Document the default codec.
* Swap the order of assertEquals in tests to match the expected pattern (expected, actual).