### PR TITLE
(WIP) [BEAM-767] Convert DisplayData include(..) API to nested(..)

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/UnboundedReadFromBoundedSource.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/UnboundedReadFromBoundedSource.java
@@ -105,10 +105,7 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
 
   @Override
   public void populateDisplayData(DisplayData.Builder builder) {
-    // We explicitly do not register base-class data, instead we use the delegate inner source.
-    builder
-        .add(DisplayData.item("source", source.getClass()))
-        .include("source", source);
+    builder.delegate(source);
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/DataflowUnboundedReadFromBoundedSource.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/DataflowUnboundedReadFromBoundedSource.java
@@ -118,9 +118,7 @@ public class DataflowUnboundedReadFromBoundedSource<T> extends PTransform<PBegin
   @Override
   public void populateDisplayData(DisplayData.Builder builder) {
     // We explicitly do not register base-class data, instead we use the delegate inner source.
-    builder
-        .add(DisplayData.item("source", source.getClass()))
-        .include("source", source);
+    builder.delegate(source);
   }
 
   /**
@@ -194,8 +192,7 @@ public class DataflowUnboundedReadFromBoundedSource<T> extends PTransform<PBegin
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      builder.add(DisplayData.item("source", boundedSource.getClass()));
-      builder.include("source", boundedSource);
+      builder.add(DisplayData.nested("source", boundedSource));
     }
 
     @VisibleForTesting

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedReadFromUnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedReadFromUnboundedSource.java
@@ -113,13 +113,12 @@ public class BoundedReadFromUnboundedSource<T> extends PTransform<PBegin, PColle
   public void populateDisplayData(DisplayData.Builder builder) {
     // We explicitly do not register base-class data, instead we use the delegate inner source.
     builder
-        .add(DisplayData.item("source", source.getClass())
+        .add(DisplayData.nested("source", source)
           .withLabel("Read Source"))
         .addIfNotDefault(DisplayData.item("maxRecords", maxNumRecords)
           .withLabel("Maximum Read Records"), Long.MAX_VALUE)
         .addIfNotNull(DisplayData.item("maxReadTime", maxReadTime)
-          .withLabel("Maximum Read Time"))
-        .include("source", source);
+          .withLabel("Maximum Read Time"));
   }
 
   private static class UnboundedToBoundedSourceAdapter<T>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -390,8 +390,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
   public void populateDisplayData(DisplayData.Builder builder) {
     // We explicitly do not register base-class data, instead we use the delegate inner source.
     builder
-        .include("source", sourceDelegate)
-        .add(DisplayData.item("source", sourceDelegate.getClass())
+        .add(DisplayData.nested("source", sourceDelegate)
           .withLabel("Read Source"));
 
     if (channelFactory instanceof Enum) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -124,10 +124,8 @@ public class Read {
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      builder
-          .add(DisplayData.item("source", source.getClass())
-            .withLabel("Read Source"))
-          .include("source", source);
+      builder.add(DisplayData.nested("source", source)
+          .withLabel("Read Source"));
     }
   }
 
@@ -191,10 +189,8 @@ public class Read {
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      builder
-          .add(DisplayData.item("source", source.getClass())
-            .withLabel("Read Source"))
-          .include("source", source);
+      builder.add(DisplayData.nested("source", source)
+          .withLabel("Read Source"));
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
@@ -117,11 +117,10 @@ public class Write {
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
       builder
-          .add(DisplayData.item("sink", sink.getClass()).withLabel("Write Sink"))
-          .include("sink", sink)
-          .addIfNotDefault(
-              DisplayData.item("numShards", getNumShards()).withLabel("Fixed Number of Shards"),
-              0);
+          .add(DisplayData.nested("sink", sink)
+              .withLabel("Write Sink"))
+          .addIfNotDefault(DisplayData.item("numShards", getNumShards())
+              .withLabel("Fixed Number of Shards"), 0);
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
@@ -1043,9 +1043,8 @@ public class CombineFns {
     for (int i = 0; i < combineFns.size(); i++) {
       HasDisplayData combineFn = combineFns.get(i);
       String token = "combineFn" + (i + 1);
-      builder.add(DisplayData.item(token, combineFn.getClass())
+      builder.add(DisplayData.nested(token, combineFn)
         .withLabel("Combine Function"));
-      builder.include(token, combineFn);
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -543,8 +543,9 @@ public class ParDo {
     return new Unbound().of(fn, displayDataForFn(fn));
   }
 
-  private static <T> DisplayData.ItemSpec<? extends Class<?>> displayDataForFn(T fn) {
-    return DisplayData.item("fn", fn.getClass()).withLabel("Transform Function");
+  private static DisplayData.ItemSpecBase<?, ?> displayDataForFn(HasDisplayData fn) {
+    return DisplayData.nested("fn", fn)
+        .withLabel("Transform Function");
   }
 
   /**
@@ -684,7 +685,7 @@ public class ParDo {
     }
 
     private <InputT, OutputT> Bound<InputT, OutputT> of(
-        Serializable originalFn, DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
+        Serializable originalFn, DisplayData.ItemSpecBase<?, ?> fnDisplayData) {
       return new Bound<>(name, originalFn, sideInputs, fnDisplayData);
     }
   }
@@ -706,13 +707,13 @@ public class ParDo {
     // Inherits name.
     private final List<PCollectionView<?>> sideInputs;
     private final Serializable fn;
-    private final DisplayData.ItemSpec<? extends Class<?>> fnDisplayData;
+    private final DisplayData.ItemSpecBase<?, ?> fnDisplayData;
 
     Bound(
         String name,
         Serializable fn,
         List<PCollectionView<?>> sideInputs,
-        DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
+        DisplayData.ItemSpecBase<?, ?> fnDisplayData) {
       super(name);
       this.fn = SerializableUtils.clone(fn);
       this.fnDisplayData = fnDisplayData;
@@ -944,7 +945,7 @@ public class ParDo {
     }
 
     private <InputT> BoundMulti<InputT, OutputT> of(
-        Serializable fn, DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
+        Serializable fn, DisplayData.ItemSpecBase<?, ?> fnDisplayData) {
       return new BoundMulti<>(name, fn, sideInputs, mainOutputTag, sideOutputTags, fnDisplayData);
     }
   }
@@ -966,7 +967,7 @@ public class ParDo {
     private final List<PCollectionView<?>> sideInputs;
     private final TupleTag<OutputT> mainOutputTag;
     private final TupleTagList sideOutputTags;
-    private final DisplayData.ItemSpec<? extends Class<?>> fnDisplayData;
+    private final DisplayData.ItemSpecBase<?, ?> fnDisplayData;
     private final Serializable fn;
 
     BoundMulti(
@@ -975,7 +976,7 @@ public class ParDo {
         List<PCollectionView<?>> sideInputs,
         TupleTag<OutputT> mainOutputTag,
         TupleTagList sideOutputTags,
-        DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
+        DisplayData.ItemSpecBase<?, ?> fnDisplayData) {
       super(name);
       this.sideInputs = sideInputs;
       this.mainOutputTag = mainOutputTag;
@@ -1119,8 +1120,8 @@ public class ParDo {
   private static void populateDisplayData(
       DisplayData.Builder builder,
       HasDisplayData fn,
-      DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
-    builder.include("fn", fn).add(fnDisplayData);
+      DisplayData.ItemSpecBase<?, ?> fnDisplayData) {
+    builder.add(fnDisplayData);
   }
 
   private static boolean isSplittable(OldDoFn<?, ?> oldDoFn) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
@@ -124,7 +124,7 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
   @Override
   public void populateDisplayData(DisplayData.Builder builder) {
     super.populateDisplayData(builder);
-    builder.include("partitionFn", partitionDoFn);
+    builder.add(DisplayData.nested("partitionFn", partitionDoFn));
   }
 
   private final transient PartitionDoFn<T> partitionDoFn;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -70,8 +70,8 @@ public class DisplayData implements Serializable {
 
   /**
    * Collect the {@link DisplayData} from a component. This will traverse all subcomponents
-   * specified via {@link Builder#include} in the given component. Data in this component will be in
-   * a namespace derived from the component.
+   * specified via {@link DisplayData#nested} in the given component. Data in this component will be
+   * in a namespace derived from the component.
    */
   public static DisplayData from(HasDisplayData component) {
     checkNotNull(component, "component argument cannot be null");
@@ -181,6 +181,7 @@ public class DisplayData implements Serializable {
      *
      * @see HasDisplayData#populateDisplayData(DisplayData.Builder)
      */
+    // TODO: Remove this API in favor of #nested
     Builder include(String path, HasDisplayData subComponent);
 
     /**
@@ -203,17 +204,17 @@ public class DisplayData implements Serializable {
     /**
      * Register the given display item.
      */
-    Builder add(ItemSpec<?> item);
+    Builder add(ItemSpecBase<?, ?> item);
 
     /**
      * Register the given display item if the value is not null.
      */
-    Builder addIfNotNull(ItemSpec<?> item);
+    Builder addIfNotNull(ItemSpecBase<?, ?> item);
 
     /**
      * Register the given display item if the value is different than the specified default.
      */
-    <T> Builder addIfNotDefault(ItemSpec<T> item, @Nullable T defaultValue);
+    <T> Builder addIfNotDefault(ItemSpecBase<T, ?> item, @Nullable T defaultValue);
   }
 
   /**
@@ -301,13 +302,17 @@ public class DisplayData implements Serializable {
     @Nullable
     public abstract String getLinkUrl();
 
-    private static Item create(ItemSpec<?> spec, Path path) {
+    private static Item create(ItemSpecBase<?, ?> spec, Path path) {
       checkNotNull(spec, "spec cannot be null");
       checkNotNull(path, "path cannot be null");
       Class<?> ns = checkNotNull(spec.getNamespace(), "namespace must be set");
 
       return new AutoValue_DisplayData_Item(path, ns, spec.getKey(), spec.getType(),
           spec.getValue(), spec.getShortValue(), spec.getLabel(), spec.getLinkUrl());
+    }
+
+    private Identifier getIdentifier() {
+      return Identifier.of(getPath(), getNamespace(), getKey());
     }
 
     @Override
@@ -317,32 +322,69 @@ public class DisplayData implements Serializable {
   }
 
   /**
-   * Specifies an {@link Item} to register as display data. Each item is identified by a given
-   * path, key, and namespace from the component the display item belongs to.
+   * Base class to specify an {@link Item} to register as display data.
    *
-   * <p>{@link Item Items} are registered via {@link DisplayData.Builder#add}
-   * within {@link HasDisplayData#populateDisplayData} implementations.
+   *  @see ItemSpec
    */
-  @AutoValue
-  public abstract static class ItemSpec<T> implements Serializable {
-    /**
-     * The namespace for the display item. If unset, defaults to the component which
-     * the display item is registered to.
-     */
-    @Nullable
-    public abstract Class<?> getNamespace();
+  public abstract static class ItemSpecBase<ValueT, SelfT extends ItemSpecBase<ValueT, SelfT>>
+  implements Serializable {
+    private final String key;
+    private final Type type;
+
+    private FormattedItemValue value;
+    @Nullable private Class<?> namespace;
+    @Nullable private String label;
+    @Nullable private String linkUrl;
+
+    private ItemSpecBase(String key, Type type, @Nullable Object value) {
+      this.key = key;
+      this.type = type;
+
+      withRawValue(value);
+    }
 
     /**
      * The key for the display item. Each display item is created with a key and value
      * via {@link DisplayData#item}.
      */
-    public abstract String getKey();
+    public final String getKey() {
+      return key;
+    }
+
+    /**
+     * The namespace for the display item, or null if unset. If unset, the item will default to the
+     * component registering it.
+     */
+    @Nullable
+    public final Class<?> getNamespace() {
+      return namespace;
+    }
+
+    /**
+     * Set the item {@link ItemSpec#getNamespace() namespace} from the given {@link Class}.
+     */
+    public final SelfT withNamespace(Class<?> namespace) {
+      checkNotNull(namespace, "namespace cannot be null");
+      this.namespace = namespace;
+      return self();
+    }
 
     /**
      * The {@link DisplayData.Type} of display data. All display data conforms to a predefined set
      * of allowed types.
      */
-    public abstract Type getType();
+    public final Type getType() {
+      return type;
+    }
+
+    /**
+     * Set the item value from the given raw value. The {@link #getValue() value} and
+     * {@link #getShortValue()} are calculated based on the {@link #getType() type}.
+     */
+    SelfT withRawValue(@Nullable Object value) {
+      this.value = type.safeFormat(value);
+      return self();
+    }
 
     /**
      * The value of the display item. The value is translated from the input to
@@ -350,7 +392,9 @@ public class DisplayData implements Serializable {
      * item's {@link #getType() type}.
      */
     @Nullable
-    public abstract Object getValue();
+    public final Object getValue() {
+      return value.getLongValue();
+    }
 
     /**
      * The optional short value for an item, or {@code null} if none is provided.
@@ -364,81 +408,46 @@ public class DisplayData implements Serializable {
      * choose to display it instead of or in addition to the {@link #getValue() value}.
      */
     @Nullable
-    public abstract Object getShortValue();
+    public final Object getShortValue() {
+      return value.getShortValue();
+    }
 
     /**
      * The optional label for an item. The label is a human-readable description of what
      * the metadata represents. UIs may choose to display the label instead of the item key.
      */
     @Nullable
-    public abstract String getLabel();
-
-    /**
-     * The optional link URL for an item. The URL points to an address where the reader
-     * can find additional context for the display data.
-     */
-    @Nullable
-    public abstract String getLinkUrl();
-
-    private static <T> ItemSpec<T> create(String key, Type type, @Nullable T value) {
-      return ItemSpec.<T>builder()
-          .setKey(key)
-          .setType(type)
-          .setRawValue(value)
-          .build();
-    }
-
-    /**
-     * Set the item {@link ItemSpec#getNamespace() namespace} from the given {@link Class}.
-     *
-     * <p>This method does not alter the current instance, but instead returns a new
-     * {@link ItemSpec} with the namespace set.
-     */
-    public ItemSpec<T> withNamespace(Class<?> namespace) {
-      checkNotNull(namespace, "namespace argument cannot be null");
-      return toBuilder()
-          .setNamespace(namespace)
-          .build();
+    public final String getLabel() {
+      return label;
     }
 
     /**
      * Set the item {@link Item#getLabel() label}.
      *
      * <p>Specifying a null value will clear the label if it was previously defined.
-     *
-     * <p>This method does not alter the current instance, but instead returns a new
-     * {@link ItemSpec} with the label set.
      */
-    public ItemSpec<T> withLabel(@Nullable String label) {
-      return toBuilder()
-          .setLabel(label)
-          .build();
+    public final SelfT withLabel(@Nullable String label) {
+      this.label = label;
+      return self();
+    }
+
+    /**
+     * The optional link URL for an item. The URL points to an address where the reader
+     * can find additional context for the display data.
+     */
+    @Nullable
+    public final String getLinkUrl() {
+      return linkUrl;
     }
 
     /**
      * Set the item {@link Item#getLinkUrl() link url}.
      *
      * <p>Specifying a null value will clear the link url if it was previously defined.
-     *
-     * <p>This method does not alter the current instance, but instead returns a new
-     * {@link ItemSpec} with the link url set.
      */
-    public ItemSpec<T> withLinkUrl(@Nullable String url) {
-      return toBuilder()
-          .setLinkUrl(url)
-          .build();
-    }
-
-    /**
-     * Creates a similar item to the current instance but with the specified value.
-     *
-     * <p>This should only be used internally. It is useful to compare the value of a
-     * {@link DisplayData.Item} to the value derived from a specified input.
-     */
-    private ItemSpec<T> withValue(T value) {
-      return toBuilder()
-          .setRawValue(value)
-          .build();
+    public final SelfT withLinkUrl(@Nullable String linkUrl) {
+      this.linkUrl = linkUrl;
+      return self();
     }
 
     @Override
@@ -446,32 +455,155 @@ public class DisplayData implements Serializable {
       return String.format("%s:%s=%s", getNamespace(), getKey(), getValue());
     }
 
-    static <T> ItemSpec.Builder<T> builder() {
-      return new AutoValue_DisplayData_ItemSpec.Builder<>();
+    @Override
+    public int hashCode() {
+      // Exclude mutable fields from hashcode.
+      return Objects.hash(key, type);
     }
 
-    abstract ItemSpec.Builder<T> toBuilder();
-
-    @AutoValue.Builder
-    abstract static class Builder<T> {
-      public abstract ItemSpec.Builder<T> setKey(String key);
-      public abstract ItemSpec.Builder<T> setNamespace(@Nullable Class<?> namespace);
-      public abstract ItemSpec.Builder<T> setType(Type type);
-      public abstract ItemSpec.Builder<T> setValue(@Nullable Object longValue);
-      public abstract ItemSpec.Builder<T> setShortValue(@Nullable Object shortValue);
-      public abstract ItemSpec.Builder<T> setLabel(@Nullable String label);
-      public abstract ItemSpec.Builder<T> setLinkUrl(@Nullable String url);
-      public abstract ItemSpec<T> build();
-
-
-      abstract Type getType();
-
-      ItemSpec.Builder<T> setRawValue(@Nullable T value) {
-        FormattedItemValue formatted = getType().safeFormat(value);
-        return this
-            .setValue(formatted.getLongValue())
-            .setShortValue(formatted.getShortValue());
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof ItemSpecBase)) {
+        return false;
       }
+
+      ItemSpecBase other = (ItemSpecBase) obj;
+      return Objects.equals(this.key, other.key)
+          && Objects.equals(this.namespace, other.namespace)
+          && Objects.equals(this.type, other.type)
+          && Objects.equals(this.value, other.value)
+          && Objects.equals(this.label, other.label)
+          && Objects.equals(this.linkUrl, other.linkUrl);
+    }
+
+    /** Self-reference, used as return value for builder method return values. */
+    abstract SelfT self();
+
+    /** Test whether the given value is equal to the raw value representing this spec. */
+    abstract boolean rawValueEquals(@Nullable ValueT rawValue);
+
+    /**
+     * Commit zero or more items to the builder for the current item spec. Subclasses override this
+     * method in order to change how items are added.
+     */
+    void commit(InternalBuilder builder) {
+      checkNotNull(getValue(), "Input value cannot be null");
+
+      if (getNamespace() == null) {
+        namespace = builder.currentNamespace();
+      }
+
+      Item item = Item.create(this, builder.currentPath());
+      Identifier id = item.getIdentifier();
+      checkArgument(!builder.entries.containsKey(id),
+          "Display data key (%s) is not unique within the specified path and namespace: %s%s.",
+          item.getKey(), item.getPath(), item.getNamespace());
+      builder.entries.put(id, item);
+    }
+  }
+
+  /**
+   * Specifies an {@link Item} to register as display data. Each item is identified by a given
+   * path, key, and namespace from the component the display item belongs to.
+   *
+   * <p>{@link Item Items} are registered via {@link DisplayData.Builder#add}
+   * within {@link HasDisplayData#populateDisplayData} implementations.
+   */
+  public static class ItemSpec<T> extends ItemSpecBase<T, ItemSpec<T>> {
+    private ItemSpec(String key, Type type, @Nullable T value) {
+      super(key, type, value);
+    }
+
+    @Override
+    ItemSpec<T> self() {
+      return this;
+    }
+
+    /**
+     * Determine if the given value is equivalent to the raw value representing this spec. Useful
+     * to compare against a specified default value in
+     * {@link Builder#addIfNotDefault}.
+     */
+    @Override
+    boolean rawValueEquals(@Nullable T rawValue) {
+      Object otherValue = getType().safeFormat(rawValue).getLongValue();
+      return Objects.equals(getValue(), otherValue);
+    }
+  }
+
+  /**
+   * Specifies a nested sub-component to register as display data.
+   *
+   * @see ItemSpec
+   */
+  public static final class NestedItemSpec extends ItemSpecBase<HasDisplayData, NestedItemSpec> {
+    @Nullable private final HasDisplayData subComponent;
+    private boolean addClassItem = true;
+
+    private NestedItemSpec(String path, @Nullable HasDisplayData subComponent) {
+      super(path, Type.JAVA_CLASS, subComponent == null ? null : subComponent.getClass());
+      this.subComponent = subComponent;
+    }
+
+    /**
+     * Set the class identity to register for the nested subcomponent. To exclude a class item
+     * for the subcomponent, use {@link #withoutClassItem()}.
+     */
+    public NestedItemSpec withClassItem(Class<?> clazz) {
+      checkNotNull(clazz, "class must not be null");
+      return withClassItemInternal(true, clazz);
+    }
+
+    /**
+     * Exclude registering a class item for the nested subcomponent. By default, a class item is
+     * registered for nested components with the identity of the subcomponent class. To override the
+     * class identity, use {@link #withClassItem(Class)}.
+     */
+    public NestedItemSpec withoutClassItem() {
+      return withClassItemInternal(false, null);
+    }
+
+    private NestedItemSpec withClassItemInternal(boolean shouldAdd, @Nullable Class<?> clazz) {
+      addClassItem = shouldAdd;
+      withRawValue(clazz);
+      return self();
+    }
+
+    @Override
+    void commit(InternalBuilder builder) {
+      if (addClassItem) {
+        super.commit(builder);
+      }
+
+      checkNotNull(subComponent, "subComponent cannot be null");
+      builder.include(getKey(), subComponent);
+    }
+
+    @Override
+    NestedItemSpec self() {
+      return this;
+    }
+
+    @Override
+    boolean rawValueEquals(@Nullable HasDisplayData rawValue) {
+      return Objects.equals(subComponent, rawValue);
+    }
+
+    @Override
+    public int hashCode() {
+      // Exclude mutable fields from hashcode.
+      return super.hashCode();
+    }
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof NestedItemSpec)) {
+        return false;
+      }
+
+      NestedItemSpec other = (NestedItemSpec) obj;
+      return super.equals(obj)
+          && Objects.equals(this.subComponent, other.subComponent)
+          && Objects.equals(this.addClassItem, other.addClassItem);
     }
   }
 
@@ -512,7 +644,7 @@ public class DisplayData implements Serializable {
    * Structured path of registered display data within a component hierarchy.
    *
    * <p>Display data items registered directly by a component will have the {@link Path#root() root}
-   * path. If the component {@link Builder#include includes} a sub-component, its display data will
+   * path. If the component {@link DisplayData#nested nests} a sub-component, its display data will
    * be registered at the path specified. Each sub-component path is created by appending a child
    * element to the path of its parent component, forming a hierarchy.
    */
@@ -708,7 +840,7 @@ public class DisplayData implements Serializable {
     }
   }
 
-  static class FormattedItemValue {
+  static final class FormattedItemValue implements Serializable {
     /**
      * Default instance which contains null values.
      */
@@ -731,6 +863,23 @@ public class DisplayData implements Serializable {
     }
     Object getShortValue() {
       return this.shortValue;
+    }
+
+    @Override
+    public int hashCode() {
+      return longValue == null ? 0 : longValue.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof FormattedItemValue)) {
+        return false;
+      }
+
+      FormattedItemValue other = (FormattedItemValue) obj;
+
+      // Equality based only on long value; short value is derived.
+      return Objects.equals(this.longValue, other.longValue);
     }
   }
 
@@ -805,54 +954,39 @@ public class DisplayData implements Serializable {
       return this;
     }
 
-    /**
-     * Marker exception class for exceptions encountered while populating display data.
-     */
-    private static class PopulateDisplayDataException extends RuntimeException {
-      PopulateDisplayDataException(String message, Throwable cause) {
-        super(message, cause);
-      }
-    }
-
     @Override
-    public Builder add(ItemSpec<?> item) {
+    public Builder add(ItemSpecBase<?, ?> item) {
       checkNotNull(item, "Input display item cannot be null");
       return addItemIf(true, item);
     }
 
     @Override
-    public Builder addIfNotNull(ItemSpec<?> item) {
+    public Builder addIfNotNull(ItemSpecBase<?, ?> item) {
       checkNotNull(item, "Input display item cannot be null");
       return addItemIf(item.getValue() != null, item);
     }
 
     @Override
-    public <T> Builder addIfNotDefault(ItemSpec<T> item, @Nullable T defaultValue) {
+    public <T> Builder addIfNotDefault(ItemSpecBase<T, ?> item, @Nullable T defaultValue) {
       checkNotNull(item, "Input display item cannot be null");
-      ItemSpec<T> defaultItem = item.withValue(defaultValue);
-      return addItemIf(!Objects.equals(item, defaultItem), item);
+      return addItemIf(!item.rawValueEquals(defaultValue), item);
     }
 
-    private Builder addItemIf(boolean condition, ItemSpec<?> spec) {
+    private Builder addItemIf(boolean condition, ItemSpecBase<?, ?> spec) {
       if (!condition) {
         return this;
       }
 
-      checkNotNull(spec, "Input display item cannot be null");
-      checkNotNull(spec.getValue(), "Input display value cannot be null");
-
-      if (spec.getNamespace() == null) {
-        spec = spec.withNamespace(latestNs);
-      }
-      Item item = Item.create(spec, latestPath);
-
-      Identifier id = Identifier.of(item.getPath(), item.getNamespace(), item.getKey());
-      checkArgument(!entries.containsKey(id),
-          "Display data key (%s) is not unique within the specified path and namespace: %s%s.",
-          item.getKey(), item.getPath(), item.getNamespace());
-
-      entries.put(id, item);
+      spec.commit(this);
       return this;
+    }
+
+    Class<?> currentNamespace() {
+      return latestNs;
+    }
+
+    Path currentPath() {
+      return latestPath;
     }
 
     private DisplayData build() {
@@ -923,6 +1057,15 @@ public class DisplayData implements Serializable {
     return item(key, Type.JAVA_CLASS, value);
   }
 
+  // TODO: Javadoc
+  public static <T extends HasDisplayData> NestedItemSpec nested(String path,
+      @Nullable T subComponent) {
+    checkNotNull(path, "Must specify a non-empty path");
+    checkArgument(!path.equals(""), "Must specify a non-empty path");
+
+    return new NestedItemSpec(path, subComponent);
+  }
+
   /**
    * Create a display item for the specified key, type, and value. This method should be used
    * if the type of the input value can only be determined at runtime. Otherwise,
@@ -937,6 +1080,15 @@ public class DisplayData implements Serializable {
     checkNotNull(key, "key argument cannot be null");
     checkNotNull(type, "type argument cannot be null");
 
-    return ItemSpec.create(key, type, value);
+    return new ItemSpec<>(key, type, value);
+  }
+
+  /**
+   * Marker exception class for exceptions encountered while populating display data.
+   */
+  static class PopulateDisplayDataException extends RuntimeException {
+    PopulateDisplayDataException(String message, Throwable cause) {
+      super(message, cause);
+    }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
@@ -574,12 +574,8 @@ public class Window {
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
 
-      if (windowFn != null) {
-        builder
-            .add(DisplayData.item("windowFn", windowFn.getClass())
-              .withLabel("Windowing Function"))
-            .include("windowFn", windowFn);
-      }
+      builder.addIfNotNull(DisplayData.nested("windowFn", windowFn)
+        .withLabel("Windowing Function"));
 
       if (allowedLateness != null) {
         builder.addIfNotDefault(DisplayData.item("allowedLateness", allowedLateness)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataMatchers.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataMatchers.java
@@ -199,7 +199,7 @@ public class DisplayDataMatchers {
         return DisplayData.from(new HasDisplayData() {
           @Override
           public void populateDisplayData(DisplayData.Builder builder) {
-            builder.include(path, subComponent);
+            builder.add(DisplayData.nested(path, subComponent));
           }
         });
       }
@@ -367,6 +367,28 @@ public class DisplayDataMatchers {
       @Override
       protected String featureValueOf(DisplayData.Item actual) {
         return actual.getLabel();
+      }
+    };
+  }
+
+  /**
+   * Creates a matcher that matches if the examined {@link DisplayData.Item} has the specified
+   * link url.
+   */
+  public static Matcher<DisplayData.Item> hasLinkUrl(String url) {
+    return hasLinkUrl(is(url));
+  }
+
+  /**
+   * Creates a matcher that matches if the examined {@link DisplayData.Item} has a link url matching
+   * the specified url matcher.
+   */
+  public static Matcher<DisplayData.Item> hasLinkUrl(Matcher<String> urlMatcher) {
+    return new FeatureMatcher<DisplayData.Item, String>(
+        urlMatcher, "display item with linkUrl", "linkUrl") {
+      @Override
+      protected String featureValueOf(DisplayData.Item actual) {
+        return actual.getLinkUrl();
       }
     };
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -20,12 +20,14 @@ package org.apache.beam.sdk.transforms.display;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasKey;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasLabel;
+import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasLinkUrl;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasNamespace;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasPath;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasType;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasValue;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.includesDisplayDataFor;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
@@ -152,28 +154,25 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testCanBuildDisplayData() {
-    DisplayData data =
-        DisplayData.from(new HasDisplayData() {
-              @Override
-              public void populateDisplayData(DisplayData.Builder builder) {
-                builder.add(DisplayData.item("foo", "bar"));
-              }
-            });
-
+    DisplayData data = DisplayData.from(new HasFooBarDisplayData());
     assertThat(data.items(), hasSize(1));
     assertThat(data, hasDisplayItem("foo", "bar"));
   }
 
+  /**
+   * Registers a single piece of display data with key=foo and value=bar. Who knew this was such
+   * a useful pattern!
+   */
+  private static class HasFooBarDisplayData implements HasDisplayData, Serializable {
+    @Override
+    public void populateDisplayData(Builder builder) {
+      builder.add(DisplayData.item("foo", "bar"));
+    }
+  }
+
   @Test
   public void testAsMap() {
-    DisplayData data =
-        DisplayData.from(
-            new HasDisplayData() {
-              @Override
-              public void populateDisplayData(DisplayData.Builder builder) {
-                builder.add(DisplayData.item("foo", "bar"));
-              }
-            });
+    DisplayData data = DisplayData.from(new HasFooBarDisplayData());
 
     Map<DisplayData.Identifier, DisplayData.Item> map = data.asMap();
     assertEquals(map.size(), 1);
@@ -205,25 +204,18 @@ public class DisplayDataTest implements Serializable {
         hasValue(ISO_FORMATTER.print(value)),
         hasShortValue(nullValue(String.class)),
         hasLabel("the current instant"),
-        hasUrl(is("http://time.gov")));
+        hasLinkUrl("http://time.gov"));
 
     assertThat(item, matchesAllOf);
   }
 
   @Test
   public void testUnspecifiedOptionalProperties() {
-    DisplayData data =
-        DisplayData.from(
-            new HasDisplayData() {
-              @Override
-              public void populateDisplayData(DisplayData.Builder builder) {
-                builder.add(DisplayData.item("foo", "bar"));
-              }
-            });
-
     assertThat(
-        data,
-        hasDisplayItem(allOf(hasLabel(nullValue(String.class)), hasUrl(nullValue(String.class)))));
+        DisplayData.from(new HasFooBarDisplayData()),
+        hasDisplayItem(allOf(
+            hasLabel(nullValue(String.class)),
+            hasLinkUrl(nullValue(String.class)))));
   }
 
   @Test
@@ -231,6 +223,7 @@ public class DisplayDataTest implements Serializable {
     DisplayData data = DisplayData.from(new HasDisplayData() {
       @Override
       public void populateDisplayData(Builder builder) {
+        HasDisplayData comp = new HasFooBarDisplayData();
         builder
             .addIfNotDefault(DisplayData.item("defaultString", "foo"), "foo")
             .addIfNotDefault(DisplayData.item("notDefaultString", "foo"), "notFoo")
@@ -249,14 +242,16 @@ public class DisplayDataTest implements Serializable {
             .addIfNotDefault(
                 DisplayData.item("defaultClass", DisplayDataTest.class),
                 DisplayDataTest.class)
-            .addIfNotDefault(
-                DisplayData.item("notDefaultClass", DisplayDataTest.class),
-                null);
+            .addIfNotDefault(DisplayData.item("notDefaultClass", DisplayDataTest.class),
+                null)
+            .addIfNotDefault(DisplayData.nested("defaultNested", comp), comp)
+            .addIfNotDefault(DisplayData.nested("notDefaultNested", comp), null);
       }
     });
 
-    assertThat(data.items(), hasSize(7));
-    assertThat(data.items(), everyItem(hasKey(startsWith("notDefault"))));
+    assertThat(data.items(), everyItem(hasKey(anyOf(
+        startsWith("notDefault"),
+        is("foo")))));  // nested display data
   }
 
   @Test
@@ -305,12 +300,15 @@ public class DisplayDataTest implements Serializable {
             .addIfNotNull(DisplayData.item("nullDuration", (Duration) null))
             .addIfNotNull(DisplayData.item("notNullDuration", Duration.ZERO))
             .addIfNotNull(DisplayData.item("nullClass", (Class<?>) null))
-            .addIfNotNull(DisplayData.item("notNullClass", DisplayDataTest.class));
+            .addIfNotNull(DisplayData.item("notNullClass", DisplayDataTest.class))
+            .addIfNotNull(DisplayData.nested("nullNested", null))
+            .addIfNotNull(DisplayData.nested("notNullNested", new HasFooBarDisplayData()));
       }
     });
 
-    assertThat(data.items(), hasSize(7));
-    assertThat(data.items(), everyItem(hasKey(startsWith("notNull"))));
+    assertThat(data.items(), everyItem(hasKey(anyOf(
+        startsWith("notNull"),
+        is("foo")))));  // nested display data
   }
 
   @Test
@@ -407,13 +405,7 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testIncludes() {
-    final HasDisplayData subComponent =
-        new HasDisplayData() {
-          @Override
-          public void populateDisplayData(DisplayData.Builder builder) {
-            builder.add(DisplayData.item("foo", "bar"));
-          }
-        };
+    final HasDisplayData subComponent = new HasFooBarDisplayData();
 
     DisplayData data =
         DisplayData.from(
@@ -428,19 +420,152 @@ public class DisplayDataTest implements Serializable {
   }
 
   @Test
+  public void testNested() {
+    final HasDisplayData subComponent = new HasFooBarDisplayData();
+    DisplayData data = DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        builder.add(DisplayData.nested("p", subComponent));
+      }
+    });
+
+    assertThat(data, hasDisplayItem("p", subComponent.getClass()));
+    assertThat(data, includesDisplayDataFor("p", subComponent));
+  }
+
+  @Test
+  public void testNestedWithClassOverride() {
+    final Class<?> clazz = new Object() {}.getClass();
+    DisplayData data = DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        builder.add(DisplayData.nested("p", new HasFooBarDisplayData())
+          .withClassItem(clazz));
+      }
+    });
+
+    assertThat(data, hasDisplayItem("p", clazz));
+  }
+
+  @Test
+  public void testNestedWithMetadataOverrides() {
+    DisplayData data = DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        builder.add(DisplayData.nested("p", new HasFooBarDisplayData())
+            .withLabel("label1")
+            .withLinkUrl("link2"));
+      }
+    });
+
+    assertThat(data, hasDisplayItem(allOf(
+        hasKey("p"),
+        hasLabel("label1"),
+        hasLinkUrl("link2"))));
+  }
+
+  @Test
+  public void testNestedNullPath() {
+    thrown.expect(NullPointerException.class);
+    DisplayData.nested(null, new HasFooBarDisplayData());
+  }
+
+  @Test
+  public void testNestedEmptyPath() {
+    thrown.expect(NullPointerException.class);
+    DisplayData.nested(null, new HasFooBarDisplayData());
+  }
+
+
+  @Test
+  public void testNestedSameComponentDifferentPaths() {
+    final HasDisplayData subComp = new HasFooBarDisplayData();
+    DisplayData data = DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder
+            .add(DisplayData.nested("p1", subComp))
+            .add(DisplayData.nested("p2", subComp));
+      }
+    });
+
+    assertThat(data, hasDisplayItem("p1", HasFooBarDisplayData.class));
+    assertThat(data, includesDisplayDataFor("p1", subComp));
+    assertThat("class item for duplicate item shoudl be added",
+        data, hasDisplayItem("p2", HasFooBarDisplayData.class));
+    assertThat("duplicate subcomponent should not be included twice",
+        data, not(includesDisplayDataFor("p2", subComp)));
+  }
+
+  @Test
+  public void testNestedDuplicatePath() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder
+            .add(DisplayData.nested("p", new HasFooBarDisplayData() {})
+              .withoutClassItem())
+            .add(DisplayData.nested("p", new HasFooBarDisplayData() {})
+              .withoutClassItem());
+      }
+    });
+  }
+
+  @Test
+  public void testNestedKeyAlreadyUsed() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder
+            .add(DisplayData.item("key", "value"))
+            .add(DisplayData.nested("key", new HasFooBarDisplayData()));
+      }
+    });
+  }
+
+  @Test
+  public void testNestedWithoutClassItem() {
+    final HasFooBarDisplayData subComponent = new HasFooBarDisplayData();
+    DisplayData data = DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.add(DisplayData.nested("p", subComponent)
+          .withoutClassItem());
+      }
+    });
+
+    assertThat(data, includesDisplayDataFor("p", subComponent));
+    assertThat(data, not(hasDisplayItem("p", HasFooBarDisplayData.class)));
+  }
+
+  @Test
+  public void testNestedWithoutClassItemKeyAlreadyUsed() {
+    DisplayData data = DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder
+            .add(DisplayData.item("key", "value"))
+            .add(DisplayData.nested("key", new HasFooBarDisplayData())
+              .withoutClassItem());
+      }
+    });
+
+    assertThat(data, hasDisplayItem("key", "value"));
+  }
+
+  @Test
+  public void testNestedClassOverrideNull() {
+    thrown.expect(NullPointerException.class);
+    DisplayData.nested("key", new HasFooBarDisplayData())
+        .withClassItem(null);
+  }
+
+  @Test
   public void testIncludeSameComponentAtDifferentPaths() {
-    final HasDisplayData subComponent1 = new HasDisplayData() {
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("foo", "bar"));
-      }
-    };
-    final HasDisplayData subComponent2 = new HasDisplayData() {
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("foo2", "bar2"));
-      }
-    };
+    final HasDisplayData subComponent1 = new HasFooBarDisplayData();
+    final HasDisplayData subComponent2 = new HasFooBarDisplayData();
 
     HasDisplayData component = new HasDisplayData() {
       @Override
@@ -448,7 +573,6 @@ public class DisplayDataTest implements Serializable {
         builder
             .include("p1", subComponent1)
             .include("p2", subComponent2);
-
       }
     };
 
