### PR TITLE
[BEAM-802] -- Add ability to stage a job and/or stop the execution

### DIFF
--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -59,7 +59,6 @@ class WordExtractingDoFn(beam.DoFn):
 
 def run(argv=None):
   """Main entry point; defines and runs the wordcount pipeline."""
-
   parser = argparse.ArgumentParser()
   parser.add_argument('--input',
                       dest='input',

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -411,7 +411,7 @@ class DataflowApplicationClient(object):
       self.stage_file(gcs_or_local_path, file_name, StringIO(job.json()))
 
     if not template_location:
-      self.submit_job_description()
+      return self.submit_job_description()
 
   def create_job_description(self, job):
     """Creates a job described by the workflow proto."""

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -327,6 +327,9 @@ class Job(object):
     self.base64_str_re = re.compile(r'^[A-Za-z0-9+/]*=*$')
     self.coder_str_re = re.compile(r'^([A-Za-z]+\$)([A-Za-z0-9+/]*=*)$')
 
+  def json(self):
+    return encoding.MessageToJson(self.proto)
+
 
 class DataflowApplicationClient(object):
   """A Dataflow API client used by application code to create and query jobs."""
@@ -405,7 +408,7 @@ class DataflowApplicationClient(object):
     if job_location:
       gcs_or_local_path = os.path.dirname(job_location)
       file_name = os.path.basename(job_location)
-      self.stage_file(gcs_or_local_path, file_name, StringIO(str(job)))
+      self.stage_file(gcs_or_local_path, file_name, StringIO(job.json()))
 
     if not template_location:
       self.send_job_description()

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -395,7 +395,8 @@ class DataflowApplicationClient(object):
   @retry.no_retries  # Using no_retries marks this as an integration point.
   def create_job(self, job, pipeline_options):
     """Creates a job description.
-    Additionally, it may stage it and/or submit it for remote execution."""
+    Additionally, it may stage it and/or submit it for remote execution.
+    """
     self.create_job_description(job)
 
     # Stage and submit the job when necessary

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -393,16 +393,16 @@ class DataflowApplicationClient(object):
 
   # TODO(silviuc): Refactor so that retry logic can be applied.
   @retry.no_retries  # Using no_retries marks this as an integration point.
-  def create_job(self, job, pipeline_options):
+  def create_job(self, job):
     """Creates a job description.
     Additionally, it may stage it and/or submit it for remote execution.
     """
     self.create_job_description(job)
 
     # Stage and submit the job when necessary
-    dataflow_job_file = pipeline_options.view_as(DebugOptions).dataflow_job_file
+    dataflow_job_file = job.options.view_as(DebugOptions).dataflow_job_file
     template_location = (
-        pipeline_options.view_as(GoogleCloudOptions).template_location)
+        job.options.view_as(GoogleCloudOptions).template_location)
 
     job_location = template_location or dataflow_job_file
     if job_location:

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -21,11 +21,10 @@ import codecs
 import json
 import logging
 import os
-
-from StringIO import StringIO
-
 import re
 import time
+
+from StringIO import StringIO
 
 from apitools.base.py import encoding
 from apitools.base.py import exceptions
@@ -411,7 +410,7 @@ class DataflowApplicationClient(object):
       self.stage_file(gcs_or_local_path, file_name, StringIO(job.json()))
 
     if not template_location:
-      self.send_job_description()
+      self.submit_job_description()
 
   def create_job_description(self, job):
     """Creates a job described by the workflow proto."""
@@ -423,7 +422,7 @@ class DataflowApplicationClient(object):
     # TODO(silviuc): Remove the debug logging eventually.
     logging.info('JOB: %s', job)
 
-  def send_job_description(self):
+  def submit_job_description(self):
     """Creates and excutes a job request."""
     request = dataflow.DataflowProjectsJobsCreateRequest()
     request.projectId = self.google_cloud_options.project

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -28,6 +28,7 @@ from StringIO import StringIO
 
 from apitools.base.py import encoding
 from apitools.base.py import exceptions
+
 from apache_beam import utils
 from apache_beam.internal.auth import get_service_credentials
 from apache_beam.internal.json_value import to_json_value

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -412,6 +412,8 @@ class DataflowApplicationClient(object):
 
     if not template_location:
       return self.submit_job_description()
+    else:
+      return None
 
   def create_job_description(self, job):
     """Creates a job described by the workflow proto."""

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -400,20 +400,14 @@ class DataflowApplicationClient(object):
     dataflow_job_file = pipeline_options.view_as(DebugOptions).dataflow_job_file
     template_location = (
         pipeline_options.view_as(GoogleCloudOptions).template_location)
-    if template_location:
-      if dataflow_job_file:
-        raise RuntimeError(
-            '--dataflow_job_file and --template_location '
-            'are mutually exclusive.')
-      gcs_or_local_path = os.path.dirname(template_location)
-      file_name = os.path.basename(template_location)
+
+    job_location = template_location or dataflow_job_file
+    if job_location:
+      gcs_or_local_path = os.path.dirname(job_location)
+      file_name = os.path.basename(job_location)
       self.stage_file(gcs_or_local_path, file_name, StringIO(str(job)))
-    elif dataflow_job_file:
-      gcs_or_local_path = os.path.dirname(dataflow_job_file)
-      file_name = os.path.basename(dataflow_job_file)
-      self.stage_file(gcs_or_local_path, file_name, StringIO(str(job)))
-      self.send_job_description()
-    else:
+
+    if not template_location:
       self.send_job_description()
 
   def create_job_description(self, job):

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -21,8 +21,7 @@ import codecs
 import json
 import logging
 import os
-from os.path import dirname
-from os.path import basename
+
 from StringIO import StringIO
 
 import re
@@ -406,12 +405,12 @@ class DataflowApplicationClient(object):
         raise RuntimeError(
             '--dataflow_job_file and --template_location '
             'are mutually exclusive.')
-      gcs_or_local_path = dirname(template_location)
-      file_name = basename(template_location)
+      gcs_or_local_path = os.path.dirname(template_location)
+      file_name = os.path.basename(template_location)
       self.stage_file(gcs_or_local_path, file_name, StringIO(str(job)))
     elif dataflow_job_file:
-      gcs_or_local_path = dirname(dataflow_job_file)
-      file_name = basename(dataflow_job_file)
+      gcs_or_local_path = os.path.dirname(dataflow_job_file)
+      file_name = os.path.basename(dataflow_job_file)
       self.stage_file(gcs_or_local_path, file_name, StringIO(str(job)))
       self.send_job_description()
     else:

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -417,7 +417,7 @@ class DataflowApplicationClient(object):
     else:
       self.send_job_description()
 
-  def create_job_description(self, job):  # NEW
+  def create_job_description(self, job):
     """Creates a job described by the workflow proto."""
     resources = dependency.stage_job_resources(
         job.options, file_copy=self._gcs_file_copy)

--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -159,10 +159,12 @@ class DataflowPipelineRunner(PipelineRunner):
     # Import here to avoid adding the dependency for local running scenarios.
     # pylint: disable=wrong-import-order, wrong-import-position
     from apache_beam.internal import apiclient
+
+    # Get a Dataflow API client and set its options
     self.job = apiclient.Job(pipeline.options)
+
     # The superclass's run will trigger a traversal of all reachable nodes.
     super(DataflowPipelineRunner, self).run(pipeline)
-    # Get a Dataflow API client and submit the job.
     standard_options = pipeline.options.view_as(StandardOptions)
     if standard_options.streaming:
       job_version = DataflowPipelineRunner.STREAMING_ENVIRONMENT_MAJOR_VERSION
@@ -170,8 +172,10 @@ class DataflowPipelineRunner(PipelineRunner):
       job_version = DataflowPipelineRunner.BATCH_ENVIRONMENT_MAJOR_VERSION
     self.dataflow_client = apiclient.DataflowApplicationClient(
         pipeline.options, job_version)
+
+    # Create the job
     self.result = DataflowPipelineResult(
-        self.dataflow_client.create_job(self.job))
+        self.dataflow_client.create_job(self.job, pipeline.options))
 
     if self.blocking:
       thread = threading.Thread(

--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -159,17 +159,18 @@ class DataflowPipelineRunner(PipelineRunner):
     # Import here to avoid adding the dependency for local running scenarios.
     # pylint: disable=wrong-import-order, wrong-import-position
     from apache_beam.internal import apiclient
-
-    # Get a Dataflow API client and set its options
     self.job = apiclient.Job(pipeline.options)
 
     # The superclass's run will trigger a traversal of all reachable nodes.
     super(DataflowPipelineRunner, self).run(pipeline)
+
     standard_options = pipeline.options.view_as(StandardOptions)
     if standard_options.streaming:
       job_version = DataflowPipelineRunner.STREAMING_ENVIRONMENT_MAJOR_VERSION
     else:
       job_version = DataflowPipelineRunner.BATCH_ENVIRONMENT_MAJOR_VERSION
+
+    # Get a Dataflow API client and set its options
     self.dataflow_client = apiclient.DataflowApplicationClient(
         pipeline.options, job_version)
 

--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -178,7 +178,7 @@ class DataflowPipelineRunner(PipelineRunner):
     self.result = DataflowPipelineResult(
         self.dataflow_client.create_job(self.job))
 
-    if self.blocking:
+    if self.result.has_job and self.blocking:
       thread = threading.Thread(
           target=DataflowPipelineRunner.poll_for_job_completion,
           args=(self, self.result.job_id()))
@@ -656,6 +656,10 @@ class DataflowPipelineResult(PipelineResult):
 
   def job_id(self):
     return self._job.id
+
+  @property
+  def has_job(self):
+    return self._job is not None
 
   def current_state(self):
     """Return the current state of the remote job.

--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -176,7 +176,7 @@ class DataflowPipelineRunner(PipelineRunner):
 
     # Create the job
     self.result = DataflowPipelineResult(
-        self.dataflow_client.create_job(self.job, pipeline.options))
+        self.dataflow_client.create_job(self.job))
 
     if self.blocking:
       thread = threading.Thread(

--- a/sdks/python/apache_beam/template_runner_test.py
+++ b/sdks/python/apache_beam/template_runner_test.py
@@ -34,25 +34,22 @@ from apache_beam.internal import apiclient
 class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
   """TemplatingDataflow integration tests."""
   def test_full_completion(self):
-    dummy_sdk_file = tempfile.NamedTemporaryFile()
+    dummy_file = tempfile.NamedTemporaryFile()
+    dummy_dir = tempfile.mkdtemp()
 
     remote_runner = DataflowPipelineRunner()
     pipeline = Pipeline(remote_runner,
                         options=PipelineOptions([
                             '--dataflow_endpoint=ignored',
-                            '--sdk_location=' + dummy_sdk_file.name,
+                            '--sdk_location=' + dummy_file.name,
                             '--job_name=test-job',
                             '--project=test-project',
-                            '--staging_location=ignored',
+                            '--staging_location=' + dummy_dir,
                             '--temp_location=/dev/null',
-                            '--template_location=/tmp/template-file',
+                            '--template_location=' + dummy_file.name,
                             '--no_auth=True']))
-    try:
-      os.remove('/tmp/template-file')
-    except OSError as err:
-      print err
     pipeline.run()
-    with open('/tmp/template-file') as template_file:
+    with open(dummy_file.name) as template_file:
       saved_job_dict = json.load(template_file)
       self.assertEqual(
           saved_job_dict['environment']['sdkPipelineOptions']

--- a/sdks/python/apache_beam/template_runner_test.py
+++ b/sdks/python/apache_beam/template_runner_test.py
@@ -52,15 +52,14 @@ class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
     except OSError as err:
       print err
     pipeline.run()
-
     with open('/tmp/template-file') as template_file:
-      saved_job_dict = json.load(template_file) # BETTER
+      saved_job_dict = json.load(template_file)
       self.assertEqual(
-          saved_job_dict['environment']['sdkPipelineOptions']['project'],
-          'test-project')
+          saved_job_dict['environment']['sdkPipelineOptions']
+          ['options']['project'], 'test-project')
       self.assertEqual(
-          saved_job_dict['environment']['sdkPipelineOptions']['job_name'],
-          'test-job')
+          saved_job_dict['environment']['sdkPipelineOptions']
+          ['options']['job_name'], 'test-job')
 
   def test_bad_path(self):
     dummy_sdk_file = tempfile.NamedTemporaryFile()

