### PR TITLE
Add alias (--extra_packages) for --extra_package pipeline option

### DIFF
--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -449,7 +449,7 @@ class SetupOptions(PipelineOptions):
          'tarball from here. If the string "default", '
          'a standard SDK location is used. If empty, no SDK is copied.'))
     parser.add_argument(
-        '--extra_package',
+        '--extra_package', '--extra_packages',
         dest='extra_packages',
         action='append',
         default=None,

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -109,6 +109,17 @@ class PipelineOptionsTest(unittest.TestCase):
     options = PipelineOptions(flags=[''])
     self.assertEqual(options.get_all_options()['experiments'], None)
 
+  def test_extra_package(self):
+    options = PipelineOptions(['--extra_package', 'abc',
+                               '--extra_packages', 'def',
+                               '--extra_packages', 'ghi'])
+    self.assertEqual(
+        sorted(options.get_all_options()['extra_packages']),
+        ['abc', 'def', 'ghi'])
+
+    options = PipelineOptions(flags=[''])
+    self.assertEqual(options.get_all_options()['extra_packages'], None)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
Add alias for two reasons:
- user friendliness (allows both options)
- code cleanliness (matches option to keyword argument name--dest)