@@ -501,27 +625,38 @@ public class DisplayDataTest implements Serializable {
   }
 
   @Test
-  public void testItemEquality() {
+  public void testItemSpecEquality() {
     new EqualsTester()
         .addEqualityGroup(DisplayData.item("foo", "bar"), DisplayData.item("foo", "bar"))
         .addEqualityGroup(DisplayData.item("foo", "barz"))
+        .addEqualityGroup(DisplayData.item("foo", "bar").withLabel("l"))
+        .addEqualityGroup(DisplayData.item("foo", "bar").withLinkUrl("u"))
+        .addEqualityGroup(DisplayData.item("foo", "bar").withNamespace(DisplayDataTest.class))
+        .testEquals();
+  }
+
+  @Test
+  public void testNestedItemSpecEquality() {
+    HasDisplayData comp = new HasFooBarDisplayData();
+    new EqualsTester()
+        .addEqualityGroup(DisplayData.nested("key", comp), DisplayData.nested("key", comp))
+        .addEqualityGroup(DisplayData.nested("key", new HasFooBarDisplayData()))
+        .addEqualityGroup(DisplayData.nested("key", comp).withLabel("l"))
+        .addEqualityGroup(DisplayData.nested("key", comp).withLinkUrl("u"))
+        .addEqualityGroup(DisplayData.nested("key", comp).withNamespace(DisplayDataTest.class))
+        .addEqualityGroup(
+            DisplayData.nested("key", comp).withClassItem(DisplayDataTest.class),
+            DisplayData.nested("key", comp).withoutClassItem().withClassItem(DisplayDataTest.class))
+        .addEqualityGroup(
+            DisplayData.nested("key", comp).withoutClassItem(),
+            DisplayData.nested("key", comp).withClassItem(DisplayDataTest.class).withoutClassItem())
         .testEquals();
   }
 
   @Test
   public void testDisplayDataEquality() {
-    HasDisplayData component1 = new HasDisplayData() {
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("foo", "bar"));
-      }
-    };
-    HasDisplayData component2 = new HasDisplayData() {
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("foo", "bar"));
-      }
-    };
+    HasDisplayData component1 = new HasFooBarDisplayData(){};
+    HasDisplayData component2 = new HasFooBarDisplayData(){};
 
     DisplayData component1DisplayData1 = DisplayData.from(component1);
     DisplayData component1DisplayData2 = DisplayData.from(component1);
