### PR TITLE
[BEAM-939] Use the credentials from GcpOptions instead of relying on BigtableOptions

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -27,6 +27,8 @@ import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.RowFilter;
 import com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.CredentialOptions;
+import com.google.cloud.bigtable.config.CredentialOptions.CredentialType;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -49,11 +51,13 @@ import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
 import org.apache.beam.sdk.io.range.ByteKey;
 import org.apache.beam.sdk.io.range.ByteKeyRange;
 import org.apache.beam.sdk.io.range.ByteKeyRangeTracker;
+import org.apache.beam.sdk.options.GcpOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.ReleaseInfo;
 import org.apache.beam.sdk.values.KV;
@@ -283,7 +287,12 @@ public class BigtableIO {
     @Override
     public PCollection<Row> apply(PBegin input) {
       BigtableSource source =
-          new BigtableSource(getBigtableService(), tableId, filter, keyRange, null);
+          new BigtableSource(new SerializableFunction<PipelineOptions, BigtableService>() {
+            @Override
+            public BigtableService apply(PipelineOptions options) {
+              return getBigtableService(options);
+            }
+          }, tableId, filter, keyRange, null);
       return input.getPipeline().apply(org.apache.beam.sdk.io.Read.from(source));
     }
 
@@ -293,7 +302,9 @@ public class BigtableIO {
       checkArgument(!tableId.isEmpty(), "Table ID not specified");
       try {
         checkArgument(
-            getBigtableService().tableExists(tableId), "Table %s does not exist", tableId);
+            getBigtableService(input.getPipeline().getOptions()).tableExists(tableId),
+            "Table %s does not exist",
+            tableId);
       } catch (IOException e) {
         logger.warn("Error checking whether table {} exists; proceeding.", tableId, e);
       }
@@ -373,11 +384,17 @@ public class BigtableIO {
      * {@link #withBigtableService} or creates and returns an implementation that talks to
      * {@code Cloud Bigtable}.
      */
-    private BigtableService getBigtableService() {
+    private BigtableService getBigtableService(PipelineOptions pipelineOptions) {
       if (bigtableService != null) {
         return bigtableService;
       }
-      return new BigtableServiceImpl(options);
+      BigtableOptions.Builder clonedOptions = options.toBuilder();
+      if (options.getCredentialOptions().getCredentialType() == CredentialType.DefaultCredentials) {
+        clonedOptions.setCredentialOptions(
+            CredentialOptions.credential(
+                pipelineOptions.as(GcpOptions.class).getGcpCredential()));
+      }
+      return new BigtableServiceImpl(clonedOptions.build());
     }
   }
 
@@ -479,7 +496,13 @@ public class BigtableIO {
 
     @Override
     public PDone apply(PCollection<KV<ByteString, Iterable<Mutation>>> input) {
-      input.apply(ParDo.of(new BigtableWriterFn(tableId, getBigtableService())));
+      input.apply(ParDo.of(new BigtableWriterFn(tableId,
+          new SerializableFunction<PipelineOptions, BigtableService>() {
+        @Override
+        public BigtableService apply(PipelineOptions options) {
+          return getBigtableService(options);
+        }
+      })));
       return PDone.in(input.getPipeline());
     }
 
@@ -489,7 +512,9 @@ public class BigtableIO {
       checkArgument(!tableId.isEmpty(), "Table ID not specified");
       try {
         checkArgument(
-            getBigtableService().tableExists(tableId), "Table %s does not exist", tableId);
+            getBigtableService(input.getPipeline().getOptions()).tableExists(tableId),
+            "Table %s does not exist",
+            tableId);
       } catch (IOException e) {
         logger.warn("Error checking whether table {} exists; proceeding.", tableId, e);
       }
@@ -534,28 +559,35 @@ public class BigtableIO {
      * {@link #withBigtableService} or creates and returns an implementation that talks to
      * {@code Cloud Bigtable}.
      */
-    private BigtableService getBigtableService() {
+    private BigtableService getBigtableService(PipelineOptions pipelineOptions) {
       if (bigtableService != null) {
         return bigtableService;
       }
-      return new BigtableServiceImpl(options);
+      BigtableOptions.Builder clonedOptions = options.toBuilder();
+      if (options.getCredentialOptions().getCredentialType() == CredentialType.DefaultCredentials) {
+        clonedOptions.setCredentialOptions(
+            CredentialOptions.credential(
+                pipelineOptions.as(GcpOptions.class).getGcpCredential()));
+      }
+      return new BigtableServiceImpl(clonedOptions.build());
     }
 
     private class BigtableWriterFn extends DoFn<KV<ByteString, Iterable<Mutation>>, Void> {
 
-      public BigtableWriterFn(String tableId, BigtableService bigtableService) {
+      public BigtableWriterFn(String tableId,
+          SerializableFunction<PipelineOptions, BigtableService> bigtableServiceFactory) {
         this.tableId = checkNotNull(tableId, "tableId");
-        this.bigtableService = checkNotNull(bigtableService, "bigtableService");
+        this.bigtableServiceFactory =
+            checkNotNull(bigtableServiceFactory, "bigtableServiceFactory");
         this.failures = new ConcurrentLinkedQueue<>();
       }
 
-      @Setup
-      public void setup() throws Exception {
-        bigtableWriter = bigtableService.openForWriting(tableId);
-      }
-
       @StartBundle
-      public void startBundle(Context c) {
+      public void startBundle(Context c) throws IOException {
+        if (bigtableWriter == null) {
+          bigtableWriter = bigtableServiceFactory.apply(
+              c.getPipelineOptions()).openForWriting(tableId);
+        }
         recordsWritten = 0;
       }
 
@@ -587,7 +619,7 @@ public class BigtableIO {
 
       ///////////////////////////////////////////////////////////////////////////////
       private final String tableId;
-      private final BigtableService bigtableService;
+      private final SerializableFunction<PipelineOptions, BigtableService> bigtableServiceFactory;
       private BigtableService.Writer bigtableWriter;
       private long recordsWritten;
       private final ConcurrentLinkedQueue<BigtableWriteException> failures;
@@ -645,12 +677,12 @@ public class BigtableIO {
 
   static class BigtableSource extends BoundedSource<Row> {
     public BigtableSource(
-        BigtableService service,
+        SerializableFunction<PipelineOptions, BigtableService> serviceFactory,
         String tableId,
         @Nullable RowFilter filter,
         ByteKeyRange range,
         @Nullable Long estimatedSizeBytes) {
-      this.service = service;
+      this.serviceFactory = serviceFactory;
       this.tableId = tableId;
       this.filter = filter;
       this.range = range;
@@ -668,7 +700,7 @@ public class BigtableIO {
     }
 
     ////// Private state and internal implementation details //////
-    private final BigtableService service;
+    private final SerializableFunction<PipelineOptions, BigtableService> serviceFactory;
     private final String tableId;
     @Nullable private final RowFilter filter;
     private final ByteKeyRange range;
@@ -678,18 +710,18 @@ public class BigtableIO {
     protected BigtableSource withStartKey(ByteKey startKey) {
       checkNotNull(startKey, "startKey");
       return new BigtableSource(
-          service, tableId, filter, range.withStartKey(startKey), estimatedSizeBytes);
+          serviceFactory, tableId, filter, range.withStartKey(startKey), estimatedSizeBytes);
     }
 
     protected BigtableSource withEndKey(ByteKey endKey) {
       checkNotNull(endKey, "endKey");
       return new BigtableSource(
-          service, tableId, filter, range.withEndKey(endKey), estimatedSizeBytes);
+          serviceFactory, tableId, filter, range.withEndKey(endKey), estimatedSizeBytes);
     }
 
     protected BigtableSource withEstimatedSizeBytes(Long estimatedSizeBytes) {
       checkNotNull(estimatedSizeBytes, "estimatedSizeBytes");
-      return new BigtableSource(service, tableId, filter, range, estimatedSizeBytes);
+      return new BigtableSource(serviceFactory, tableId, filter, range, estimatedSizeBytes);
     }
 
     /**
@@ -697,8 +729,9 @@ public class BigtableIO {
      * boundaries and estimated sizes. We can use these samples to ensure that splits are on
      * different tablets, and possibly generate sub-splits within tablets.
      */
-    private List<SampleRowKeysResponse> getSampleRowKeys() throws IOException {
-      return service.getSampleRowKeys(this);
+    private List<SampleRowKeysResponse> getSampleRowKeys(PipelineOptions pipelineOptions)
+        throws IOException {
+      return serviceFactory.apply(pipelineOptions).getSampleRowKeys(this);
     }
 
     @Override
@@ -712,7 +745,7 @@ public class BigtableIO {
           Math.max(sizeEstimate / maximumNumberOfSplits, desiredBundleSizeBytes);
 
       // Delegate to testable helper.
-      return splitIntoBundlesBasedOnSamples(desiredBundleSizeBytes, getSampleRowKeys());
+      return splitIntoBundlesBasedOnSamples(desiredBundleSizeBytes, getSampleRowKeys(options));
     }
 
     /** Helper that splits this source into bundles based on Cloud Bigtable sampled row keys. */
@@ -798,7 +831,7 @@ public class BigtableIO {
     public long getEstimatedSizeBytes(PipelineOptions options) throws IOException {
       // Delegate to testable helper.
       if (estimatedSizeBytes == null) {
-        estimatedSizeBytes = getEstimatedSizeBytesBasedOnSamples(getSampleRowKeys());
+        estimatedSizeBytes = getEstimatedSizeBytesBasedOnSamples(getSampleRowKeys(options));
       }
       return estimatedSizeBytes;
     }
@@ -840,7 +873,7 @@ public class BigtableIO {
 
     @Override
     public BoundedReader<Row> createReader(PipelineOptions options) throws IOException {
-      return new BigtableReader(this, service);
+      return new BigtableReader(this, serviceFactory.apply(options));
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.config.CredentialOptions.CredentialType;
 import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
@@ -383,8 +384,12 @@ public class BigtableIO {
      * Helper function that either returns the mock Bigtable service supplied by
      * {@link #withBigtableService} or creates and returns an implementation that talks to
      * {@code Cloud Bigtable}.
+     *
+     * <p>Also populate the credentials option from {@link GcpOptions#getGcpCredential()} if the
+     * default credentials are being used on {@link BigtableOptions}.
      */
-    private BigtableService getBigtableService(PipelineOptions pipelineOptions) {
+    @VisibleForTesting
+    BigtableService getBigtableService(PipelineOptions pipelineOptions) {
       if (bigtableService != null) {
         return bigtableService;
       }
@@ -558,8 +563,12 @@ public class BigtableIO {
      * Helper function that either returns the mock Bigtable service supplied by
      * {@link #withBigtableService} or creates and returns an implementation that talks to
      * {@code Cloud Bigtable}.
+     *
+     * <p>Also populate the credentials option from {@link GcpOptions#getGcpCredential()} if the
+     * default credentials are being used on {@link BigtableOptions}.
      */
-    private BigtableService getBigtableService(PipelineOptions pipelineOptions) {
+    @VisibleForTesting
+    BigtableService getBigtableService(PipelineOptions pipelineOptions) {
       if (bigtableService != null) {
         return bigtableService;
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
@@ -21,6 +21,7 @@ import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
@@ -92,6 +93,11 @@ interface BigtableService extends Serializable {
      */
     Row getCurrentRow() throws NoSuchElementException;
   }
+
+  /**
+   * Returns the BigtableOptions used to configure this BigtableService.
+   */
+  BigtableOptions getBigtableOptions();
 
   /**
    * Returns {@code true} if the table with the give name exists.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -61,6 +61,11 @@ class BigtableServiceImpl implements BigtableService {
   private final BigtableOptions options;
 
   @Override
+  public BigtableOptions getBigtableOptions() {
+    return options;
+  }
+
+  @Override
   public BigtableWriterImpl openForWriting(String tableId) throws IOException {
     BigtableSession session = new BigtableSession(options);
     BigtableTableName tableName = options.getInstanceName().toTableName(tableId);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This allows for us to create a version of the service depending on the PipelineOptions passed in at this time. This uses a function which takes in the contextual PipelineOptions and creates a service from it allowing us to not serialize the Credentials within the BigtableOptions.