### PR TITLE
Remove tox cache from previous workspace

### DIFF
--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -31,6 +31,9 @@ set -v
 # pip install --user installation location.
 LOCAL_PATH=$HOME/.local/bin/
 
+#Remove any tox cache from previous workspace
+rm -rf sdks/python/.tox
+
 # INFRA does not install virtualenv
 pip install virtualenv --user
 

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -31,7 +31,7 @@ set -v
 # pip install --user installation location.
 LOCAL_PATH=$HOME/.local/bin/
 
-#Remove any tox cache from previous workspace
+# Remove any tox cache from previous workspace
 rm -rf sdks/python/.tox
 
 # INFRA does not install virtualenv


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Jenkins doesn't cleanup the previous workspace and since .tox is in the gitignore, explicitly deleting it.
