### PR TITLE
[BEAM-27] Add setTimer and deleteTimer by ID in TimerInternals

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTimerInternals.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTimerInternals.java
@@ -21,7 +21,9 @@ import javax.annotation.Nullable;
 import org.apache.beam.runners.direct.WatermarkManager.TimerUpdate;
 import org.apache.beam.runners.direct.WatermarkManager.TimerUpdate.TimerUpdateBuilder;
 import org.apache.beam.runners.direct.WatermarkManager.TransformWatermarks;
+import org.apache.beam.sdk.util.TimeDomain;
 import org.apache.beam.sdk.util.TimerInternals;
+import org.apache.beam.sdk.util.state.StateNamespace;
 import org.joda.time.Instant;
 
 /**
@@ -45,8 +47,19 @@ class DirectTimerInternals implements TimerInternals {
   }
 
   @Override
+  public void setTimer(StateNamespace namespace, String timerId, Instant target,
+      TimeDomain timeDomain) {
+    throw new UnsupportedOperationException("Setting timer by ID not yet supported.");
+  }
+
+  @Override
   public void setTimer(TimerData timerKey) {
     timerUpdateBuilder.setTimer(timerKey);
+  }
+
+  @Override
+  public void deleteTimer(StateNamespace namespace, String timerId) {
+    throw new UnsupportedOperationException("Canceling of timer by ID is not yet supported.");
   }
 
   @Override

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -55,6 +55,7 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.util.state.StateInternals;
 import org.apache.beam.sdk.util.state.StateInternalsFactory;
+import org.apache.beam.sdk.util.state.StateNamespace;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
@@ -451,6 +452,12 @@ public class WindowDoFnOperator<K, InputT, OutputT>
     public TimerInternals timerInternals() {
       return new TimerInternals() {
         @Override
+        public void setTimer(
+            StateNamespace namespace, String timerId, Instant target, TimeDomain timeDomain) {
+          throw new UnsupportedOperationException("Setting a timer by ID is not yet supported.");
+        }
+
+        @Override
         public void setTimer(TimerData timerKey) {
           if (timerKey.getDomain().equals(TimeDomain.EVENT_TIME)) {
             registerEventTimeTimer(timerKey);
@@ -460,6 +467,12 @@ public class WindowDoFnOperator<K, InputT, OutputT>
             throw new UnsupportedOperationException(
                 "Unsupported time domain: " + timerKey.getDomain());
           }
+        }
+
+        @Override
+        public void deleteTimer(StateNamespace namespace, String timerId) {
+          throw new UnsupportedOperationException(
+              "Canceling of a timer by ID is not yet supported.");
         }
 
         @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/TimerInternals.java
@@ -50,16 +50,35 @@ import org.joda.time.Instant;
 public interface TimerInternals {
 
   /**
-   * Writes out a timer to be fired when the watermark reaches the given
-   * timestamp.
+   * Writes out a timer to be fired when the current time in the specified time domain reaches the
+   * target timestamp.
    *
-   * <p>The combination of {@code namespace}, {@code timestamp} and {@code domain} uniquely
-   * identify a timer. Multiple timers set for the same parameters can be safely deduplicated.
+   * <p>The combination of {@code namespace} and {@code timerId} uniquely identify a timer.
+   *
+   * <p>If a timer is set and then set again before it fires, later settings should clear the prior
+   * setting.
+   *
+   * <p>It is an error to set a timer for two different time domains.
+   */
+  void setTimer(StateNamespace namespace, String timerId, Instant target, TimeDomain timeDomain);
+
+  /**
+   * Writes out a timer to be fired when the watermark reaches the given timestamp, automatically
+   * generating an id for it from the provided {@link TimerData}.
+   *
+   * <p>The {@link TimerData} contains all the fields necessary to set the timer. The timer's ID
+   * is determinstically generated from the {@link TimerData}, so it may be canceled using
+   * the same {@link TimerData}.
    */
   void setTimer(TimerData timerKey);
 
   /**
    * Deletes the given timer.
+   */
+  void deleteTimer(StateNamespace namespace, String timerId);
+
+  /**
+   * Deletes the given timer, automatically inferring its ID from the {@link TimerData}.
    */
   void deleteTimer(TimerData timerKey);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
@@ -36,6 +36,7 @@ import org.joda.time.Instant;
  * computation and key in a Windmill-like streaming environment.
  */
 public class InMemoryTimerInternals implements TimerInternals {
+
   /** At most one timer per timestamp is kept. */
   private Set<TimerData> existingTimers = new HashSet<>();
 
@@ -97,11 +98,22 @@ public class InMemoryTimerInternals implements TimerInternals {
   }
 
   @Override
+  public void setTimer(StateNamespace namespace, String timerId, Instant target,
+      TimeDomain timeDomain) {
+    throw new UnsupportedOperationException("Setting a timer by ID is not yet supported.");
+  }
+
+  @Override
   public void setTimer(TimerData timer) {
     WindowTracing.trace("TestTimerInternals.setTimer: {}", timer);
     if (existingTimers.add(timer)) {
       queue(timer.getDomain()).add(timer);
     }
+  }
+
+  @Override
+  public void deleteTimer(StateNamespace namespace, String timerId) {
+    throw new UnsupportedOperationException("Canceling a timer by ID is not yet supported.");
   }
 
   @Override


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:
- [x] Make sure the PR title is formatted like:
  `[BEAM-<Jira issue #>] Description of pull request`
- [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
     Travis-CI on your fork and ensure the whole test matrix passes).
- [x] Replace `<Jira issue #>` in the title with the actual Jira issue
     number, if there is one.
- [x] If this contribution is large, please file an Apache
     [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).
---

I have pulled this commit out of my ongoing work to add timers to `DoFn`, specifically my branch where I add `DoFnInvoker.invokeOnTimer(<id>, ...)`.

For users, timers will have IDs. This is a step towards that API. I think it is also just better in most ways, especially for being able to delete timers without having to know exactly when it was set for.

Before this change, a timer's ID is its `TimeDomain` + `Instant`. Inlining `TimerData` for this description, I think `setTimer(TimeDomain, Instant)` is OK for setting an anonymous "wake up" as we use it today, while `deleteTimer(TimeDomain, Instant)` should be removed.

R: @tgroh and @aljoscha and @amitsela 

I am curious about runner-specific thoughts if you have any.