@@ -531,28 +666,6 @@ public class DisplayDataTest implements Serializable {
         .addEqualityGroup(component1DisplayData1, component1DisplayData2)
         .addEqualityGroup(component2DisplayData)
         .testEquals();
-  }
-
-  @Test
-  public void testAcceptsKeysWithDifferentNamespaces() {
-    DisplayData data =
-        DisplayData.from(
-            new HasDisplayData() {
-              @Override
-              public void populateDisplayData(DisplayData.Builder builder) {
-                builder
-                    .add(DisplayData.item("foo", "bar"))
-                    .include("p",
-                        new HasDisplayData() {
-                          @Override
-                          public void populateDisplayData(DisplayData.Builder builder) {
-                            builder.add(DisplayData.item("foo", "bar"));
-                          }
-                        });
-              }
-            });
-
-    assertThat(data.items(), hasSize(2));
   }
 
   @Test
@@ -587,17 +700,13 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testToString() {
-    HasDisplayData component = new HasDisplayData() {
-      @Override
-      public void populateDisplayData(DisplayData.Builder builder) {
-        builder.add(DisplayData.item("foo", "bar"));
-      }
-    };
-
-    DisplayData data = DisplayData.from(component);
-    assertEquals(String.format("[]%s:foo=bar", component.getClass().getName()), data.toString());
+    DisplayData data = DisplayData.from(new HasFooBarDisplayData());
+    assertEquals(
+        String.format("[]%s:foo=bar", HasFooBarDisplayData.class.getName()),
+        data.toString());
   }
 
