### PR TITLE
[BEAM-551] Add method to output runtime options

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -323,7 +323,7 @@ public interface PipelineOptions extends HasDisplayData {
   }
 
   /**
-   * Return a map of properties which correspond to {@link RuntimeValueProvider},
+   * Returns a map of properties which correspond to {@link RuntimeValueProvider},
    * keyed by the property name.  The value is a map containing type and default
    * information.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.auto.service.AutoService;
 import com.google.common.base.MoreObjects;
 import java.lang.reflect.Proxy;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
@@ -320,6 +321,13 @@ public interface PipelineOptions extends HasDisplayData {
           normalizedAppName, normalizedUserName, datePart, randomPart);
     }
   }
+
+  /**
+   * Return a map of properties which correspond to {@link RuntimeValueProvider},
+   * keyed by the property name.  The value is a map containing type and default
+   * information.
+   */
+  Map<String, Map<String, Object>> outputRuntimeOptions();
 
   /**
    * Provides a unique ID for this {@link PipelineOptions} object, assigned at graph

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -989,6 +989,7 @@ public class PipelineOptionsFactory {
     // Ignore methods on the base PipelineOptions interface.
     try {
       methods.add(iface.getMethod("as", Class.class));
+      methods.add(iface.getMethod("outputRuntimeOptions"));
       methods.add(iface.getMethod("populateDisplayData", DisplayData.Builder.class));
     } catch (NoSuchMethodException | SecurityException e) {
       throw new RuntimeException(e);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -246,7 +246,7 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
   }
 
   /**
-   * Return a map of properties which correspond to {@link ValueProvider}.
+   * Returns a map of properties which correspond to {@link RuntimeValueProvider}.
    */
   public Map<String, Map<String, Object>> outputRuntimeOptions(PipelineOptions options) {
     Set<PipelineOptionSpec> optionSpecs = PipelineOptionsReflector.getOptionSpecs(knownInterfaces);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -130,6 +131,8 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
       return equals(args[0]);
     } else if (args == null && "hashCode".equals(method.getName())) {
       return hashCode();
+    } else if (args == null && "outputRuntimeOptions".equals(method.getName())) {
+      return outputRuntimeOptions((PipelineOptions) proxy);
     } else if (args != null && "as".equals(method.getName()) && args[0] instanceof Class) {
       @SuppressWarnings("unchecked")
       Class<? extends PipelineOptions> clazz = (Class<? extends PipelineOptions>) args[0];
@@ -240,6 +243,31 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
   @Override
   public int hashCode() {
     return hashCode;
+  }
+
+  /**
+   * Return a map of properties which correspond to {@link ValueProvider}.
+   */
+  public Map<String, Map<String, Object>> outputRuntimeOptions(PipelineOptions options) {
+    Set<PipelineOptionSpec> optionSpecs = PipelineOptionsReflector.getOptionSpecs(knownInterfaces);
+    Map<String, Map<String, Object>> properties = Maps.newHashMap();
+
+    for (PipelineOptionSpec spec : optionSpecs) {
+      if (spec.getGetterMethod().getReturnType().equals(ValueProvider.class)) {
+        Map<String, Object> property = Maps.newHashMap();
+        property.put("type",
+                     ((ParameterizedType) spec.getGetterMethod()
+                      .getGenericReturnType()).getActualTypeArguments()[0]);
+
+        // Get the default value, if it exists.
+        Object vp = invoke(options, spec.getGetterMethod(), null);
+        if (vp instanceof StaticValueProvider) {
+          property.put("default", ((StaticValueProvider) vp).get());
+        }
+        properties.put(spec.getName(), property);
+      }
+    }
+    return properties;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -254,16 +254,14 @@ class ProxyInvocationHandler implements InvocationHandler, HasDisplayData {
 
     for (PipelineOptionSpec spec : optionSpecs) {
       if (spec.getGetterMethod().getReturnType().equals(ValueProvider.class)) {
+        Object vp = invoke(options, spec.getGetterMethod(), null);
+        if (((ValueProvider) vp).isAccessible()) {
+          continue;
+        }
         Map<String, Object> property = Maps.newHashMap();
         property.put("type",
                      ((ParameterizedType) spec.getGetterMethod()
                       .getGenericReturnType()).getActualTypeArguments()[0]);
-
-        // Get the default value, if it exists.
-        Object vp = invoke(options, spec.getGetterMethod(), null);
-        if (vp instanceof StaticValueProvider) {
-          property.put("default", ((StaticValueProvider) vp).get());
-        }
         properties.put(spec.getName(), property);
       }
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
@@ -88,11 +89,9 @@ public class PipelineOptionsTest {
   public void testOutputRuntimeOptions() {
     ValueProviderOptions options =
         PipelineOptionsFactory.fromArgs(
-      new String[]{"--string=baz"}).as(ValueProviderOptions.class);
-    assertEquals(options.outputRuntimeOptions(), ImmutableMap.of(
-                   "string",
-                   ImmutableMap.of("type", String.class, "default", "baz"),
-                   "bool",
-                   ImmutableMap.of("type", Boolean.class)));
+            new String[]{"--string=baz"}).as(ValueProviderOptions.class);
+    Map<String, ?> expected = ImmutableMap.of(
+        "bool", ImmutableMap.of("type", Boolean.class));
+    assertEquals(expected, options.outputRuntimeOptions());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
@@ -17,9 +17,11 @@
  */
 package org.apache.beam.sdk.options;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Set;
 import org.junit.Rule;
@@ -69,5 +71,28 @@ public class PipelineOptionsTest {
   public void testDynamicAs() {
     BaseTestOptions options = PipelineOptionsFactory.create().as(BaseTestOptions.class);
     assertNotNull(options);
+  }
+
+  private static interface ValueProviderOptions extends PipelineOptions {
+    ValueProvider<Boolean> getBool();
+    void setBool(ValueProvider<Boolean> value);
+
+    ValueProvider<String> getString();
+    void setString(ValueProvider<String> value);
+
+    String getNotAValueProvider();
+    void setNotAValueProvider(String value);
+  }
+
+  @Test
+  public void testOutputRuntimeOptions() {
+    ValueProviderOptions options =
+        PipelineOptionsFactory.fromArgs(
+      new String[]{"--string=baz"}).as(ValueProviderOptions.class);
+    assertEquals(options.outputRuntimeOptions(), ImmutableMap.of(
+                   "string",
+                   ImmutableMap.of("type", String.class, "default", "baz"),
+                   "bool",
+                   ImmutableMap.of("type", Boolean.class)));
   }
 }


### PR DESCRIPTION
Add a method that outputs the dynamic options from PipelineOptions, so an interested consumer could write these to a metadata storage location in order to more intelligently provide information about the parameters that a template supports.

R: @davorbonaci  
