### PR TITLE
[BEAM-822] Adjust how and when we build package-info.java to avoid spurious rebuilds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -831,6 +831,45 @@
             <!-- Another temp override, to be set to true in due course. -->
             <showDeprecation>false</showDeprecation>
           </configuration>
+          <executions>
+
+            <!--
+              Exclude package-info.java from main compilation to work around
+              https://jira.codehaus.org/browse/MCOMPILER-205
+            -->
+            <execution>
+              <id>default-compile</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <phase>compile</phase>
+              <configuration>
+                <excludes>
+                  <exclude>**/package-info.java</exclude>
+                </excludes>
+              </configuration>
+            </execution>
+
+            <!-- 
+              Compile just package-info.java to avoid 
+              https://bugs.openjdk.java.net/browse/JDK-8022161
+            -->
+            <execution>
+              <id>compile-package-info</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <phase>compile</phase>
+              <configuration>
+                <compilerArgs>
+                  <arg>-Xpkginfo:always</arg>
+                </compilerArgs>
+                <includes>
+                  <include>**/package-info.java</include>
+                </includes>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Together with #1204 this will eliminate spurious rebuilds of the Java SDK.

R: @lukecwik  and @swegner does this violate anything you had in mind for `build-tools`? It could also go in the core SDK, I suppose. It is nice to put it somewhere that users will not depend on it. (so if they obey IWYU it is not part of the API)