### PR TITLE
[BEAM-742] Translation from Trigger to TriggerStateMachine

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.core.triggers;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnceTriggerStateMachine;
@@ -43,6 +44,10 @@ public class AfterAllStateMachine extends OnceTriggerStateMachine {
   @SafeVarargs
   public static OnceTriggerStateMachine of(OnceTriggerStateMachine... triggers) {
     return new AfterAllStateMachine(Arrays.<TriggerStateMachine>asList(triggers));
+  }
+
+  public static OnceTriggerStateMachine of(Iterable<? extends TriggerStateMachine> triggers) {
+    return new AfterAllStateMachine(ImmutableList.copyOf(triggers));
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -82,7 +82,7 @@ public abstract class AfterDelayFromFirstElementStateMachine extends OnceTrigger
    */
   protected final List<SerializableFunction<Instant, Instant>> timestampMappers;
 
-  private final TimeDomain timeDomain;
+  protected final TimeDomain timeDomain;
 
   public AfterDelayFromFirstElementStateMachine(
       TimeDomain timeDomain,
@@ -94,6 +94,21 @@ public abstract class AfterDelayFromFirstElementStateMachine extends OnceTrigger
 
   private Instant getTargetTimestamp(OnElementContext c) {
     return computeTargetTimestamp(c.currentProcessingTime());
+  }
+
+  /**
+   * The time domain according for which this trigger sets timers.
+   */
+  public TimeDomain getTimeDomain() {
+    return timeDomain;
+  }
+
+  /**
+   * The mapping functions applied to the arrival time of an element to determine when to
+   * set a wake-up timer for triggering.
+   */
+  public List<SerializableFunction<Instant, Instant>> getTimestampMappers() {
+    return timestampMappers;
   }
 
   /**

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -97,7 +97,7 @@ public abstract class AfterDelayFromFirstElementStateMachine extends OnceTrigger
   }
 
   /**
-   * The time domain according for which this trigger sets timers.
+   * The time domain according to which this trigger sets timers.
    */
   public TimeDomain getTimeDomain() {
     return timeDomain;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterEachStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterEachStateMachine.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.core.triggers;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -52,6 +53,10 @@ public class AfterEachStateMachine extends TriggerStateMachine {
   @SafeVarargs
   public static TriggerStateMachine inOrder(TriggerStateMachine... triggers) {
     return new AfterEachStateMachine(Arrays.<TriggerStateMachine>asList(triggers));
+  }
+
+  public static TriggerStateMachine inOrder(Iterable<? extends TriggerStateMachine> triggers) {
+    return new AfterEachStateMachine(ImmutableList.copyOf(triggers));
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.core.triggers;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnceTriggerStateMachine;
@@ -44,6 +45,11 @@ public class AfterFirstStateMachine extends OnceTriggerStateMachine {
   public static OnceTriggerStateMachine of(
       OnceTriggerStateMachine... triggers) {
     return new AfterFirstStateMachine(Arrays.<TriggerStateMachine>asList(triggers));
+  }
+
+  public static OnceTriggerStateMachine of(
+      Iterable<? extends TriggerStateMachine> triggers) {
+    return new AfterFirstStateMachine(ImmutableList.copyOf(triggers));
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
@@ -49,6 +49,13 @@ private static final StateTag<Object, AccumulatorCombiningState<Long, long[], Lo
   }
 
   /**
+   * The number of elements after which this trigger may fire.
+   */
+  public int getElementCount() {
+    return countElems;
+  }
+
+  /**
    * Creates a trigger that fires when the pane contains at least {@code countElems} elements.
    */
   public static AfterPaneStateMachine elementCountAtLeast(int countElems) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -93,11 +93,11 @@ public class AfterWatermarkStateMachine {
       this.lateTrigger = lateTrigger;
     }
 
-    public TriggerStateMachine withEarlyFirings(OnceTriggerStateMachine earlyTrigger) {
+    public AfterWatermarkEarlyAndLate withEarlyFirings(OnceTriggerStateMachine earlyTrigger) {
       return new AfterWatermarkEarlyAndLate(earlyTrigger, lateTrigger);
     }
 
-    public TriggerStateMachine withLateFirings(OnceTriggerStateMachine lateTrigger) {
+    public AfterWatermarkEarlyAndLate withLateFirings(OnceTriggerStateMachine lateTrigger) {
       return new AfterWatermarkEarlyAndLate(earlyTrigger, lateTrigger);
     }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachines.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachines.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.triggers;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnceTriggerStateMachine;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.windowing.AfterAll;
+import org.apache.beam.sdk.transforms.windowing.AfterDelayFromFirstElement;
+import org.apache.beam.sdk.transforms.windowing.AfterEach;
+import org.apache.beam.sdk.transforms.windowing.AfterFirst;
+import org.apache.beam.sdk.transforms.windowing.AfterPane;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterSynchronizedProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
+import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
+import org.apache.beam.sdk.transforms.windowing.Never.NeverTrigger;
+import org.apache.beam.sdk.transforms.windowing.OrFinallyTrigger;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Trigger;
+import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
+import org.apache.beam.sdk.util.TimeDomain;
+import org.joda.time.Instant;
+
+/** Translates a {@link Trigger} to a {@link TriggerStateMachine}. */
+public class TriggerStateMachines {
+
+  private TriggerStateMachines() {}
+
+  @VisibleForTesting static final StateMachineConverter CONVERTER = new StateMachineConverter();
+
+  public static TriggerStateMachine stateMachineForTrigger(Trigger trigger) {
+    return CONVERTER.evaluateTrigger(trigger);
+  }
+
+  public static OnceTriggerStateMachine stateMachineForOnceTrigger(OnceTrigger trigger) {
+    return CONVERTER.evaluateOnceTrigger(trigger);
+  }
+
+  @VisibleForTesting
+  static class StateMachineConverter {
+
+    public TriggerStateMachine evaluateTrigger(Trigger trigger) {
+      Method evaluationMethod = getEvaluationMethod(trigger.getClass());
+      return tryEvaluate(evaluationMethod, trigger);
+    }
+
+    public OnceTriggerStateMachine evaluateOnceTrigger(OnceTrigger trigger) {
+      Method evaluationMethod = getEvaluationMethod(trigger.getClass());
+      return (OnceTriggerStateMachine) tryEvaluate(evaluationMethod, trigger);
+    }
+
+    private TriggerStateMachine tryEvaluate(Method evaluationMethod, Trigger trigger) {
+      try {
+        return (TriggerStateMachine) evaluationMethod.invoke(this, trigger);
+      } catch (InvocationTargetException exc) {
+        if (exc.getCause() instanceof RuntimeException) {
+          throw (RuntimeException) exc.getCause();
+        } else {
+          throw new RuntimeException(exc.getCause());
+        }
+      } catch (IllegalAccessException exc) {
+        throw new IllegalStateException(
+            String.format("Internal error: could not invoke %s", evaluationMethod));
+      }
+    }
+
+    private Method getEvaluationMethod(Class<?> clazz) {
+      Method evaluationMethod;
+      try {
+        return getClass().getDeclaredMethod("evaluateSpecific", clazz);
+      } catch (NoSuchMethodException exc) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Cannot translate trigger class %s to a state machine.", clazz.getCanonicalName()),
+            exc);
+      }
+    }
+
+    private TriggerStateMachine evaluateSpecific(DefaultTrigger v) {
+      return DefaultTriggerStateMachine.of();
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(AfterWatermark.FromEndOfWindow v) {
+      return AfterWatermarkStateMachine.pastEndOfWindow();
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(NeverTrigger v) {
+      return NeverStateMachine.ever();
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(AfterSynchronizedProcessingTime v) {
+      return new AfterSynchronizedProcessingTimeStateMachine();
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(AfterFirst v) {
+      List<OnceTriggerStateMachine> subStateMachines =
+          Lists.newArrayListWithCapacity(v.subTriggers().size());
+      for (Trigger subtrigger : v.subTriggers()) {
+        subStateMachines.add(stateMachineForOnceTrigger((OnceTrigger) subtrigger));
+      }
+      return AfterFirstStateMachine.of(subStateMachines);
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(AfterAll v) {
+      List<OnceTriggerStateMachine> subStateMachines =
+          Lists.newArrayListWithCapacity(v.subTriggers().size());
+      for (Trigger subtrigger : v.subTriggers()) {
+        subStateMachines.add(stateMachineForOnceTrigger((OnceTrigger) subtrigger));
+      }
+      return AfterAllStateMachine.of(subStateMachines);
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(AfterPane v) {
+      return AfterPaneStateMachine.elementCountAtLeast(v.getElementCount());
+    }
+
+    private TriggerStateMachine evaluateSpecific(AfterWatermark.AfterWatermarkEarlyAndLate v) {
+      AfterWatermarkStateMachine.AfterWatermarkEarlyAndLate machine =
+          AfterWatermarkStateMachine.pastEndOfWindow()
+              .withEarlyFirings(stateMachineForOnceTrigger(v.getEarlyTrigger()));
+
+      if (v.getLateTrigger() != null) {
+        machine = machine.withLateFirings(stateMachineForOnceTrigger(v.getLateTrigger()));
+      }
+      return machine;
+    }
+
+    private TriggerStateMachine evaluateSpecific(AfterEach v) {
+      List<TriggerStateMachine> subStateMachines =
+          Lists.newArrayListWithCapacity(v.subTriggers().size());
+
+      for (Trigger subtrigger : v.subTriggers()) {
+        subStateMachines.add(stateMachineForTrigger(subtrigger));
+      }
+
+      return AfterEachStateMachine.inOrder(subStateMachines);
+    }
+
+    private TriggerStateMachine evaluateSpecific(Repeatedly v) {
+      return RepeatedlyStateMachine.forever(stateMachineForTrigger(v.getRepeatedTrigger()));
+    }
+
+    private TriggerStateMachine evaluateSpecific(OrFinallyTrigger v) {
+      return new OrFinallyStateMachine(
+          stateMachineForTrigger(v.getMainTrigger()),
+          stateMachineForOnceTrigger(v.getUntilTrigger()));
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(AfterProcessingTime v) {
+      return evaluateSpecific((AfterDelayFromFirstElement) v);
+    }
+
+    private OnceTriggerStateMachine evaluateSpecific(final AfterDelayFromFirstElement v) {
+      return new AfterDelayFromFirstElementStateMachineAdapter(v);
+    }
+
+    private static class AfterDelayFromFirstElementStateMachineAdapter
+        extends AfterDelayFromFirstElementStateMachine {
+
+      public AfterDelayFromFirstElementStateMachineAdapter(AfterDelayFromFirstElement v) {
+        this(v.getTimeDomain(), v.getTimestampMappers());
+      }
+
+      private AfterDelayFromFirstElementStateMachineAdapter(
+          TimeDomain timeDomain, List<SerializableFunction<Instant, Instant>> timestampMappers) {
+        super(timeDomain, timestampMappers);
+      }
+
+      @Override
+      public Instant getCurrentTime(TriggerContext context) {
+        switch (timeDomain) {
+          case PROCESSING_TIME:
+            return context.currentProcessingTime();
+          case SYNCHRONIZED_PROCESSING_TIME:
+            return context.currentSynchronizedProcessingTime();
+          case EVENT_TIME:
+            return context.currentEventTime();
+          default:
+            throw new IllegalArgumentException("A time domain that doesn't exist was received!");
+        }
+      }
+
+      @Override
+      protected AfterDelayFromFirstElementStateMachine newWith(
+          List<SerializableFunction<Instant, Instant>> transform) {
+        return new AfterDelayFromFirstElementStateMachineAdapter(timeDomain, transform);
+      }
+    }
+  }
+}

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachinesTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachinesTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.triggers;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnceTriggerStateMachine;
+import org.apache.beam.sdk.transforms.windowing.AfterAll;
+import org.apache.beam.sdk.transforms.windowing.AfterDelayFromFirstElement;
+import org.apache.beam.sdk.transforms.windowing.AfterEach;
+import org.apache.beam.sdk.transforms.windowing.AfterFirst;
+import org.apache.beam.sdk.transforms.windowing.AfterPane;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
+import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
+import org.apache.beam.sdk.transforms.windowing.Never;
+import org.apache.beam.sdk.transforms.windowing.Never.NeverTrigger;
+import org.apache.beam.sdk.transforms.windowing.OrFinallyTrigger;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
+import org.apache.beam.sdk.util.TimeDomain;
+import org.joda.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests the {@link TriggerStateMachines} static utility methods. */
+@RunWith(JUnit4.class)
+public class TriggerStateMachinesTest {
+
+  //
+  // Tests for leaf trigger translation
+  //
+
+  @Test
+  public void testStateMachineForAfterPane() {
+    int count = 37;
+    AfterPane trigger = AfterPane.elementCountAtLeast(count);
+    AfterPaneStateMachine machine =
+        (AfterPaneStateMachine) TriggerStateMachines.stateMachineForOnceTrigger(trigger);
+
+    assertThat(machine.getElementCount(), equalTo(trigger.getElementCount()));
+  }
+
+  @Test
+  public void testStateMachineForAfterProcessingTime() {
+    Duration minutes = Duration.standardMinutes(94);
+    Duration hours = Duration.standardHours(13);
+
+    AfterDelayFromFirstElement trigger =
+        AfterProcessingTime.pastFirstElementInPane().plusDelayOf(minutes).alignedTo(hours);
+
+    AfterDelayFromFirstElementStateMachine machine =
+        (AfterDelayFromFirstElementStateMachine)
+            TriggerStateMachines.stateMachineForOnceTrigger(trigger);
+
+    assertThat(machine.getTimeDomain(), equalTo(TimeDomain.PROCESSING_TIME));
+
+    // This equality is function equality, but due to the structure of the code (no serialization)
+    // it is OK to check
+    assertThat(machine.getTimestampMappers(), equalTo(trigger.getTimestampMappers()));
+  }
+
+  @Test
+  public void testStateMachineForAfterWatermark() {
+    AfterWatermark.FromEndOfWindow trigger = AfterWatermark.pastEndOfWindow();
+    AfterWatermarkStateMachine.FromEndOfWindow machine =
+        (AfterWatermarkStateMachine.FromEndOfWindow)
+            TriggerStateMachines.stateMachineForOnceTrigger(trigger);
+    // No parameters, so if it doesn't crash, we win!
+  }
+
+  @Test
+  public void testDefaultTriggerTranslation() {
+    DefaultTrigger trigger = DefaultTrigger.of();
+    DefaultTriggerStateMachine machine =
+        (DefaultTriggerStateMachine)
+            checkNotNull(TriggerStateMachines.stateMachineForTrigger(trigger));
+    // No parameters, so if it doesn't crash, we win!
+  }
+
+  @Test
+  public void testNeverTranslation() {
+    NeverTrigger trigger = Never.ever();
+    NeverStateMachine machine =
+        (NeverStateMachine) checkNotNull(TriggerStateMachines.stateMachineForTrigger(trigger));
+    // No parameters, so if it doesn't crash, we win!
+  }
+
+  //
+  // Tests for composite trigger translation
+  //
+  // These check just that translation was invoked recursively using somewhat random
+  // leaf subtriggers; by induction it all holds together. Beyond this, explicit tests
+  // of particular triggers will suffice.
+
+  private static final int ELEM_COUNT = 472;
+  private static final Duration DELAY = Duration.standardSeconds(95673);
+
+  private final OnceTrigger subtrigger1 = AfterPane.elementCountAtLeast(ELEM_COUNT);
+  private final OnceTrigger subtrigger2 =
+      AfterProcessingTime.pastFirstElementInPane().plusDelayOf(DELAY);
+
+  private final OnceTriggerStateMachine submachine1 =
+      TriggerStateMachines.stateMachineForOnceTrigger(subtrigger1);
+  private final OnceTriggerStateMachine submachine2 =
+      TriggerStateMachines.stateMachineForOnceTrigger(subtrigger2);
+
+  @Test
+  public void testAfterEachTranslation() {
+    AfterEach trigger = AfterEach.inOrder(subtrigger1, subtrigger2);
+    AfterEachStateMachine machine =
+        (AfterEachStateMachine) TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(machine, equalTo(AfterEachStateMachine.inOrder(submachine1, submachine2)));
+  }
+
+  @Test
+  public void testAfterFirstTranslation() {
+    AfterFirst trigger = AfterFirst.of(subtrigger1, subtrigger2);
+    AfterFirstStateMachine machine =
+        (AfterFirstStateMachine) TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(machine, equalTo(AfterFirstStateMachine.of(submachine1, submachine2)));
+  }
+
+  @Test
+  public void testAfterAllTranslation() {
+    AfterAll trigger = AfterAll.of(subtrigger1, subtrigger2);
+    AfterAllStateMachine machine =
+        (AfterAllStateMachine) TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(machine, equalTo(AfterAllStateMachine.of(submachine1, submachine2)));
+  }
+
+  @Test
+  public void testAfterWatermarkEarlyTranslation() {
+    AfterWatermark.AfterWatermarkEarlyAndLate trigger =
+        AfterWatermark.pastEndOfWindow().withEarlyFirings(subtrigger1);
+    AfterWatermarkStateMachine.AfterWatermarkEarlyAndLate machine =
+        (AfterWatermarkStateMachine.AfterWatermarkEarlyAndLate)
+            TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(
+        machine,
+        equalTo(AfterWatermarkStateMachine.pastEndOfWindow().withEarlyFirings(submachine1)));
+  }
+
+  @Test
+  public void testAfterWatermarkEarlyLateTranslation() {
+    AfterWatermark.AfterWatermarkEarlyAndLate trigger =
+        AfterWatermark.pastEndOfWindow().withEarlyFirings(subtrigger1).withLateFirings(subtrigger2);
+    AfterWatermarkStateMachine.AfterWatermarkEarlyAndLate machine =
+        (AfterWatermarkStateMachine.AfterWatermarkEarlyAndLate)
+            TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(
+        machine,
+        equalTo(
+            AfterWatermarkStateMachine.pastEndOfWindow()
+                .withEarlyFirings(submachine1)
+                .withLateFirings(submachine2)));
+  }
+
+  @Test
+  public void testOrFinallyTranslation() {
+    OrFinallyTrigger trigger = subtrigger1.orFinally(subtrigger2);
+    OrFinallyStateMachine machine =
+        (OrFinallyStateMachine) TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(machine, equalTo(submachine1.orFinally(submachine2)));
+  }
+
+  @Test
+  public void testRepeatedlyTranslation() {
+    Repeatedly trigger = Repeatedly.forever(subtrigger1);
+    RepeatedlyStateMachine machine =
+        (RepeatedlyStateMachine) TriggerStateMachines.stateMachineForTrigger(trigger);
+
+    assertThat(machine, equalTo(RepeatedlyStateMachine.forever(submachine1)));
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterAll.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterAll.java
@@ -41,7 +41,7 @@ public class AfterAll extends OnceTrigger {
   /**
    * Returns an {@code AfterAll} {@code Trigger} with the given subtriggers.
    */
-  public static OnceTrigger of(OnceTrigger... triggers) {
+  public static AfterAll of(OnceTrigger... triggers) {
     return new AfterAll(Arrays.<Trigger>asList(triggers));
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterDelayFromFirstElement.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterDelayFromFirstElement.java
@@ -97,6 +97,21 @@ public abstract class AfterDelayFromFirstElement extends OnceTrigger {
   }
 
   /**
+   * The time domain according for which this trigger sets timers.
+   */
+  public TimeDomain getTimeDomain() {
+    return timeDomain;
+  }
+
+  /**
+   * The mapping functions applied to the arrival time of an element to determine when to
+   * set a wake-up timer for triggering.
+   */
+  public List<SerializableFunction<Instant, Instant>> getTimestampMappers() {
+    return timestampMappers;
+  }
+
+  /**
    * Aligns timestamps to the smallest multiple of {@code size} since the {@code offset} greater
    * than the timestamp.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterEach.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterEach.java
@@ -54,7 +54,7 @@ public class AfterEach extends Trigger {
    * Returns an {@code AfterEach} {@code Trigger} with the given subtriggers.
    */
   @SafeVarargs
-  public static Trigger inOrder(Trigger... triggers) {
+  public static AfterEach inOrder(Trigger... triggers) {
     return new AfterEach(Arrays.<Trigger>asList(triggers));
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterFirst.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterFirst.java
@@ -42,7 +42,7 @@ public class AfterFirst extends OnceTrigger {
   /**
    * Returns an {@code AfterFirst} {@code Trigger} with the given subtriggers.
    */
-  public static OnceTrigger of(OnceTrigger... triggers) {
+  public static AfterFirst of(OnceTrigger... triggers) {
     return new AfterFirst(Arrays.<Trigger>asList(triggers));
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterPane.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterPane.java
@@ -51,6 +51,13 @@ private static final StateTag<Object, AccumulatorCombiningState<Long, long[], Lo
   }
 
   /**
+   * The number of elements after which this trigger may fire.
+   */
+  public int getElementCount() {
+    return countElems;
+  }
+
+  /**
    * Creates a trigger that fires when the pane contains at least {@code countElems} elements.
    */
   public static AfterPane elementCountAtLeast(int countElems) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterSynchronizedProcessingTime.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterSynchronizedProcessingTime.java
@@ -25,7 +25,11 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.TimeDomain;
 import org.joda.time.Instant;
 
-class AfterSynchronizedProcessingTime extends AfterDelayFromFirstElement {
+/**
+ * A trigger that fires after synchronized processing time has reached a shared
+ * threshold between upstream workers.
+ */
+public class AfterSynchronizedProcessingTime extends AfterDelayFromFirstElement {
 
   @Override
   @Nullable

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
@@ -102,11 +102,11 @@ public class AfterWatermark {
       this.lateTrigger = lateTrigger;
     }
 
-    public Trigger withEarlyFirings(OnceTrigger earlyTrigger) {
+    public AfterWatermarkEarlyAndLate withEarlyFirings(OnceTrigger earlyTrigger) {
       return new AfterWatermarkEarlyAndLate(earlyTrigger, lateTrigger);
     }
 
-    public Trigger withLateFirings(OnceTrigger lateTrigger) {
+    public AfterWatermarkEarlyAndLate withLateFirings(OnceTrigger lateTrigger) {
       return new AfterWatermarkEarlyAndLate(earlyTrigger, lateTrigger);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/AfterWatermark.java
@@ -85,6 +85,14 @@ public class AfterWatermark {
     @Nullable
     private final OnceTrigger lateTrigger;
 
+    public OnceTrigger getEarlyTrigger() {
+      return earlyTrigger;
+    }
+
+    public OnceTrigger getLateTrigger() {
+      return lateTrigger;
+    }
+
     @SuppressWarnings("unchecked")
     public AfterWatermarkEarlyAndLate(OnceTrigger earlyTrigger, OnceTrigger lateTrigger) {
       super(lateTrigger == null

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/DefaultTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/DefaultTrigger.java
@@ -30,7 +30,7 @@ import org.joda.time.Instant;
 public class DefaultTrigger extends Trigger{
 
   private DefaultTrigger() {
-    super(null);
+    super();
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
@@ -39,8 +39,10 @@ public final class Never {
     return new NeverTrigger();
   }
 
-  // package-private in order to check identity for string formatting.
-  static class NeverTrigger extends OnceTrigger {
+  /**
+   * The actual trigger class for {@link Never} triggers.
+   */
+  public static class NeverTrigger extends OnceTrigger {
     protected NeverTrigger() {
       super(null);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
@@ -34,7 +34,7 @@ public final class Never {
    * Returns a trigger which never fires. Output will be produced from the using {@link GroupByKey}
    * when the {@link BoundedWindow} closes.
    */
-  public static OnceTrigger ever() {
+  public static NeverTrigger ever() {
     // NeverTrigger ignores all inputs and is Window-type independent.
     return new NeverTrigger();
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/OrFinallyTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/OrFinallyTrigger.java
@@ -26,7 +26,7 @@ import org.joda.time.Instant;
 /**
  * Executes the {@code actual} trigger until it finishes or until the {@code until} trigger fires.
  */
-class OrFinallyTrigger extends Trigger {
+public class OrFinallyTrigger extends Trigger {
 
   private static final int ACTUAL = 0;
   private static final int UNTIL = 1;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/OrFinallyTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/OrFinallyTrigger.java
@@ -35,6 +35,21 @@ class OrFinallyTrigger extends Trigger {
     super(Arrays.asList(actual, until));
   }
 
+  /**
+   * The main trigger, which will continue firing until the "until" trigger fires. See
+   * {@link #getUntilTrigger()}
+   */
+  public Trigger getMainTrigger() {
+    return subTriggers().get(ACTUAL);
+  }
+
+  /**
+   * The trigger that signals termination of this trigger.
+   */
+  public OnceTrigger getUntilTrigger() {
+    return (OnceTrigger) subTriggers().get(UNTIL);
+  }
+
   @Override
   public void onElement(OnElementContext c) throws Exception {
     c.trigger().subTrigger(ACTUAL).invokeOnElement(c);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Repeatedly.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Repeatedly.java
@@ -49,10 +49,16 @@ public class Repeatedly extends Trigger {
     return new Repeatedly(repeated);
   }
 
-  private Repeatedly(Trigger repeated) {
-    super(Arrays.asList(repeated));
+  private Trigger repeatedTrigger;
+
+  private Repeatedly(Trigger repeatedTrigger) {
+    super(Arrays.asList(repeatedTrigger));
+    this.repeatedTrigger = repeatedTrigger;
   }
 
+  public Trigger getRepeatedTrigger() {
+    return repeatedTrigger;
+  }
 
   @Override
   public void onElement(OnElementContext c) throws Exception {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms.windowing;
 import com.google.common.base.Joiner;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -263,13 +264,15 @@ public abstract class Trigger implements Serializable {
     public abstract MergingTriggerInfo trigger();
   }
 
-  @Nullable
   protected final List<Trigger> subTriggers;
 
-  protected Trigger(@Nullable List<Trigger> subTriggers) {
+  protected Trigger(List<Trigger> subTriggers) {
     this.subTriggers = subTriggers;
   }
 
+  protected Trigger() {
+    this(Collections.EMPTY_LIST);
+  }
 
   /**
    * Called every time an element is incorporated into a window.
@@ -370,7 +373,7 @@ public abstract class Trigger implements Serializable {
     }
   }
 
-  public Iterable<Trigger> subTriggers() {
+  public List<Trigger> subTriggers() {
     return subTriggers;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
@@ -490,7 +490,7 @@ public abstract class Trigger implements Serializable {
    * <p>Note that if {@code t1} is {@link OnceTrigger}, then {@code t1.orFinally(t2)} is the same
    * as {@code AfterFirst.of(t1, t2)}.
    */
-  public Trigger orFinally(OnceTrigger until) {
+  public OrFinallyTrigger orFinally(OnceTrigger until) {
     return new OrFinallyTrigger(this, until);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ReshuffleTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ReshuffleTrigger.java
@@ -31,7 +31,7 @@ import org.joda.time.Instant;
 public class ReshuffleTrigger<W extends BoundedWindow> extends Trigger {
 
   public ReshuffleTrigger() {
-    super(null);
+    super();
   }
 
   @Override


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This add a `TriggerStateMachines` utility class to `runners-core` with one key piece of functionality: converting a `Trigger` (where we pretend it is just a piece of syntax) to a `TriggerStateMachine` (which is just a copy of what triggers currently are).

In doing so, a fairly large number of trivial accessors and private/public alteration were necessary to the existing trigger codebase, but no functionality changes.

It is worth noting briefly the options for disjoint unions in Java, to explain why I chose the one I did:

1. A binder/evaluator a la `StateBinder` (this is the super-type-safe way of doing data in Java) but that adds a non-user-facing method to the interface. It can be useful sometimes, such as the way that `StateTag` has a phantom type that gets propagated to the return type of the visitor.
2. A visitor a la `PipelineVisitor` that just mutates some internal state. This is roughly the same as the prior, but returning `void` and mutating makes it easier to return complex data but forces an ordering.
3. Using reflection to treat the Java class as the disjoint union tag. This is the approach taken by Scala, and the approach I take here. I tried to minimize the reflective boilerplate this induced. No type safety is really lost, since in the technical vision, this trigger will be an AST sent over the wire (aka no type safety is available).

R: @bjchambers 
