### PR TITLE
[BEAM-896] adjust ReadSourceITCase to exclude Beam temporary files

### DIFF
--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/ReadSourceITCase.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/ReadSourceITCase.java
@@ -55,7 +55,8 @@ public class ReadSourceITCase extends JavaProgramTestBase {
 
   @Override
   protected void postSubmit() throws Exception {
-    compareResultsByLinesInMemory(Joiner.on('\n').join(EXPECTED_RESULT), resultPath);
+    compareResultsByLinesInMemory(Joiner.on('\n')
+        .join(EXPECTED_RESULT), resultPath, new String[] {"temp-beam-"});
   }
 
   @Override


### PR DESCRIPTION
This should fix the test failures in `ReadSourceITCase` caused by #1050.

@dhalperi Wouldn't it be nice to have the temporary folder prefix somewhere accessible as a static variable?

