### PR TITLE
Remove false/crashing "backwards compatibility" from Sink

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Sink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Sink.java
@@ -214,9 +214,7 @@ public abstract class Sink<T> implements Serializable, HasDisplayData {
     /**
      * Returns a coder for the writer result type.
      */
-    public Coder<WriteT> getWriterResultCoder() {
-      return null;
-    }
+    public abstract Coder<WriteT> getWriterResultCoder();
   }
 
   /**


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @dhalperi 

From http://stackoverflow.com/questions/40384347/google-dataflow-java-lang-illegalargumentexception-cannot-setcodernull.

Perhaps this was put in there to avoid giving people compile errors, though the backwards compatibility is false. If they use `Write` this method is always called and always causes a crash unless overridden.