### PR TITLE
Fix Failing Flink RunnableOnService Tests

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -174,10 +174,16 @@ public class DoFnOperator<InputT, FnOutputT, OutputT>
           ExecutionContext.StepContext stepContext,
           String aggregatorName,
           Combine.CombineFn<InputT, AccumT, OutputT> combine) {
-        SerializableFnAggregatorWrapper<InputT, OutputT> result =
-            new SerializableFnAggregatorWrapper<>(combine);
 
-        getRuntimeContext().addAccumulator(aggregatorName, result);
+        @SuppressWarnings("unchecked")
+        SerializableFnAggregatorWrapper<InputT, OutputT> result =
+            (SerializableFnAggregatorWrapper<InputT, OutputT>)
+                getRuntimeContext().getAccumulator(aggregatorName);
+
+        if (result == null) {
+          result = new SerializableFnAggregatorWrapper<>(combine);
+          getRuntimeContext().addAccumulator(aggregatorName, result);
+        }
         return result;
       }
     };


### PR DESCRIPTION
The problem was that the DoFnInvoker was invoking
createAggregatorForDoFn in the AggregatorFactory several times and
Flink only allows adding each aggregator once. This now adds a check
for whether an aggregator exists already.