+  // TODO: Convert these to nested() tests or remove if redundant.
   @Test
   public void testHandlesIncludeCycles() {
 
@@ -907,20 +1016,12 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testContextProperlyReset() {
-    final HasDisplayData subComponent =
-        new HasDisplayData() {
-          @Override
-          public void populateDisplayData(DisplayData.Builder builder) {
-            builder.add(DisplayData.item("foo", "bar"));
-          }
-        };
-
     HasDisplayData component =
         new HasDisplayData() {
           @Override
           public void populateDisplayData(DisplayData.Builder builder) {
             builder
-              .include("p", subComponent)
+              .include("p", new HasFooBarDisplayData())
               .add(DisplayData.item("alpha", "bravo"));
           }
         };
@@ -942,6 +1043,7 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testIncludeNull() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
     thrown.expectCause(isA(NullPointerException.class));
     DisplayData.from(
         new HasDisplayData() {
@@ -954,6 +1056,7 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testIncludeNullPath() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
     thrown.expectCause(isA(NullPointerException.class));
     DisplayData.from(new HasDisplayData() {
       @Override
@@ -965,6 +1068,7 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testIncludeEmptyPath() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
     thrown.expectCause(isA(IllegalArgumentException.class));
     DisplayData.from(new HasDisplayData() {
       @Override
@@ -976,51 +1080,110 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testNullKey() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
     thrown.expectCause(isA(NullPointerException.class));
-    DisplayData.from(
-        new HasDisplayData() {
-          @Override
-          public void populateDisplayData(Builder builder) {
-            builder.add(DisplayData.item(null, "foo"));
-          }
-        });
+    DisplayData.from(new HasDisplayData() {
+        @Override
+        public void populateDisplayData(Builder builder) {
+          builder.add(DisplayData.item(null, "foo"));
+        }
+      });
   }
 
   @Test
-  public void testRejectsNullValues() {
-    DisplayData.from(
-      new HasDisplayData() {
+  public void testRejectsNullStringValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.add(DisplayData.item("key", (String) null));
+      }
+    });
+  }
+
+  @Test
+  public void testRejectsNullIntegerValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.add(DisplayData.item("key", (Integer) null));
+      }
+    });
+  }
+
+  @Test
+  public void testRejectsNullFloatingPointValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.add(DisplayData.item("key", (Double) null));
+      }
+    });
+  }
+
+  @Test
+  public void testRejectsNullBooleanValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.add(DisplayData.item("key", (Boolean) null));
+      }
+    });
+  }
+
+  @Test
+  public void testRejectsNullClassValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
         @Override
         public void populateDisplayData(Builder builder) {
-          try {
-            builder.add(DisplayData.item("key", (String) null));
-            throw new RuntimeException("Should throw on null string value");
-          } catch (NullPointerException ex) {
-            // Expected
-          }
-
-          try {
-            builder.add(DisplayData.item("key", (Class<?>) null));
-            throw new RuntimeException("Should throw on null class value");
-          } catch (NullPointerException ex) {
-            // Expected
-          }
-
-          try {
-            builder.add(DisplayData.item("key", (Duration) null));
-            throw new RuntimeException("Should throw on null duration value");
-          } catch (NullPointerException ex) {
-            // Expected
-          }
-
-          try {
-            builder.add(DisplayData.item("key", (Instant) null));
-            throw new RuntimeException("Should throw on null instant value");
-          } catch (NullPointerException ex) {
-            // Expected
-          }
+          builder.add(DisplayData.item("key", (Class<?>) null));
         }
       });