--- a/sdks/python/apache_beam/template_runner_test.py
+++ b/sdks/python/apache_beam/template_runner_test.py
@@ -19,7 +19,6 @@
 
 from __future__ import absolute_import
 
-import os
 import json
 import unittest
 import tempfile

--- a/sdks/python/apache_beam/template_runner_test.py
+++ b/sdks/python/apache_beam/template_runner_test.py
@@ -1,0 +1,76 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration tests for templated pipelines."""
+
+from __future__ import absolute_import
+
+import json
+import unittest
+
+# import apache_beam as beam
+from apache_beam.pipeline import Pipeline
+from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
+from apache_beam.utils.options import PipelineOptions
+from apache_beam.internal import apiclient
+
+
+class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
+  """TemplatingDataflow integration tests."""
+  def test_full_completion(self):
+    remote_runner = DataflowPipelineRunner()
+    pipeline = Pipeline(remote_runner,
+                        options=PipelineOptions([
+                            '--dataflow_endpoint=ignored',
+                            '--job_name=test-job',
+                            '--project=test-project',
+                            '--staging_location=ignored',
+                            '--temp_location=/dev/null',
+                            '--template_location=/tmp/test-file',
+                            '--no_auth=True']))
+    remote_runner.job = apiclient.Job(pipeline.options)
+    remote_runner.run(pipeline)
+
+    with open('/tmp/test-file') as template_file:
+      saved_job_dict = json.loads(template_file.read())
+      self.assertEqual(
+          saved_job_dict['environment']['sdkPipelineOptions']['project'],
+          'test-project')
+      self.assertEqual(
+          saved_job_dict['environment']['sdkPipelineOptions']['job_name'],
+          'test-job')
+
+  def test_bad_path(self):
+    remote_runner = DataflowPipelineRunner()
+    pipeline = Pipeline(remote_runner,
+                        options=PipelineOptions([
+                            '--dataflow_endpoint=ignored',
+                            '--job_name=test-job',
+                            '--project=test-project',
+                            '--staging_location=ignored',
+                            '--temp_location=/dev/null',
+                            '--template_location=/bad/path',
+                            '--no_auth=True']))
+    remote_runner.job = apiclient.Job(pipeline.options)
+
+    with self.assertRaises(IOError):
+      remote_runner.run(pipeline)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/template_runner_test.py
+++ b/sdks/python/apache_beam/template_runner_test.py
@@ -23,7 +23,7 @@ import json
 import unittest
 import tempfile
 
-# import apache_beam as beam
+import apache_beam as beam
 from apache_beam.pipeline import Pipeline
 from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
 from apache_beam.utils.options import PipelineOptions
@@ -47,6 +47,8 @@ class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
                             '--temp_location=/dev/null',
                             '--template_location=' + dummy_file.name,
                             '--no_auth=True']))
+
+    pipeline | beam.Create([1, 2, 3]) | beam.Map(lambda x: x) # pylint: disable=expression-not-assigned
     pipeline.run()
     with open(dummy_file.name) as template_file:
       saved_job_dict = json.load(template_file)

--- a/sdks/python/apache_beam/template_runner_test.py
+++ b/sdks/python/apache_beam/template_runner_test.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""Integration tests for templated pipelines."""
+"""Unit tests for templated pipelines."""
 
 from __future__ import absolute_import
 
