### PR TITLE
[BEAM-822] Move resource filtering later to avoid spurious rebuilds

### DIFF
--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -40,13 +40,6 @@
   </properties>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-
     <pluginManagement>
       <plugins>
         <plugin>
@@ -142,6 +135,28 @@
           <!-- Set testSourceDirectory in order to exclude generated-test-sources -->
           <testSourceDirectory>${project.basedir}/src/test/</testSourceDirectory>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>resources</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+            <configuration>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:
- [x] Make sure the PR title is formatted like:
  `[BEAM-<Jira issue #>] Description of pull request`
- [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
     Travis-CI on your fork and ensure the whole test matrix passes).
- [x] Replace `<Jira issue #>` in the title with the actual Jira issue
     number, if there is one.
- [x] If this contribution is large, please file an Apache
     [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).
---

R: @lukecwik  OR @jbonofre 

I'm not sure if there is a pitfall to this maven configuration. I have checked that the output is the same, and that it does not cause a rebuild of the SDK (the empty `package-info.class` issue needs separate treatment, so I just tested by suppressing them)
