### PR TITLE
fix exception during formatting

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -715,7 +715,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
       } else {
         // If it was an unknown type encoded as an array, be conservative and assume
         // that we don't know anything about the order.
-        reportError(context, "encoding %s as an ARRAY was unexpected");
+        reportError(context, "encoding %s as an ARRAY was unexpected", type);
         return;
       }
 


### PR DESCRIPTION
reportError make internal string formatting and sometime return error
because can't find args for pattern.

java.util.MissingFormatArgumentException: Format specifier '%s'