+  }
+
+  @Test
+  public void testRejectsNullDurationValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+        @Override
+        public void populateDisplayData(Builder builder) {
+          builder.add(DisplayData.item("key", (Duration) null));
+        }
+      });
+  }
+
+  @Test
+  public void testRejectsNullTimestampValues() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+        @Override
+        public void populateDisplayData(Builder builder) {
+          builder.add(DisplayData.item("key", (Instant) null));
+        }
+      });
+  }
+
+  @Test
+  public void testRejectsNullNestedComponent() {
+    thrown.expect(DisplayData.PopulateDisplayDataException.class);
+    thrown.expectCause(isA(NullPointerException.class));
+    DisplayData.from(new HasDisplayData() {
+      @Override
+      public void populateDisplayData(Builder builder) {
+        builder.add(DisplayData.nested("p", null));
+      }
+    });
   }
 
   @Test
@@ -1079,12 +1242,7 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testJsonSerializationAnonymousClassNamespace() throws IOException {
-    HasDisplayData component = new HasDisplayData() {
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("foo", "bar"));
-      }
-    };
+    HasDisplayData component = new HasFooBarDisplayData() {};
     DisplayData data = DisplayData.from(component);
 
     JsonNode json = MAPPER.readTree(MAPPER.writeValueAsBytes(data));
