### PR TITLE
Add support for experiments flag

### DIFF
--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -37,6 +37,7 @@ from apache_beam.utils import retry
 from apache_beam.utils.dependency import get_required_container_version
 from apache_beam.utils.dependency import get_sdk_name_and_version
 from apache_beam.utils.names import PropertyNames
+from apache_beam.utils.options import DebugOptions
 from apache_beam.utils.options import GoogleCloudOptions
 from apache_beam.utils.options import StandardOptions
 from apache_beam.utils.options import WorkerOptions
@@ -107,6 +108,7 @@ class Environment(object):
     self.standard_options = options.view_as(StandardOptions)
     self.google_cloud_options = options.view_as(GoogleCloudOptions)
     self.worker_options = options.view_as(WorkerOptions)
+    self.debug_options = options.view_as(DebugOptions)
     self.proto = dataflow.Environment()
     self.proto.clusterManagerApiService = COMPUTE_API_SERVICE
     self.proto.dataset = '%s/cloud_dataflow' % BIGQUERY_API_SERVICE
@@ -141,6 +143,10 @@ class Environment(object):
             value=to_json_value(job_type)),
         dataflow.Environment.VersionValue.AdditionalProperty(
             key='major', value=to_json_value(environment_version))])
+    # Experiments
+    if self.debug_options.experiments:
+      for experiment in self.debug_options.experiments:
+        self.proto.experiments.append(experiment)
     # Worker pool(s) information.
     package_descriptors = []
     for package in packages:

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -364,6 +364,15 @@ class DebugOptions(PipelineOptions):
     parser.add_argument('--dataflow_job_file',
                         default=None,
                         help='Debug file to write the workflow specification.')
+    parser.add_argument(
+        '--experiment',
+        dest='experiments',
+        action='append',
+        default=None,
+        help=
+        ('Runners may provide a number of experimental features that can be '
+         'enabled with this flag. Please sync with the owners of the runner '
+         'before enabling any experiments.'))
 
 
 class ProfilingOptions(PipelineOptions):

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -80,7 +80,7 @@ class PipelineOptionsTest(unittest.TestCase):
           PipelineOptionsTest.MockOptions).mock_option,
                        case['expected']['mock_option'])
 
-  def test_option_with_spcae(self):
+  def test_option_with_space(self):
     options = PipelineOptions(flags=['--option with space= value with space'])
     self.assertEqual(
         getattr(options.view_as(PipelineOptionsTest.MockOptions),
@@ -100,6 +100,14 @@ class PipelineOptionsTest(unittest.TestCase):
     options.view_as(PipelineOptionsTest.MockOptions).mock_flag = True
     self.assertEqual(options.get_all_options()['num_workers'], 5)
     self.assertEqual(options.get_all_options()['mock_flag'], True)
+
+  def test_experiments(self):
+    options = PipelineOptions(['--experiment', 'abc', '--experiment', 'def'])
+    self.assertEqual(
+        sorted(options.get_all_options()['experiments']), ['abc', 'def'])
+
+    options = PipelineOptions(flags=[''])
+    self.assertEqual(options.get_all_options()['experiments'], None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a new --experiment flag, to allow runners to optionally enable
experimental features.

This is similar to the same flag in the java sdk.