### PR TITLE
[BEAM-822] Move the separate package-info.java compile to java7 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,8 @@
     <woodstox.version>4.4.1</woodstox.version>
     
     <compiler.error.flag>-Werror</compiler.error.flag>
+    <compiler.default.pkginfo.flag>-Xpkginfo:always</compiler.default.pkginfo.flag>
+    <compiler.default.exclude>nothing</compiler.default.exclude>
   </properties>
 
   <packaging>pom</packaging>
@@ -223,6 +225,48 @@
       <properties>
         <beam.javadoc_opts>-Xdoclint:-missing</beam.javadoc_opts>
       </properties>
+    </profile>
+    <profile>
+      <id>java7-packageinfo</id>
+      <activation>
+        <jdk>1.7</jdk>
+      </activation>
+      <properties>
+        <!--
+         Exclude package-info.java from main compilation to work around
+         https://jira.codehaus.org/browse/MCOMPILER-205
+         -->
+        <compiler.default.pkginfo.flag>-Xpkginfo:legacy</compiler.default.pkginfo.flag>
+        <compiler.default.exclude>**/package-info.java</compiler.default.exclude>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <!--
+               Compile just package-info.java to avoid
+               https://bugs.openjdk.java.net/browse/JDK-8022161
+               -->
+              <execution>
+                <id>compile-package-info</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <compilerArgs>
+                    <arg>-Xpkginfo:always</arg>
+                  </compilerArgs>
+                  <includes>
+                    <include>**/package-info.java</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -832,10 +876,6 @@
           </configuration>
           <executions>
 
-            <!--
-              Exclude package-info.java from main compilation to work around
-              https://jira.codehaus.org/browse/MCOMPILER-205
-            -->
             <execution>
               <id>default-compile</id>
               <goals>
@@ -843,29 +883,12 @@
               </goals>
               <phase>compile</phase>
               <configuration>
-                <excludes>
-                  <exclude>**/package-info.java</exclude>
-                </excludes>
-              </configuration>
-            </execution>
-
-            <!-- 
-              Compile just package-info.java to avoid 
-              https://bugs.openjdk.java.net/browse/JDK-8022161
-            -->
-            <execution>
-              <id>compile-package-info</id>
-              <goals>
-                <goal>compile</goal>
-              </goals>
-              <phase>compile</phase>
-              <configuration>
                 <compilerArgs>
-                  <arg>-Xpkginfo:always</arg>
+                  <arg>${compiler.default.pkginfo.flag}</arg>
                 </compilerArgs>
-                <includes>
-                  <include>**/package-info.java</include>
-                </includes>
+                <excludes>
+                  <exclude>${compiler.default.exclude}</exclude>
+                </excludes>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Move the separate package-info.java compile to java7 profile since it's not needed with java8
This fixes compiling in Eclipse (assuming Neon which require java8)
Slightly speeds up Java8 compile (one invoke of compiler plugin)