### PR TITLE
Stop running WordCount on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ install:
 
 script:
   - travis_retry mvn --settings .travis/settings.xml --batch-mode --update-snapshots --no-snapshot-updates $MAVEN_OVERRIDE verify
-  - travis_retry .travis/test_wordcount.sh
 
 cache:
   directories:


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The signal from Travis CI is so degraded we should delete it rather than keep it as-is. This is one attempt to salvage it.

My overall thought is that we should simplify its responsibilities until it is not flaky. And that basically implies that it will simply do less, which means it can be used to try to give very rapid feedback, while Jenkins does the more intense stuff.

So this PR just proposes removing the flaky and slow integration test. Technically, we lose the matrix of JDKs. In practice, we already ignore them and combine the matrix with "OR" instead of "AND".

R: @dhalperi 
CC: @jasonkuster