### PR TITLE
Support @ValidatesRunner(RunnableOnService) in Python

### DIFF
--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -42,7 +42,7 @@ class TestPipeline(Pipeline):
                                               --job_name myJobName \
                                               --num_workers 1'
 
-  For example, sse assert_that for test validation::
+  For example, use assert_that for test validation::
 
     pipeline = TestPipeline()
     pcoll = ...

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -32,21 +32,17 @@ class TestPipeline(Pipeline):
   of the pipeline runner. Those test functions are recommended to be tagged by
   @pytest.mark.ValidatesRunner annotation.
 
-  Test functions that run against a pipeline runner are recommended to be tagged
-  by @pytest.mark.ValidatesRunner annotation. TestPipeline class has a
-  functionality to parse arguments from command line and build pipeline options
-  for such tests.
-
   In order to configure the test with customized pipeline options from command
   line, system argument 'test_options' can be used to obtains a list of pipeline
-  options. If no options specified, DirectPipelineRunner will be used as
-  default. For example::
+  options. If no options specified, default value will be used.
 
-    '--runner DirectPipelineRunner \
-    --job_name myJobName \
-    --num_workers 1'
+  For example, use following command line to execute all ValidatesRunner tests::
 
-  Use assert_that for test validation. For example::
+    pytest -m ValidatesRunner --test_options='--runner DirectPipelineRunner \
+                                              --job_name myJobName \
+                                              --num_workers 1'
+
+  For example, sse assert_that for test validation::
 
     pipeline = TestPipeline()
     pcoll = ...
@@ -69,7 +65,7 @@ class TestPipeline(Pipeline):
     known, unused_argv = parser.parse_known_args()
 
     options = []
-    if known.test_options is not None:
+    if known.test_options:
       options = known.test_options.split()
 
     return PipelineOptions(options)

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test Pipeline, a wrapper of Pipeline for test purpose"""
+
+import argparse
+
+from apache_beam.pipeline import Pipeline
+from apache_beam.utils.options import PipelineOptions
+
+class TestPipeline(Pipeline):
+  """TestPipeline class can be used inside of tests that can be configured to
+  run against pipeline runner.
+
+  It has a functionality to parse arguments from command line and build pipeline
+  options for tests who runs against a pipeline runner and utilizes resources
+  of the pipeline runner. Those test functions are recommended to be tagged by
+  @pytest.mark.ValidatesRunner annotation.
+
+  Test functions that run against a pipeline runner are recommended to be tagged
+  by @pytest.mark.ValidatesRunner annotation. TestPipeline class has a functionality
+  to parse arguments from command line and build pipeline options for such tests.
+
+  In order to configure the test with customized pipeline options from command
+  line, system argument 'test_options' can be used to obtains a list of pipeline
+  options. If no options specified, DirectPipelineRunner will be used as default.
+  For example::
+
+    '--runner DirectPipelineRunner \
+    --job_name myJobName \
+    --num_workers 1'
+
+  Use assert_that for test validation. For example::
+
+    pipeline = TestPipeline()
+    pcoll = ...
+    assert_that(pcoll, equal_to([1,2,3]))
+    pipeline.run()
+  """
+
+  def __init__(self, runner=None, options=None, argv=None):
+    if options is None:
+      options = self.create_pipeline_opt_from_args()
+    super(TestPipeline, self).__init__(runner, options, argv)
+
+  def create_pipeline_opt_from_args(self):
+    """Create a pipeline options from command line argument: --test_options"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--test_options',
+                       type=str,
+                       action='store',
+                       help='only run tests providing service options')
+    known, argv = parser.parse_known_args()
+
+    options = []
+    if known.test_options is not None:
+      options = known.test_options.split()
+
+    return PipelineOptions(options)

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -22,6 +22,7 @@ import argparse
 from apache_beam.pipeline import Pipeline
 from apache_beam.utils.options import PipelineOptions
 
