### PR TITLE
[BEAM-854] Directly implement ReifyTimestampsAndWindows in SparkRunner

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupCombineFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupCombineFunctions.java
@@ -36,7 +36,6 @@ import org.apache.beam.sdk.transforms.CombineWithContext;
 import org.apache.beam.sdk.transforms.OldDoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
-import org.apache.beam.sdk.util.ReifyTimestampAndWindowsDoFn;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.KV;
@@ -48,7 +47,6 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-
 import scala.Tuple2;
 
 
@@ -77,8 +75,7 @@ public class GroupCombineFunctions {
     // Use coders to convert objects in the PCollection to byte arrays, so they
     // can be transferred over the network for the shuffle.
     JavaRDD<WindowedValue<KV<K, Iterable<WindowedValue<V>>>>> groupedByKey =
-        rdd.mapPartitions(new DoFnFunction<KV<K, V>, KV<K, WindowedValue<V>>>(null,
-                new ReifyTimestampAndWindowsDoFn<K, V>(), runtimeContext, null, null))
+        rdd.map(new ReifyTimestampsAndWindowsFunction<K, V>())
             .map(WindowingHelpers.<KV<K, WindowedValue<V>>>unwindowFunction())
             .mapToPair(TranslationUtils.<K, WindowedValue<V>>toPairFunction())
             .mapToPair(CoderHelpers.toByteFunction(keyCoder, wvCoder))

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/ReifyTimestampsAndWindowsFunction.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/ReifyTimestampsAndWindowsFunction.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.spark.translation;
+
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.spark.api.java.function.Function;
+
+/**
+ * Simple {@link Function} to bring the windowing information into the value from the implicit
+ * background representation of the {@link PCollection}.
+ */
+public class ReifyTimestampsAndWindowsFunction<K, V>
+    implements Function<WindowedValue<KV<K, V>>, WindowedValue<KV<K, WindowedValue<V>>>> {
+  @Override
+  public WindowedValue<KV<K, WindowedValue<V>>> call(WindowedValue<KV<K, V>> elem)
+      throws Exception {
+    return WindowedValue.of(
+        KV.of(
+            elem.getValue().getKey(),
+            WindowedValue.of(
+                elem.getValue().getValue(),
+                elem.getTimestamp(),
+                elem.getWindows(),
+                elem.getPane())),
+        elem.getTimestamp(),
+        elem.getWindows(),
+        elem.getPane());
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @amitsela 

I introduced a performance issue in [BEAM-854](https://issues.apache.org/jira/browse/BEAM-854) that affects the SparkRunner and DirectRunner. As per discussion there, `ReifyTimestampsAndWindows` can only use the multi-window `WindowedValue` representation if it is implemented as a primitive. The fix is pretty trivial, and actually just simpler anyhow. I ran `mvn integration-test -Plocal-runnable-on-service-tests -pl runners/spark` but feel free to pull this down and do it right if I have missed something, inline the class, etc, whatever you like.