### PR TITLE
[BEAM-747] Improve FileChecksumMatcher That Inconsistent With Filesystem

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WordCountIT.java
@@ -65,7 +65,7 @@ public class WordCountIT {
         "output",
         "results"));
     options.setOnSuccessMatcher(
-        new FileChecksumMatcher(DEFAULT_OUTPUT_CHECKSUM, options.getOutput() + "*"));
+        new FileChecksumMatcher(DEFAULT_OUTPUT_CHECKSUM, options.getOutput() + "*-of-*"));
 
     WordCount.main(TestPipeline.convertToArgs(options));
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FileChecksumMatcher.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FileChecksumMatcher.java
@@ -20,7 +20,12 @@ package org.apache.beam.sdk.testing;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.client.util.BackOff;
+import com.google.api.client.util.BackOffUtils;
+import com.google.api.client.util.Sleeper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.CharStreams;
@@ -28,14 +33,21 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.IOChannelFactory;
 import org.apache.beam.sdk.util.IOChannelUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,20 +55,41 @@ import org.slf4j.LoggerFactory;
  * Matcher to verify file checksum in E2E test.
  *
  * <p>For example:
- * <pre>{@code [
- *   assertTrue(job, new FileChecksumMatcher(checksumString, filePath));
- * ]}</pre>
+ * <pre>{@code
+ *   assertThat(job, new FileChecksumMatcher(checksumString, filePath));
+ * }</pre>
+ * or
+ * <pre>{@code
+ *   assertThat(job, new FileChecksumMatcher(checksumString, filePath, shardTemplate));
+ * }</pre>
+ *
+ * <p>Checksum of outputs is generated based on SHA-1 algorithm. If output file is empty,
+ * SHA-1 hash of empty string (da39a3ee5e6b4b0d3255bfef95601890afd80709) is used as expected.
  */
 public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
     implements SerializableMatcher<PipelineResult> {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileChecksumMatcher.class);
 
+  static final int MAX_READ_RETRIES = 4;
+  static final Duration DEFAULT_SLEEP_DURATION = Duration.standardSeconds(10L);
+  static final FluentBackoff BACK_OFF_FACTORY =
+      FluentBackoff.DEFAULT
+          .withInitialBackoff(DEFAULT_SLEEP_DURATION)
+          .withMaxRetries(MAX_READ_RETRIES);
+
+  private static final String DEFAULT_SHARD_TEMPLATE = "\\S*\\d+-of-(\\d+)$";
+
   private final String expectedChecksum;
   private final String filePath;
+  private final Pattern shardTemplate;
   private String actualChecksum;
 
   public FileChecksumMatcher(String checksum, String filePath) {
+    this(checksum, filePath, null);
+  }
+
+  public FileChecksumMatcher(String checksum, String filePath, String shardTemplate) {
     checkArgument(
         !Strings.isNullOrEmpty(checksum),
         "Expected valid checksum, but received %s", checksum);
@@ -66,48 +99,105 @@ public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
 
     this.expectedChecksum = checksum;
     this.filePath = filePath;
+    this.shardTemplate =
+        Pattern.compile(shardTemplate == null ? DEFAULT_SHARD_TEMPLATE : shardTemplate);
   }
 
   @Override
   public boolean matchesSafely(PipelineResult pipelineResult) {
+    // Load output data
+    List<String> outputs;
     try {
-      // Load output data
-      List<String> outputs = readLines(filePath);
-
-      // Verify outputs. Checksum is computed using SHA-1 algorithm
-      actualChecksum = hashing(outputs);
-      LOG.info("Generated checksum for output data: {}", actualChecksum);
-
-      return actualChecksum.equals(expectedChecksum);
-    } catch (IOException e) {
-      throw new RuntimeException(
-          String.format("Failed to read from path: %s", filePath));
+      outputs = readFilesWithRetries(Sleeper.DEFAULT, BACK_OFF_FACTORY.backoff());
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Failed to read from: %s", filePath), e);
     }
+
+    // Verify outputs. Checksum is computed using SHA-1 algorithm
+    actualChecksum = computeHash(outputs);
+    LOG.info("Generated checksum: {}", actualChecksum);
+
+    return actualChecksum.equals(expectedChecksum);
   }
 
-  private List<String> readLines(String path) throws IOException {
-    List<String> readData = new ArrayList<>();
-    IOChannelFactory factory = IOChannelUtils.getFactory(path);
+  @VisibleForTesting
+  List<String> readFilesWithRetries(Sleeper sleeper, BackOff backOff)
+      throws IOException, InterruptedException {
+    IOChannelFactory factory = IOChannelUtils.getFactory(filePath);
+    IOException lastException = null;
 
-    // Match inputPath which may contains glob
-    Collection<String> files = factory.match(path);
+    do {
+      try {
+        // Match inputPath which may contains glob
+        Collection<String> files = factory.match(filePath);
+        LOG.info("Found {} file(s) by matching the path: {}", files.size(), filePath);
 
-    // Read data from file paths
-    int i = 0;
+        if (files.isEmpty() || !checkTotalNumOfFiles(files)) {
+          continue;
+        }
+
+        // Read data from file paths
+        return readLines(files, factory);
+      } catch (IOException e) {
+        // Ignore and retry
+        lastException = e;
+        LOG.warn("Error in file reading. Ignore and retry.");
+      }
+    } while(BackOffUtils.next(sleeper, backOff));
+    // Failed after max retries
+    throw new IOException(
+        String.format("Unable to read file(s) after retrying %d times", MAX_READ_RETRIES),
+        lastException);
+  }
+
+  @VisibleForTesting
+  List<String> readLines(Collection<String> files, IOChannelFactory factory) throws IOException {
+    List<String> allLines = Lists.newArrayList();
+    int i = 1;
     for (String file : files) {
       try (Reader reader =
-          Channels.newReader(factory.open(file), StandardCharsets.UTF_8.name())) {
+               Channels.newReader(factory.open(file), StandardCharsets.UTF_8.name())) {
         List<String> lines = CharStreams.readLines(reader);
-        readData.addAll(lines);
+        allLines.addAll(lines);
         LOG.info(
-            "[{} of {}] Read {} lines from file: {}", i, files.size() - 1, lines.size(), file);
+            "[{} of {}] Read {} lines from file: {}", i, files.size(), lines.size(), file);
       }
       i++;
     }
-    return readData;
+    return allLines;
   }
 