@@ -1103,14 +1261,21 @@ public class DisplayDataTest implements Serializable {
 
   @Test
   public void testCanSerializeItemSpecReference() {
-    DisplayData.ItemSpec<?> spec = DisplayData.item("clazz", DisplayDataTest.class);
-    SerializableUtils.ensureSerializable(new HoldsItemSpecReference(spec));
+    DisplayData.ItemSpec<?> item = DisplayData.item("clazz", DisplayDataTest.class);
+    DisplayData.NestedItemSpec nested = DisplayData.nested("p", new HasFooBarDisplayData());
+    SerializableUtils.ensureSerializable(new HoldsItemSpecReference(item, nested));
   }
 
   private static class HoldsItemSpecReference implements Serializable {
-    private final DisplayData.ItemSpec<?> spec;
-    public HoldsItemSpecReference(DisplayData.ItemSpec<?> spec) {
-      this.spec = spec;
+    @SuppressWarnings("unused") // used to test serialization
+    private final DisplayData.ItemSpec<?> item;
+    @SuppressWarnings("unused") // used to test serialization
+    private final DisplayData.NestedItemSpec nested;
+    public HoldsItemSpecReference(
+        DisplayData.ItemSpec<?> item,
+        DisplayData.NestedItemSpec nested) {
+      this.item = item;
+      this.nested = nested;
     }
   }
 
@@ -1242,16 +1407,6 @@ public class DisplayDataTest implements Serializable {
   private static class NoopDisplayData implements HasDisplayData {
     @Override
     public void populateDisplayData(Builder builder) {}
-  }
-
-  private static Matcher<DisplayData.Item> hasUrl(Matcher<String> urlMatcher) {
-    return new FeatureMatcher<DisplayData.Item, String>(
-        urlMatcher, "display item with url", "URL") {
-      @Override
-      protected String featureValueOf(DisplayData.Item actual) {
-        return actual.getLinkUrl();
-      }
-    };
   }
 
   private static  <T> Matcher<DisplayData.Item> hasShortValue(Matcher<T> valueStringMatcher) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -802,7 +802,7 @@ public class DatastoreV1 {
       builder
           .addIfNotNull(DisplayData.item("projectId", projectId)
               .withLabel("Output Project"))
-          .include("mutationFn", mutationFn);
+          .add(DisplayData.nested("mutationFn", mutationFn));
     }
 
     public String getProjectId() {


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

In the Java SDK, components can register display data directly, as well as include display data from sub-components via the `include(..)` operation. In #1008, we add 'paths' to display data metadata and also include a `delegate(..)` action.

During the change for paths, we noticed an emerging pattern where components will typically add the `.getClass()` of a subcomponent before including it. We can support this convention better by embedding it in a single configurable operation, `.nested(..)`

So this:
```java
@Override
public void populateDisplayData(DisplayData.Builder builder) {
  builder
    .add(DisplayData.item("windowFn", windowFn.getClass()))
    .include("windowFn", windowFn)
    .add(DisplayData.item("otherProperty", otherProp));
}
```

becomes this:
```java
@Override
public void populateDisplayData(DisplayData.Builder builder) {
  builder
    .add(DisplayData.nested("windowFn", windowFn))
    .add(DisplayData.item("otherProperty", otherProp));
}
```

See https://github.com/apache/incubator-beam/pull/1088#discussion_r83332515 for more context.