### PR TITLE
DirectPipelineRunner bug fixes

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -29,6 +29,8 @@ from apache_beam import io
 from apache_beam import pvalue
 from apache_beam import typehints
 from apache_beam.io import fileio
+from apache_beam.transforms.util import assert_that
+from apache_beam.transforms.util import equal_to
 from apache_beam.utils.options import TypeOptions
 from apache_beam.examples.snippets import snippets
 
@@ -307,7 +309,9 @@ class TypeHintsTest(unittest.TestCase):
       # [END type_hints_runtime_on]
 
   def test_deterministic_key(self):
-    lines = ['banana,fruit,3', 'kiwi,fruit,2', 'kiwi,fruit,2', 'zucchini,veg,3']
+    p = beam.Pipeline('DirectPipelineRunner')
+    lines = (p | beam.Create(
+        ['banana,fruit,3', 'kiwi,fruit,2', 'kiwi,fruit,2', 'zucchini,veg,3']))
 
     # [START type_hints_deterministic_key]
     class Player(object):
@@ -338,9 +342,11 @@ class TypeHintsTest(unittest.TestCase):
             beam.typehints.Tuple[Player, int]))
     # [END type_hints_deterministic_key]
 
-    self.assertEquals(
-        {('banana', 3), ('kiwi', 4), ('zucchini', 3)},
-        set(totals | beam.Map(lambda (k, v): (k.name, v))))
+    assert_that(
+        totals | beam.Map(lambda (k, v): (k.name, v)),
+        equal_to([('banana', 3), ('kiwi', 4), ('zucchini', 3)]))
+
+    p.run()
 
 
 class SnippetsTest(unittest.TestCase):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -24,6 +24,7 @@ from apache_beam.pipeline import Pipeline
 from apache_beam.pipeline import PipelineOptions
 from apache_beam.pipeline import PipelineVisitor
 from apache_beam.runners.dataflow.native_io.iobase import NativeSource
+from apache_beam.transforms import CombineGlobally
 from apache_beam.transforms import Create
 from apache_beam.transforms import FlatMap
 from apache_beam.transforms import Map
@@ -216,6 +217,10 @@ class PipelineTest(unittest.TestCase):
         ['x' * len_elements + 'y' * num_maps] * num_elements))
 
     pipeline.run()
+
+  def test_aggregator_empty_input(self):
+    actual = [] | CombineGlobally(max).without_defaults()
+    self.assertEqual(actual, [])
 
   def test_pipeline_as_context(self):
     def raise_exception(exn):

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -125,7 +125,7 @@ class BufferingInMemoryCache(object):
     for key, value in self._cache.iteritems():
       applied_ptransform, tag = key
       self._pvalue_cache.cache_output(applied_ptransform, tag, value)
-      self._cache = None
+    self._cache = None
 
 
 class DirectPipelineResult(PipelineResult):

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -20,10 +20,10 @@
 from __future__ import absolute_import
 
 import collections
-import copy
 
 from apache_beam import coders
 from apache_beam import pvalue
+from apache_beam.internal import pickler
 import apache_beam.io as io
 from apache_beam.runners.common import DoFnRunner
 from apache_beam.runners.common import DoFnState
@@ -338,7 +338,7 @@ class _ParDoEvaluator(_TransformEvaluator):
 
     self._counter_factory = counters.CounterFactory()
 
-    dofn = copy.deepcopy(transform.dofn)
+    dofn = pickler.loads(pickler.dumps(transform.dofn))
 
     pipeline_options = self._evaluation_context.pipeline_options
     if (pipeline_options is not None
@@ -504,7 +504,7 @@ class _NativeWriteEvaluator(_TransformEvaluator):
         side_inputs)
 
     assert applied_ptransform.transform.sink
-    self._sink = copy.deepcopy(applied_ptransform.transform.sink)
+    self._sink = pickler.loads(pickler.dumps(applied_ptransform.transform.sink))
 
   @property
   def _is_final_bundle(self):

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -338,6 +338,7 @@ class _ParDoEvaluator(_TransformEvaluator):
 
     self._counter_factory = counters.CounterFactory()
 
+    # TODO(aaltay): Consider storing the serialized form as an optimization.
     dofn = pickler.loads(pickler.dumps(transform.dofn))
 
     pipeline_options = self._evaluation_context.pipeline_options
@@ -504,6 +505,7 @@ class _NativeWriteEvaluator(_TransformEvaluator):
         side_inputs)
 
     assert applied_ptransform.transform.sink
+    # TODO(aaltay): Consider storing the serialized form as an optimization.
     self._sink = pickler.loads(pickler.dumps(applied_ptransform.transform.sink))
 
   @property


### PR DESCRIPTION
- Execute empty [] | pipelines to the end.
- use pickler to serialize/deserialize DoFns instead of deepcopy similar to the othe execution environments.