### PR TITLE
[BEAM-875] Consistency of time types across runners for BQ

### DIFF
--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -821,27 +821,36 @@ class BigQueryWrapper(object):
       # return True for both!).
       value = from_json_value(cell.v)
       if field.type == 'STRING':
+        # Input: "XYZ" --> Output: "XYZ"
         value = value
       elif field.type == 'BOOLEAN':
+        # Input: "true" --> Output: True
         value = value == 'true'
       elif field.type == 'INTEGER':
+        # Input: "123" --> Output: 123
         value = int(value)
       elif field.type == 'FLOAT':
+        # Input: "1.23" --> Output: 1.23
         value = float(value)
       elif field.type == 'TIMESTAMP':
         # The UTC should come from the timezone library but this is a known
         # issue in python 2.7 so we'll just hardcode it as we're reading using
         # utcfromtimestamp. This is just to match the output from the dataflow
         # runner with the local runner.
+        # Input: 1478134176.985864 --> Output: "2016-11-03 00:49:36.985864 UTC"
         dt = datetime.datetime.utcfromtimestamp(float(value))
         value = dt.strftime('%Y-%m-%d %H:%M:%S.%f UTC')
       elif field.type == 'BYTES':
+        # Input: "YmJi" --> Output: "YmJi"
         value = value
       elif field.type == 'DATE':
+        # Input: "2016-11-03" --> Output: "2016-11-03"
         value = value
       elif field.type == 'DATETIME':
+        # Input: "2016-11-03T00:49:36" --> Output: "2016-11-03T00:49:36"
         value = value
       elif field.type == 'TIME':
+        # Input: "00:49:36" --> Output: "00:49:36"
         value = value
       else:
         # Note that a schema field object supports also a RECORD type. However

--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -108,6 +108,7 @@ import json
 import logging
 import re
 import time
+import datetime
 import uuid
 
 from apitools.base.py.exceptions import HttpError
@@ -828,8 +829,19 @@ class BigQueryWrapper(object):
       elif field.type == 'FLOAT':
         value = float(value)
       elif field.type == 'TIMESTAMP':
-        value = float(value)
+        # The UTC should come from the timezone library but this is a known
+        # issue in python 2.7 so we'll just hardcode it as we're reading using
+        # utcfromtimestamp. This is just to match the output from the dataflow
+        # runner with the local runner.
+        dt = datetime.datetime.utcfromtimestamp(float(value))
+        value = dt.strftime('%Y-%m-%d %H:%M:%S.%f UTC')
       elif field.type == 'BYTES':
+        value = value
+      elif field.type == 'DATE':
+        value = value
+      elif field.type == 'DATETIME':
+        value = value
+      elif field.type == 'TIME':
         value = value
       else:
         # Note that a schema field object supports also a RECORD type. However

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -20,6 +20,7 @@
 import json
 import logging
 import time
+import datetime
 import unittest
 
 from apitools.base.py.exceptions import HttpError
@@ -177,9 +178,25 @@ class TestBigQueryReader(unittest.TestCase):
 
   def get_test_rows(self):
     now = time.time()
+    dt = datetime.datetime.utcfromtimestamp(float(now))
+    ts = dt.strftime('%Y-%m-%d %H:%M:%S.%f UTC')
     expected_rows = [
-        {'i': 1, 's': 'abc', 'f': 2.3, 'b': True, 't': now},
-        {'i': 10, 's': 'xyz', 'f': -3.14, 'b': False}]
+        {
+            'i': 1,
+            's': 'abc',
+            'f': 2.3,
+            'b': True,
+            't': ts,
+            'dt': '2016-10-31',
+            'ts': '22:39:12.627498',
+            'dt_ts': '2008-12-25T07:30:00'
+        },
+        {
+            'i': 10,
+            's': 'xyz',
+            'f': -3.14,
+            'b': False
+        }]
     schema = bigquery.TableSchema(
         fields=[
             bigquery.TableFieldSchema(
@@ -191,7 +208,13 @@ class TestBigQueryReader(unittest.TestCase):
             bigquery.TableFieldSchema(
                 name='s', type='STRING', mode='REQUIRED'),
             bigquery.TableFieldSchema(
-                name='t', type='TIMESTAMP', mode='NULLABLE')])
+                name='t', type='TIMESTAMP', mode='NULLABLE'),
+            bigquery.TableFieldSchema(
+                name='dt', type='DATE', mode='NULLABLE'),
+            bigquery.TableFieldSchema(
+                name='ts', type='TIME', mode='NULLABLE'),
+            bigquery.TableFieldSchema(
+                name='dt_ts', type='DATETIME', mode='NULLABLE')])
     table_rows = [
         bigquery.TableRow(f=[
             bigquery.TableCell(v=to_json_value('true')),
@@ -200,12 +223,18 @@ class TestBigQueryReader(unittest.TestCase):
             bigquery.TableCell(v=to_json_value('abc')),
             # For timestamps cannot use str() because it will truncate the
             # number representing the timestamp.
-            bigquery.TableCell(v=to_json_value('%f' % now))]),
+            bigquery.TableCell(v=to_json_value('%f' % now)),
+            bigquery.TableCell(v=to_json_value('2016-10-31')),
+            bigquery.TableCell(v=to_json_value('22:39:12.627498')),
+            bigquery.TableCell(v=to_json_value('2008-12-25T07:30:00'))]),
         bigquery.TableRow(f=[
             bigquery.TableCell(v=to_json_value('false')),
             bigquery.TableCell(v=to_json_value(str(-3.14))),
             bigquery.TableCell(v=to_json_value(str(10))),
             bigquery.TableCell(v=to_json_value('xyz')),
+            bigquery.TableCell(v=None),
+            bigquery.TableCell(v=None),
+            bigquery.TableCell(v=None),
             bigquery.TableCell(v=None)])]
     return table_rows, schema, expected_rows
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Time related datatypes were not all supported for the local runner as well as timestamps were being serialized different so changing the local runner to match the big query export environment now. 

R: @chamikaramj 