### PR TITLE
Fixes crash of shade plugin on SparkProcessContext

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkProcessContext.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkProcessContext.java
@@ -176,30 +176,31 @@ public abstract class SparkProcessContext<InputT, OutputT, ValueT>
     }
   }
 
-  static <T> WindowedValue<T> noElementWindowedValue(
-      final T output, final Instant timestamp, WindowFn<Object, ? extends BoundedWindow> windowFn) {
-    WindowFn.AssignContext assignContext = windowFn.new AssignContext() {
+  static <T, W extends BoundedWindow> WindowedValue<T> noElementWindowedValue(
+      final T output, final Instant timestamp, WindowFn<Object, W> windowFn) {
+    WindowFn<Object, W>.AssignContext assignContext =
+        windowFn.new AssignContext() {
 
-      @Override
-      public Object element() {
-        return output;
-      }
+          @Override
+          public Object element() {
+            return output;
+          }
 
-      @Override
-      public Instant timestamp() {
-        if (timestamp != null) {
-          return timestamp;
-        }
-        throw new UnsupportedOperationException("outputWithTimestamp was called with "
-            + "null timestamp.");
-      }
+          @Override
+          public Instant timestamp() {
+            if (timestamp != null) {
+              return timestamp;
+            }
+            throw new UnsupportedOperationException(
+                "outputWithTimestamp was called with " + "null timestamp.");
+          }
 
-      @Override
-      public BoundedWindow window() {
-        throw new UnsupportedOperationException("Window not available for "
-            + "start/finishBundle output.");
-      }
-    };
+          @Override
+          public BoundedWindow window() {
+            throw new UnsupportedOperationException(
+                "Window not available for " + "start/finishBundle output.");
+          }
+        };
     try {
       @SuppressWarnings("unchecked")
       Collection<? extends BoundedWindow> windows = windowFn.assignWindows(assignContext);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkProcessContext.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkProcessContext.java
@@ -176,9 +176,8 @@ public abstract class SparkProcessContext<InputT, OutputT, ValueT>
     }
   }
 
-  static <T> WindowedValue<T> noElementWindowedValue(final T output,
-                                                     final Instant timestamp,
-                                                     WindowFn<Object, ?> windowFn) {
+  static <T> WindowedValue<T> noElementWindowedValue(
+      final T output, final Instant timestamp, WindowFn<Object, ? extends BoundedWindow> windowFn) {
     WindowFn.AssignContext assignContext = windowFn.new AssignContext() {
 
       @Override


### PR DESCRIPTION
Error discovered by debugging the Maven plugin itself
(using mvnDebug) and setting a breakpoint for the exception
and then inspecting the call stack to spot a weird-looking
method signature descriptor:

`Lorg/apache/beam/sdk/transforms/windowing/WindowFn<Ljava/lang/Object;!*>.AssignContext;`

(note the exclamation mark, which is an invalid character AFAIK!
I have no idea where it came from, but the current change makes it go away)

R: @dhalperi 
CC: @amitsela 