@@ -31,7 +31,7 @@ from apache_beam.internal import apiclient
 
 
 class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
-  """TemplatingDataflow integration tests."""
+  """TemplatingDataflow tests."""
   def test_full_completion(self):
     dummy_file = tempfile.NamedTemporaryFile()
     dummy_dir = tempfile.mkdtemp()

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -276,6 +276,12 @@ class GoogleCloudOptions(PipelineOptions):
       if getattr(self, 'temp_location',
                  None) or getattr(self, 'staging_location', None) is None:
         errors.extend(validator.validate_gcs_path(self, 'temp_location'))
+
+    if self.view_as(DebugOptions).dataflow_job_file:
+      if self.view_as(GoogleCloudOptions).template_location:
+        errors.append('--dataflow_job_file and --template_location '
+                      'are mutually exclusive.')
+
     return errors
 
 

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -263,6 +263,10 @@ class GoogleCloudOptions(PipelineOptions):
                         default=None,
                         help='Identity to run virtual machines as.')
     parser.add_argument('--no_auth', dest='no_auth', type=bool, default=False)
+    # Option to run templated pipelines
+    parser.add_argument('--template_location',
+                        default=None,
+                        help='Save job to specified local or GCS location.')
 
   def validate(self, validator):
     errors = []

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -24,9 +24,6 @@ import hamcrest as hc
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.utils.options import PipelineOptions
-from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
-from apache_beam.internal import apiclient
-from apache_beam.pipeline import Pipeline
 
 
 class PipelineOptionsTest(unittest.TestCase):