+
 class TestPipeline(Pipeline):
   """TestPipeline class can be used inside of tests that can be configured to
   run against pipeline runner.
@@ -32,13 +33,14 @@ class TestPipeline(Pipeline):
   @pytest.mark.ValidatesRunner annotation.
 
   Test functions that run against a pipeline runner are recommended to be tagged
-  by @pytest.mark.ValidatesRunner annotation. TestPipeline class has a functionality
-  to parse arguments from command line and build pipeline options for such tests.
+  by @pytest.mark.ValidatesRunner annotation. TestPipeline class has a
+  functionality to parse arguments from command line and build pipeline options
+  for such tests.
 
   In order to configure the test with customized pipeline options from command
   line, system argument 'test_options' can be used to obtains a list of pipeline
-  options. If no options specified, DirectPipelineRunner will be used as default.
-  For example::
+  options. If no options specified, DirectPipelineRunner will be used as
+  default. For example::
 
     '--runner DirectPipelineRunner \
     --job_name myJobName \
@@ -61,10 +63,10 @@ class TestPipeline(Pipeline):
     """Create a pipeline options from command line argument: --test_options"""
     parser = argparse.ArgumentParser()
     parser.add_argument('--test_options',
-                       type=str,
-                       action='store',
-                       help='only run tests providing service options')
-    known, argv = parser.parse_known_args()
+                        type=str,
+                        action='store',
+                        help='only run tests providing service options')
+    known, unused_argv = parser.parse_known_args()
 
     options = []
     if known.test_options is not None:

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -42,8 +42,6 @@ def context(element, timestamp, windows):
   return WindowFn.AssignContext(timestamp, element, windows)
 
 
-
-
 class ReifyWindowsFn(core.DoFn):
   def process(self, context):
     key, values = context.element

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -42,7 +42,6 @@ def context(element, timestamp, windows):
   return WindowFn.AssignContext(timestamp, element, windows)
 
 
-sort_values = Map(lambda (k, vs): (k, sorted(vs)))
 
 
 class ReifyWindowsFn(core.DoFn):
@@ -149,7 +148,7 @@ class WindowTest(unittest.TestCase):
     result = (pcoll
               | 'w' >> WindowInto(Sessions(10))
               | GroupByKey()
-              | sort_values
+              | Map(lambda (k, vs): (k, sorted(vs)))
               | reify_windows)
     expected = [('key @ [1.0, 13.0)', [1, 2, 3]),
                 ('key @ [20.0, 45.0)', [20, 27, 35])]

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -15,11 +15,17 @@
 # limitations under the License.
 #
 
+"""A local plugin for Pytest
+
+Pytest will invoke all self-defined hooks which are build for Beam Python
+testing framework.
+"""
+
 import pytest
 
 
 def pytest_addoption(parser):
-  """Register command line options to pytest"""
+  """Register command line options to pytest before command line parsing"""
   parser.addoption('--test_options',
                    nargs='?',
                    type=str,
@@ -33,7 +39,8 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
-  """Set up @RunnableOnService marker and handle sub-categories"""
+  """Set up ValidatesRunner marker and handle sub-categories before each
+  collected functions run"""
   marker = item.get_marker('ValidatesRunner')
   category_args = item.config.getoption('sub_categories')
   if category_args is not None:

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -17,6 +17,7 @@
 
 import pytest
 
+
 def pytest_addoption(parser):
   """Register command line options to pytest"""
   parser.addoption('--test_options',
@@ -29,6 +30,7 @@ def pytest_addoption(parser):
                    type=str,
                    action='store',
                    help='providing supported features ')
+
 
 def pytest_runtest_setup(item):
   """Set up @RunnableOnService marker and handle sub-categories"""

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+def pytest_addoption(parser):
+  """Register command line options to pytest"""
+  parser.addoption('--test_options',
+                   nargs='?',
+                   type=str,
+                   action='store',
+                   help='providing pipeline options to run tests on service')
+  parser.addoption('--sub_categories',
+                   nargs='+',
+                   type=str,
+                   action='store',
+                   help='providing supported features ')
+
+def pytest_runtest_setup(item):
+  """Set up @RunnableOnService marker and handle sub-categories"""
+  marker = item.get_marker('ValidatesRunner')
+  category_args = item.config.getoption('sub_categories')
+  if category_args is not None:
+    if marker is None or len(marker.args) == 0:
+      pytest.skip('Skip ValidatesRunner tests which has no category')
+
+    func_category = marker.args[0]
+    if func_category not in category_args:
+      pytest.skip('Skip ValidatesRunner tests that is not in target categories')

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -27,9 +27,20 @@ verbosity=2
 exclude=fast_coders_test|typecoders_test
 
 [tool:pytest]
+# Change naming conventions rules. Only matched test files/classes/functions
+# are selected and executed by Pytest
 python_files = *_test.py
 python_classes = *Test
 python_functions = test_*
+
+# Append specified options to command line arguments as default configurations
+# -v: increase verbosity
+# -rsx: show extra skipped and failed test summary info
+# --ignore: ignore path during collection
+# --tb: traceback print mode
+# --cache-clear: remove all cache contents at start of run
 addopts = -v -rsx --ignore=setup.py --tb=short --cache-clear
+
+# Register markers for specific type of tests
 markers =
-    ValidatesRunner: mark tests that runs against specific runner.
+    ValidatesRunner: mark tests that runs and validates against specific runner

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -26,3 +26,10 @@ verbosity=2
 # fast_coders_test and typecoders_test.
 exclude=fast_coders_test|typecoders_test
 
+[tool:pytest]
+python_files = *_test.py
+python_classes = *Test
+python_functions = test_*
+addopts = -v -rsx --ignore=setup.py --tb=short --cache-clear
+markers =
+    ValidatesRunner: mark tests that runs against specific runner.

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -99,6 +99,7 @@ REQUIRED_PACKAGES = [
 
 REQUIRED_TEST_PACKAGES = [
     'pyhamcrest>=1.9,<2.0',
+    'pytest>=3.0.0,<4.0.0',
     ]
 
 setuptools.setup(


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

 - introduce annotation "ValidatesRunner" (same as RunnableOnService in Java) for tests that run against runner.
 - support "test_options" argument in command line used to generate customized pipeline options for tests with @ValidatesRunner tag.
 - potentially support capability metrix testing using parametrized marker(annotation).
 - new test dependency Pytest is introduced to handle marker(annotation) and test suites.

TODO: modify some existing unit tests to @ValidatesRunner tests. 