### PR TITLE
[BEAM-593] avoid throwing Exception in waitUntilFinish

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -25,8 +25,6 @@ import org.apache.commons.lang.NotImplementedException;
 import org.joda.time.Duration;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Result of executing a {@link org.apache.beam.sdk.Pipeline} with Flink. This

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.beam.sdk.AggregatorRetrievalException;
 import org.apache.beam.sdk.AggregatorValues;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.commons.lang.NotImplementedException;
 import org.joda.time.Duration;
@@ -46,6 +47,11 @@ public class FlinkDetachedRunnerResult implements PipelineResult {
     throw new AggregatorRetrievalException(
         "Accumulators can't be retrieved for detached Job executions.",
         new NotImplementedException());
+  }
+
+  @Override
+  public MetricResults metrics() {
+    throw new UnsupportedOperationException("The FlinkRunner does not currently support metrics.");
   }
 
   @Override

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -27,9 +27,8 @@ import org.joda.time.Duration;
 import java.io.IOException;
 
 /**
- * Result of executing a {@link org.apache.beam.sdk.Pipeline} with Flink. This
- * has methods to query to job runtime and the final values of
- * {@link Aggregator}s.
+ * Result of a detached execution of a {@link org.apache.beam.sdk.Pipeline} with Flink.
+ * In detached execution, results and job execution are currently unavailable.
  */
 public class FlinkDetachedRunnerResult implements PipelineResult {
 

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.flink;
 
+import java.io.IOException;
+
 import org.apache.beam.sdk.AggregatorRetrievalException;
 import org.apache.beam.sdk.AggregatorValues;
 import org.apache.beam.sdk.PipelineResult;
@@ -24,7 +26,6 @@ import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.commons.lang.NotImplementedException;
 import org.joda.time.Duration;
 
-import java.io.IOException;
 
 /**
  * Result of a detached execution of a {@link org.apache.beam.sdk.Pipeline} with Flink.

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -33,6 +33,8 @@ import java.io.IOException;
  */
 public class FlinkDetachedRunnerResult implements PipelineResult {
 
+  FlinkDetachedRunnerResult() {}
+
   @Override
   public State getState() {
     return State.UNKNOWN;

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -17,82 +17,54 @@
  */
 package org.apache.beam.runners.flink;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 import org.apache.beam.sdk.AggregatorRetrievalException;
 import org.apache.beam.sdk.AggregatorValues;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.transforms.Aggregator;
+import org.apache.commons.lang.NotImplementedException;
 import org.joda.time.Duration;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Result of executing a {@link org.apache.beam.sdk.Pipeline} with Flink. This
  * has methods to query to job runtime and the final values of
- * {@link org.apache.beam.sdk.transforms.Aggregator}s.
+ * {@link Aggregator}s.
  */
-public class FlinkRunnerResult implements PipelineResult {
-
-  private final Map<String, Object> aggregators;
-
-  private final long runtime;
-
-  FlinkRunnerResult(Map<String, Object> aggregators, long runtime) {
-    this.aggregators = (aggregators == null || aggregators.isEmpty())
-        ? Collections.<String, Object>emptyMap()
-        : Collections.unmodifiableMap(aggregators);
-    this.runtime = runtime;
-  }
+public class FlinkDetachedRunnerResult implements PipelineResult {
 
   @Override
   public State getState() {
-    return State.DONE;
+    return State.UNKNOWN;
   }
 
   @Override
   public <T> AggregatorValues<T> getAggregatorValues(final Aggregator<?, T> aggregator)
       throws AggregatorRetrievalException {
-    // TODO provide a list of all accumulator step values
-    Object value = aggregators.get(aggregator.getName());
-    if (value != null) {
-      return new AggregatorValues<T>() {
-        @Override
-        public Map<String, T> getValuesAtSteps() {
-          return (Map<String, T>) aggregators;
-        }
-      };
-    } else {
-      throw new AggregatorRetrievalException("Accumulator results not found.",
-          new RuntimeException("Accumulator does not exist."));
-    }
-  }
-
-  @Override
-  public String toString() {
-    return "FlinkRunnerResult{"
-        + "aggregators=" + aggregators
-        + ", runtime=" + runtime
-        + '}';
+    throw new AggregatorRetrievalException(
+        "Accumulators can't be retrieved for detached Job executions.",
+        new NotImplementedException());
   }
 
   @Override
   public State cancel() throws IOException {
-    throw new UnsupportedOperationException("FlinkRunnerResult does not support cancel.");
+    throw new UnsupportedOperationException("Cancelling is not yet supported.");
   }
 
   @Override
   public State waitUntilFinish() {
-    return State.DONE;
+    return State.UNKNOWN;
   }
 
   @Override
   public State waitUntilFinish(Duration duration) {
-    return State.DONE;
+    return State.UNKNOWN;
   }
 
   @Override
-  public MetricResults metrics() {
-    throw new UnsupportedOperationException("The FlinkRunner does not currently support metrics.");
+  public String toString() {
+    return "FlinkDetachedRunnerResult{}";
   }
 }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -34,6 +34,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -66,7 +67,7 @@ import org.slf4j.LoggerFactory;
  * pipeline by first translating them to a Flink Plan and then executing them either locally
  * or on a Flink cluster, depending on the configuration.
  */
-public class FlinkRunner extends PipelineRunner<FlinkRunnerResult> {
+public class FlinkRunner extends PipelineRunner<PipelineResult> {
 
   private static final Logger LOG = LoggerFactory.getLogger(FlinkRunner.class);
 
@@ -133,7 +134,7 @@ public class FlinkRunner extends PipelineRunner<FlinkRunnerResult> {
   }
 
   @Override
-  public FlinkRunnerResult run(Pipeline pipeline) {
+  public PipelineResult run(Pipeline pipeline) {
     logWarningIfPCollectionViewHasNonDeterministicKeyCoder(pipeline);
 
     LOG.info("Executing pipeline using FlinkRunner.");
@@ -154,8 +155,7 @@ public class FlinkRunner extends PipelineRunner<FlinkRunnerResult> {
 
     if (result instanceof DetachedEnvironment.DetachedJobExecutionResult) {
       LOG.info("Pipeline submitted in Detached mode");
-      Map<String, Object> accumulators = Collections.emptyMap();
-      return new FlinkRunnerResult(accumulators, -1L);
+      return new FlinkDetachedRunnerResult();
     } else {
       LOG.info("Execution finished in {} msecs", result.getNetRuntime());
       Map<String, Object> accumulators = result.getAllAccumulatorResults();

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -25,7 +25,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunnerResult.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkRunnerResult.java
@@ -33,8 +33,11 @@ import org.joda.time.Duration;
  * {@link org.apache.beam.sdk.transforms.Aggregator}s.
  */
 public class FlinkRunnerResult implements PipelineResult {
+
   private final Map<String, Object> aggregators;
+
   private final long runtime;
+
   public FlinkRunnerResult(Map<String, Object> aggregators, long runtime) {
     this.aggregators = (aggregators == null || aggregators.isEmpty())
         ? Collections.<String, Object>emptyMap()
@@ -44,7 +47,7 @@ public class FlinkRunnerResult implements PipelineResult {
 
   @Override
   public State getState() {
-    return null;
+    return State.DONE;
   }
 
   @Override
@@ -85,7 +88,7 @@ public class FlinkRunnerResult implements PipelineResult {
 
   @Override
   public State waitUntilFinish(Duration duration) {
-    throw new UnsupportedOperationException("FlinkRunnerResult does not support waitUntilFinish.");
+    return State.DONE;
   }
 
   @Override

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink;
 
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
@@ -29,7 +30,7 @@ import org.apache.beam.sdk.values.POutput;
 /**
  * Test Flink runner.
  */
-public class TestFlinkRunner extends PipelineRunner<FlinkRunnerResult> {
+public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
 
   private FlinkRunner delegate;
 
@@ -59,11 +60,9 @@ public class TestFlinkRunner extends PipelineRunner<FlinkRunnerResult> {
   }
 
   @Override
-  public FlinkRunnerResult run(Pipeline pipeline) {
+  public PipelineResult run(Pipeline pipeline) {
     try {
-      FlinkRunnerResult result = delegate.run(pipeline);
-
-      return result;
+      return delegate.run(pipeline);
     } catch (Throwable e) {
       // Special case hack to pull out assertion errors from PAssert; instead there should
       // probably be a better story along the lines of UserCodeException.


### PR DESCRIPTION
The current implementation of Flink's `PipelineResult` assumes that the pipeline has already been processed. Hence, we can return State.Done when `wailUntilFinish()` is called.