### PR TITLE
[BEAM-551] Allow TextIO to accept ValueProvider<String>

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/ReadTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/ReadTranslator.java
@@ -30,6 +30,7 @@ import org.apache.beam.runners.dataflow.DataflowPipelineTranslator.TranslationCo
 import org.apache.beam.sdk.io.FileBasedSource;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.Source;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.values.PValue;
@@ -50,10 +51,13 @@ public class ReadTranslator implements TransformTranslator<Read.Bounded<?>> {
       // TODO: Move this validation out of translation once IOChannelUtils is portable
       // and can be reconstructed on the worker.
       if (source instanceof FileBasedSource) {
-        String filePatternOrSpec = ((FileBasedSource<?>) source).getFileOrPatternSpec();
-        context.getPipelineOptions()
-               .getPathValidator()
-               .validateInputFilePatternSupported(filePatternOrSpec);
+        ValueProvider<String> filePatternOrSpec =
+            ((FileBasedSource<?>) source).getFileOrPatternSpecProvider();
+        if (filePatternOrSpec.isAccessible()) {
+          context.getPipelineOptions()
+              .getPathValidator()
+              .validateInputFilePatternSupported(filePatternOrSpec.get());
+        }
       }
 
       context.addStep(transform, "ParallelRead");

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -63,6 +63,7 @@ import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.OldDoFn;
@@ -718,6 +719,33 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     thrown.expectCause(allOf(
         instanceOf(IllegalArgumentException.class),
         ThrowableMessageMatcher.hasMessage(containsString("Unsupported wildcard usage"))));
+    t.translate(
+        pipeline,
+        (DataflowRunner) pipeline.getRunner(),
+        Collections.<DataflowPackage>emptyList());
+  }
+
+  private static class TestValueProvider implements ValueProvider<String>, Serializable {
+    @Override
+    public boolean isAccessible() {
+      return false;
+    }
+
+    @Override
+    public String get() {
+      throw new RuntimeException("Should not be called.");
+    }
+  }
+
+  @Test
+  public void testInaccessibleProvider() throws Exception {
+    DataflowPipelineOptions options = buildPipelineOptions();
+    Pipeline pipeline = Pipeline.create(options);
+    DataflowPipelineTranslator t = DataflowPipelineTranslator.fromOptions(options);
+
+    pipeline.apply(TextIO.Read.from(new TestValueProvider()).withoutValidation());
+
+    // Check that translation does not fail.
     t.translate(
         pipeline,
         (DataflowRunner) pipeline.getRunner(),

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -301,7 +301,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
    */
   private CompressedSource(
       FileBasedSource<T> sourceDelegate, DecompressingChannelFactory channelFactory) {
-    super(sourceDelegate.getFileOrPatternSpec(), Long.MAX_VALUE);
+    super(sourceDelegate.getFileOrPatternSpecProvider(), Long.MAX_VALUE);
     this.sourceDelegate = sourceDelegate;
     this.channelFactory = channelFactory;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -101,7 +101,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
    * @param minBundleSize minimum bundle size in bytes.
    */
   public FileBasedSource(String fileOrPatternSpec, long minBundleSize) {
-    this(StaticValueProvider.of(fileOrPatternSpec), 0);
+    this(StaticValueProvider.of(fileOrPatternSpec), minBundleSize);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -370,6 +370,8 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
     // We split a file-based source into subranges only if the file is efficiently seekable.
     // If a file is not efficiently seekable it would be highly inefficient to create and read a
     // source based on a subrange of that file.
+    checkState(fileOrPatternSpec.isAccessible(),
+        "isSplittable should only be called at runtime.");
     IOChannelFactory factory = IOChannelUtils.getFactory(fileOrPatternSpec.get());
     return factory.isReadSeekEfficient(fileOrPatternSpec.get());
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -279,7 +279,7 @@ public class TextIO {
       @Override
       public PCollection<T> apply(PBegin input) {
 
-        if (filepattern.get() == null) {
+        if (filepattern == null) {
           throw new IllegalStateException("need to set the filepattern of a TextIO.Read transform");
         }
 
@@ -307,20 +307,20 @@ public class TextIO {
       protected FileBasedSource<T> getSource() {
         switch (compressionType) {
           case UNCOMPRESSED:
-            return new TextSource<T>(filepattern.get(), coder);
+            return new TextSource<T>(filepattern, coder);
           case AUTO:
-            return CompressedSource.from(new TextSource<T>(filepattern.get(), coder));
+            return CompressedSource.from(new TextSource<T>(filepattern, coder));
           case BZIP2:
             return
-                CompressedSource.from(new TextSource<T>(filepattern.get(), coder))
+                CompressedSource.from(new TextSource<T>(filepattern, coder))
                     .withDecompression(CompressedSource.CompressionMode.BZIP2);
           case GZIP:
             return
-                CompressedSource.from(new TextSource<T>(filepattern.get(), coder))
+                CompressedSource.from(new TextSource<T>(filepattern, coder))
                     .withDecompression(CompressedSource.CompressionMode.GZIP);
           case ZIP:
             return
-                CompressedSource.from(new TextSource<T>(filepattern.get(), coder))
+                CompressedSource.from(new TextSource<T>(filepattern, coder))
                     .withDecompression(CompressedSource.CompressionMode.ZIP);
           default:
             throw new IllegalArgumentException("Unknown compression type: " + compressionType);
@@ -331,7 +331,8 @@ public class TextIO {
       public void populateDisplayData(DisplayData.Builder builder) {
         super.populateDisplayData(builder);
 
-        String filepatternDisplay = filepattern.get();
+        String filepatternDisplay = filepattern.isAccessible()
+          ? filepattern.get() : filepattern.toString();
         builder
             .add(DisplayData.item("compressionType", compressionType.toString())
               .withLabel("Compression Type"))
@@ -830,6 +831,12 @@ public class TextIO {
 
     @VisibleForTesting
     TextSource(String fileSpec, Coder<T> coder) {
+      super(fileSpec, 1L);
+      this.coder = coder;
+    }
+
+    @VisibleForTesting
+    TextSource(ValueProvider<String> fileSpec, Coder<T> coder) {
       super(fileSpec, 1L);
       this.coder = coder;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.beam.sdk.io.TextIO.CompressionType.UNCOMPRESSED;
 
@@ -206,8 +207,8 @@ public class TextIO {
         this(null, null, coder, true, TextIO.CompressionType.AUTO);
       }
 
-      private Bound(String name, ValueProvider<String> filepattern, Coder<T> coder,
-                    boolean validate, TextIO.CompressionType compressionType) {
+      private Bound(@Nullable String name, @Nullable ValueProvider<String> filepattern,
+          Coder<T> coder, boolean validate, TextIO.CompressionType compressionType) {
         super(name);
         this.coder = coder;
         this.filepattern = filepattern;
@@ -224,6 +225,7 @@ public class TextIO {
 
        */
       public Bound<T> from(String filepattern) {
+        checkNotNull(filepattern, "Filepattern cannot be empty.");
         return new Bound<>(name, StaticValueProvider.of(filepattern), coder, validate,
                            compressionType);
       }
@@ -232,6 +234,7 @@ public class TextIO {
        * Same as {@code from(filepattern)}, but accepting a {@link ValueProvider}.
        */
       public Bound<T> from(ValueProvider<String> filepattern) {
+        checkNotNull(filepattern, "Filepattern cannot be empty.");
         return new Bound<>(name, filepattern, coder, validate, compressionType);
       }
 
@@ -278,7 +281,6 @@ public class TextIO {
 
       @Override
       public PCollection<T> apply(PBegin input) {
-
         if (filepattern == null) {
           throw new IllegalStateException("need to set the filepattern of a TextIO.Read transform");
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -264,7 +264,7 @@ public class TextIO {
 
       @Override
       public PCollection<T> apply(PBegin input) {
-        
+
         if (filepattern.get() == null) {
           throw new IllegalStateException("need to set the filepattern of a TextIO.Read transform");
         }
@@ -293,20 +293,20 @@ public class TextIO {
       protected FileBasedSource<T> getSource() {
         switch (compressionType) {
           case UNCOMPRESSED:
-            return new TextSource<T>(filepattern, coder);
+            return new TextSource<T>(filepattern.get(), coder);
           case AUTO:
-            return CompressedSource.from(new TextSource<T>(filepattern, coder));
+            return CompressedSource.from(new TextSource<T>(filepattern.get(), coder));
           case BZIP2:
             return
-                CompressedSource.from(new TextSource<T>(filepattern, coder))
+                CompressedSource.from(new TextSource<T>(filepattern.get(), coder))
                     .withDecompression(CompressedSource.CompressionMode.BZIP2);
           case GZIP:
             return
-                CompressedSource.from(new TextSource<T>(filepattern, coder))
+                CompressedSource.from(new TextSource<T>(filepattern.get(), coder))
                     .withDecompression(CompressedSource.CompressionMode.GZIP);
           case ZIP:
             return
-                CompressedSource.from(new TextSource<T>(filepattern, coder))
+                CompressedSource.from(new TextSource<T>(filepattern.get(), coder))
                     .withDecompression(CompressedSource.CompressionMode.ZIP);
           default:
             throw new IllegalArgumentException("Unknown compression type: " + compressionType);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -132,6 +132,13 @@ public class TextIO {
     }
 
     /**
+     * Same as {@code from(filepattern)}, but accepting a {@link ValueProvider}.
+     */
+    public static Bound<String> from(ValueProvider<String> filepattern) {
+      return new Bound<>(DEFAULT_TEXT_CODER).from(filepattern);
+    }
+
+    /**
      * Returns a transform for reading text files that uses the given
      * {@code Coder<T>} to decode each of the lines of the file into a
      * value of type {@code T}.
@@ -219,6 +226,13 @@ public class TextIO {
       public Bound<T> from(String filepattern) {
         return new Bound<>(name, StaticValueProvider.of(filepattern), coder, validate,
                            compressionType);
+      }
+
+      /**
+       * Same as {@code from(filepattern)}, but accepting a {@link ValueProvider}.
+       */
+      public Bound<T> from(ValueProvider<String> filepattern) {
+        return new Bound<>(name, filepattern, coder, validate, compressionType);
       }
 
       /**


### PR DESCRIPTION
Thinking about testing, is it worth having something sub-integration-test level?  We'd likely want to add some convenience methods to RVP for that, then.

R: @dhalperi