@@ -168,23 +165,6 @@ class PipelineOptionsTest(unittest.TestCase):
 
     options = PipelineOptions(flags=[''])
     self.assertEqual(options.get_all_options()['template_location'], None)
-
-  def test_dataflow_job_file_and_template_location_mutually_exclusive(self):
-    remote_runner = DataflowPipelineRunner()
-    pipeline = Pipeline(remote_runner,
-                        options=PipelineOptions([
-                            '--dataflow_endpoint=ignored',
-                            '--job_name=test-job',
-                            '--project=test-project',
-                            '--staging_location=ignored',
-                            '--temp_location=/dev/null',
-                            '--template_location=/tmp/test-file',
-                            '--dataflow_job_file=/tmp/test-file',
-                            '--no_auth=True']))
-    remote_runner.job = apiclient.Job(pipeline.options)
-
-    with self.assertRaises(RuntimeError):
-      remote_runner.run(pipeline)
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -24,6 +24,9 @@ import hamcrest as hc
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.utils.options import PipelineOptions
+from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
+from apache_beam.internal import apiclient
+from apache_beam.pipeline import Pipeline
 
 
 class PipelineOptionsTest(unittest.TestCase):
@@ -152,6 +155,36 @@ class PipelineOptionsTest(unittest.TestCase):
     options = PipelineOptions(flags=[''])
     self.assertEqual(options.get_all_options()['extra_packages'], None)
 