-  private String hashing(List<String> strs) {
+  /**
+   * Check if total number of files is correct by comparing with the number that
+   * is parsed from shard name using a name template. If no template are specified,
+   * "SSSS-of-NNNN" will be used as default, and "NNNN" will be the expected total
+   * number of files.
+   */
+  @VisibleForTesting
+  boolean checkTotalNumOfFiles(Collection<String> files) {
+    for (String filePath : files.toArray(new String[0])) {
+      Path fileName = Paths.get(filePath).getFileName();
+      if (fileName == null) {
+        // this path has zero elements
+        continue;
+      }
+      Matcher matcher = shardTemplate.matcher(fileName.toString());
+      if (!matcher.matches()) {
+        // shard name doesn't match the pattern, check with the next shard
+        continue;
+      }
+      // once match, extract total number of shards and compare to file list
+      return files.size() == Integer.parseInt(matcher.group(1));
+    }
+    LOG.warn("No name matches the shard template: {}", shardTemplate);
+    return false;
+  }
+
+  private String computeHash(@Nonnull List<String> strs) {
+    if (strs.isEmpty()) {
+      return Hashing.sha1().hashString("", StandardCharsets.UTF_8).toString();
+    }
+
     List<HashCode> hashCodes = new ArrayList<>();
     for (String str : strs) {
       hashCodes.add(Hashing.sha1().hashString(str, StandardCharsets.UTF_8));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FileChecksumMatcher.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/FileChecksumMatcher.java
@@ -86,7 +86,7 @@ public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
   private String actualChecksum;
 
   public FileChecksumMatcher(String checksum, String filePath) {
-    this(checksum, filePath, null);
+    this(checksum, filePath, DEFAULT_SHARD_TEMPLATE);
   }
 
   public FileChecksumMatcher(String checksum, String filePath, String shardTemplate) {
@@ -169,7 +169,7 @@ public class FileChecksumMatcher extends TypeSafeMatcher<PipelineResult>
 
   /**
    * Check if total number of files is correct by comparing with the number that
-   * is parsed from shard name using a name template. If no template are specified,
+   * is parsed from shard name using a name template. If no template is specified,
    * "SSSS-of-NNNN" will be used as default, and "NNNN" will be the expected total
    * number of files.
    */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/FileChecksumMatcherTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/FileChecksumMatcherTest.java
@@ -128,8 +128,24 @@ public class FileChecksumMatcherTest {
   }
 
   @Test
-  public void testReadWithRetriesFailsWhenTemplateIncorrect()
-      throws IOException, InterruptedException {
+  public void testMatcherThatUsesCustomizedTemplate() throws Exception {
+    // Customized template: resultSSS-totalNNN
+    File tmpFile1 = tmpFolder.newFile("result0-total2");
+    File tmpFile2 = tmpFolder.newFile("result1-total2");
+    Files.write("To be or not to be, ", tmpFile1, StandardCharsets.UTF_8);
+    Files.write("it is not a question.", tmpFile2, StandardCharsets.UTF_8);
+
+    String customizedTemplate = "result\\d+-total(\\d+)$";
+    FileChecksumMatcher matcher = new FileChecksumMatcher(
+        "90552392c28396935fe4f123bd0b5c2d0f6260c8",
+        IOChannelUtils.resolve(tmpFolder.getRoot().getPath(), "*"),
+        customizedTemplate);
+
+    assertThat(pResult, matcher);
+  }
+
+  @Test
+  public void testReadWithRetriesFailsWhenTemplateIncorrect() throws Exception {
     File tmpFile = tmpFolder.newFile();
     Files.write("Test for file checksum verifier.", tmpFile, StandardCharsets.UTF_8);
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:
- [x] Make sure the PR title is formatted like:
  `[BEAM-<Jira issue #>] Description of pull request`
- [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
     Travis-CI on your fork and ensure the whole test matrix passes).
- [x] Replace `<Jira issue #>` in the title with the actual Jira issue
     number, if there is one.
- [ ] If this contribution is large, please file an Apache
     [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Add retry in FileChecksumMatcher when following conditions happens:
- IOException raised from filesystem
- No file found from output directory
- number of files found from fs doesn't equal to expected number, which is parsed from shard name using a name template. Default template "SSS-of-NNN" will be used when no template is specified.

Default retry times are 4. Default sleep duration between each retry are 10s.
