### PR TITLE
[BEAM-860] Move Apache RAT license check out of release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,28 +190,9 @@
                 </execution>
               </executions>
             </plugin>
-
-            <plugin>
-              <groupId>org.apache.rat</groupId>
-              <artifactId>apache-rat-plugin</artifactId>
-              <executions>
-                <execution>
-                  <phase>verify</phase>
-                  <goals>
-                    <goal>check</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
           </plugins>
         </pluginManagement>
 
-        <plugins>
-          <plugin>
-            <groupId>org.apache.rat</groupId>
-            <artifactId>apache-rat-plugin</artifactId>
-          </plugin>
-        </plugins>
       </build>
     </profile>
 
@@ -933,6 +914,14 @@
               <exclude>**/.settings/**/*</exclude>
             </excludes>
           </configuration>
+          <executions>
+            <execution>
+              <phase>verify</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>
@@ -1211,6 +1200,10 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:
- [x] Make sure the PR title is formatted like:
  `[BEAM-<Jira issue #>] Description of pull request`
- [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
     Travis-CI on your fork and ensure the whole test matrix passes).
- [x] Replace `<Jira issue #>` in the title with the actual Jira issue
     number, if there is one.
- [x] If this contribution is large, please file an Apache
     [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).
---

Move Apache RAT license check out of release profile. It runs quickly, so can run as a part of normal mvn verify phase. Will make it so missing licenses are caught locally more easily.

Tested this locally by removing the license from a file and running 'mvn clean verify' as well as 'mvn clean verify -P release'. Now both fail, whereas previously, only 'mvn clean verify -P release' failed.

See discussion at https://github.com/apache/incubator-beam/pull/1199#issuecomment-256802048

Would you mind looking @dhalperi ? Sorry to send 100% of my two PRs so far to you, but you do have context on this one...