+  def test_dataflow_job_file(self):
+    options = PipelineOptions(['--dataflow_job_file', 'abc'])
+    self.assertEqual(options.get_all_options()['dataflow_job_file'], 'abc')
+
+    options = PipelineOptions(flags=[''])
+    self.assertEqual(options.get_all_options()['dataflow_job_file'], None)
+
+  def test_template_location(self):
+    options = PipelineOptions(['--template_location', 'abc'])
+    self.assertEqual(options.get_all_options()['template_location'], 'abc')
+
+    options = PipelineOptions(flags=[''])
+    self.assertEqual(options.get_all_options()['template_location'], None)
+
+  def test_dataflow_job_file_and_template_location_mutually_exclusive(self):
+    remote_runner = DataflowPipelineRunner()
+    pipeline = Pipeline(remote_runner,
+                        options=PipelineOptions([
+                            '--dataflow_endpoint=ignored',
+                            '--job_name=test-job',
+                            '--project=test-project',
+                            '--staging_location=ignored',
+                            '--temp_location=/dev/null',
+                            '--template_location=/tmp/test-file',
+                            '--dataflow_job_file=/tmp/test-file',
+                            '--no_auth=True']))
+    remote_runner.job = apiclient.Job(pipeline.options)
+
+    with self.assertRaises(RuntimeError):
+      remote_runner.run(pipeline)
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -268,7 +268,6 @@ class SetupTest(unittest.TestCase):
     ])
     validator = PipelineOptionsValidator(options, runner)
     errors = validator.validate()
-    print errors
     self.assertTrue(errors)
 
   def test_validate_template_location(self):

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -260,6 +260,35 @@ class SetupTest(unittest.TestCase):
           PipelineOptions(case['options']), case['runner'])
       self.assertEqual(validator.is_service_runner(), case['expected'])
 
+  def test_dataflow_job_file_and_template_location_mutually_exclusive(self):
+    runner = MockRunners.OtherRunner()
+    options = PipelineOptions([
+        '--template_location', 'abc',
+        '--dataflow_job_file', 'def'
+    ])
+    validator = PipelineOptionsValidator(options, runner)
+    errors = validator.validate()
+    print errors
+    self.assertTrue(errors)
+
+  def test_validate_template_location(self):
+    runner = MockRunners.OtherRunner()
+    options = PipelineOptions([
+        '--template_location', 'abc',
+    ])
+    validator = PipelineOptionsValidator(options, runner)
+    errors = validator.validate()
+    self.assertFalse(errors)
+
+  def test_validate_dataflow_job_file(self):
+    runner = MockRunners.OtherRunner()
+    options = PipelineOptions([
+        '--dataflow_job_file', 'abc'
+    ])
+    validator = PipelineOptionsValidator(options, runner)
+    errors = validator.validate()
+    self.assertFalse(errors)
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()


### PR DESCRIPTION
Modify create_job to allow staging the job and not submitting it to the service.
- Modularize create_job in create job description, stage job, and send for execution.
- Modify --dataflow_job_file to stage the job and continue submitting it to the service.
- Add --template_location to stage the job but not submit it to the service.
- Add tests for both, including making them mutually exclusive (following Java SDK decision).
- Add template_runner_test.py with integration tests.