### PR TITLE
[BEAM-27] Add initial bits for DoFn Timer API

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -563,10 +563,27 @@ public class ParDo {
               DoFn.class.getSimpleName()));
     }
 
+    // To be removed when the features are complete and runners have their own adequate
+    // rejection logic
+    if (!signature.timerDeclarations().isEmpty()) {
+      throw new UnsupportedOperationException(
+          String.format("Found %s annotations on %s, but %s cannot yet be used with timers.",
+              DoFn.TimerId.class.getSimpleName(),
+              fn.getClass().getName(),
+              DoFn.class.getSimpleName()));
+    }
+
     // State is semantically incompatible with splitting
     if (!signature.stateDeclarations().isEmpty() && signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
           String.format("%s is splittable and uses state, but these are not compatible",
+              fn.getClass().getName()));
+    }
+
+    // Timers are semantically incompatible with splitting
+    if (!signature.timerDeclarations().isEmpty() && signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("%s is splittable and uses timers, but these are not compatible",
               fn.getClass().getName()));
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -564,7 +564,7 @@ public class ParDo {
     }
 
     // State is semantically incompatible with splitting
-    if (!signature.stateDeclarations().isEmpty()) {
+    if (!signature.stateDeclarations().isEmpty() && signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
           String.format("%s is splittable and uses state, but these are not compatible",
               fn.getClass().getName()));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Timer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Timer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.joda.time.Duration;
+
+/**
+ * A timer for a specified time domain that can be set to register the desire for further processing
+ * at particular time in its specified time domain.
+ *
+ * <p>See {@link TimeDomain} for details on the time domains available.
+ *
+ * <p>In a {@link DoFn}, a {@link Timer} is specified by a {@link TimerSpec} annotated with {@link
+ * DoFn.TimerId}.
+ *
+ * <p>An implementation of {@link Timer} is implicitly scoped - it may be scoped to a key and
+ * window, or a key, window, and trigger, etc.
+ *
+ * <p>A timer exists in one of two states: set or unset. A timer can be set only for a single time
+ * per scope.
+ *
+ * <p>Timer callbacks are not guaranteed to be called immediately according to the local view of the
+ * {@link TimeDomain}, but will be called at some time after the requested time, in timestamp
+ * order.
+ */
+@Experimental(Experimental.Kind.TIMERS)
+public interface Timer {
+  /**
+   * Sets or resets the time relative to the current time in the timer's {@link TimeDomain} at which
+   * this it should fire. If the timer was already set, resets it to the new requested time.
+   */
+  void setForNowPlus(Duration durationFromNow);
+
+  /**
+   * Unsets this timer. It is permitted to {@code cancel()} whether or not the timer was actually
+   * set.
+   */
+  void cancel();
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TimerSpec.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TimerSpec.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+
+/**
+ * A specification for a {@link Timer}. This includes its {@link TimeDomain}.
+ */
+@Experimental(Kind.TIMERS)
+public interface TimerSpec extends Serializable {
+  TimeDomain getTimeDomain();
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TimerSpecs.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TimerSpecs.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import com.google.auto.value.AutoValue;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+
+/**
+ * Static methods for working with {@link TimerSpec}.
+ */
+@Experimental(Kind.TIMERS)
+public class TimerSpecs {
+
+  public static TimerSpec timer(TimeDomain timeDomain) {
+    return new AutoValue_TimerSpecs_SimpleTimerSpec(timeDomain);
+  }
+
+  /**
+   * A straightforward POJO {@link TimerSpec}. Package-level access for AutoValue.
+   */
+  @AutoValue
+  abstract static class SimpleTimerSpec implements TimerSpec {
+    public abstract TimeDomain getTimeDomain();
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
@@ -139,7 +139,7 @@ public class DoFnSignaturesTest {
     DoFnSignatures.INSTANCE.getSignature(
         new DoFn<String, String>() {
           @StateId("foo")
-          String bizzle = "bazzle";
+          private final String bizzle = "bazzle";
 
           @ProcessElement
           public void foo(ProcessContext context) {}
@@ -162,7 +162,8 @@ public class DoFnSignaturesTest {
                   StateSpecs.value(VarIntCoder.of());
 
               @StateId("my-state-id")
-              StateSpec<Object, ValueState<Long>> myfield2 = StateSpecs.value(VarLongCoder.of());
+              private final StateSpec<Object, ValueState<Long>> myfield2 =
+                  StateSpecs.value(VarLongCoder.of());
 
               @ProcessElement
               public void foo(ProcessContext context) {}
@@ -244,6 +245,7 @@ public class DoFnSignaturesTest {
         decl.stateType(),
         Matchers.<TypeDescriptor<?>>equalTo(new TypeDescriptor<ValueState<Integer>>() {}));
   }
+
 
   private static class DoFnForTestSimpleStateIdNamedDoFn extends DoFn<KV<String, Integer>, Long> {
     @StateId("foo")


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @jkff 
CC: @bjchambers who gave lots of good feedback on the `StateSpec` version of this PR. Time permitting, see if you have opinions about this simpler one.

This adds the interfaces and annotations from the design for the user-facing timer API, with basic reflection and validation and some tests.

(while putting this together, I noticed that there were state examples that were invalid in ways other than the way they were testing, so that commit is in this PR too)