### PR TITLE
[BEAM-859] Fixes a compile error in SourceRDD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1096,7 +1096,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>2.4.3</version>
         </plugin>
 
         <plugin>

--- a/runners/core-java/pom.xml
+++ b/runners/core-java/pom.xml
@@ -94,7 +94,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.1</version>
         <executions>
           <!-- In the first phase, we pick dependencies and relocate them. -->
           <execution>

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
@@ -216,8 +216,10 @@ public class SourceRDD {
     private final MicrobatchSource<T, CheckpointMarkT> microbatchSource;
     private final SparkRuntimeContext runtimeContext;
 
+    // to satisfy Scala API.
     private static final scala.collection.immutable.List<Dependency<?>> NIL =
-        scala.collection.immutable.List.empty();
+        scala.collection.JavaConversions
+            .asScalaBuffer(Collections.<Dependency<?>>emptyList()).toList();
 
     public Unbounded(SparkContext sc,
                      SparkRuntimeContext runtimeContext,


### PR DESCRIPTION
This seems to be compiler-dependent, but I replaced it with a code snippet used in the same file in another place, which compiles fine.

Example previously failing log: https://s3.amazonaws.com/archive.travis-ci.org/jobs/171221509/log.txt

2016-10-27T21:58:42.674 [ERROR] /home/travis/build/apache/incubator-beam/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java:[220] 
    scala.collection.immutable.List.empty();
                                    ^^^^^
The method empty() is ambiguous for the type List

R: @kennknowles 
