### PR TITLE
[BEAM-498] Treat ProcessContext and Context like other DoFn parameters

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -34,8 +34,10 @@ import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.beam.sdk.transforms.Aggregator.AggregatorFactory;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.Context;
 import org.apache.beam.sdk.transforms.DoFn.InputProvider;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
@@ -136,16 +138,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
   }
 
   private void invokeProcessElement(WindowedValue<InputT> elem) {
-    final DoFn<InputT, OutputT>.ProcessContext processContext = createProcessContext(elem);
-
-    // Note that if the element must be exploded into all its windows, that has to be done outside
-    // of this runner.
-    final DoFn.ExtraContextFactory<InputT, OutputT> extraContextFactory =
-        createExtraContextFactory(elem);
+    DoFnProcessContext<InputT, OutputT> processContext = createProcessContext(elem);
 
     // This can contain user code. Wrap it in case it throws an exception.
     try {
-      invoker.invokeProcessElement(processContext, extraContextFactory);
+      invoker.invokeProcessElement(processContext);
     } catch (Exception ex) {
       throw wrapUserCodeException(ex);
     }
@@ -163,13 +160,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
   }
 
   /** Returns a new {@link DoFn.ProcessContext} for the given element. */
-  private DoFn<InputT, OutputT>.ProcessContext createProcessContext(WindowedValue<InputT> elem) {
+  private DoFnProcessContext<InputT, OutputT> createProcessContext(WindowedValue<InputT> elem) {
     return new DoFnProcessContext<InputT, OutputT>(fn, context, elem);
-  }
-
-  private DoFn.ExtraContextFactory<InputT, OutputT> createExtraContextFactory(
-      WindowedValue<InputT> elem) {
-    return new DoFnExtraContextFactory<InputT, OutputT>(elem.getWindows(), elem.getPane());
   }
 
   private RuntimeException wrapUserCodeException(Throwable t) {
@@ -186,7 +178,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
    * @param <InputT> the type of the {@link DoFn} (main) input elements
    * @param <OutputT> the type of the {@link DoFn} (main) output elements
    */
-  private static class DoFnContext<InputT, OutputT> extends DoFn<InputT, OutputT>.Context {
+  private static class DoFnContext<InputT, OutputT> extends DoFn<InputT, OutputT>.Context
+      implements DoFn.ExtraContextFactory<InputT, OutputT> {
     private static final int MAX_SIDE_OUTPUTS = 1000;
 
     final PipelineOptions options;
@@ -369,6 +362,56 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
       checkNotNull(combiner, "Combiner passed to createAggregator cannot be null");
       return aggregatorFactory.createAggregatorForDoFn(fn.getClass(), stepContext, name, combiner);
     }
+
+    @Override
+    public BoundedWindow window() {
+      throw new UnsupportedOperationException(
+          "Cannot access window outside of @ProcessElement and @OnTimer methods.");
+    }
+
+    @Override
+    public Context context(DoFn<InputT, OutputT> doFn) {
+      return this;
+    }
+
+    @Override
+    public ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
+      throw new UnsupportedOperationException(
+          "Cannot access ProcessContext outside of @Processelement method.");
+    }
+
+    @Override
+    public InputProvider<InputT> inputProvider() {
+      throw new UnsupportedOperationException("InputProvider is for testing only.");
+    }
+
+    @Override
+    public OutputReceiver<OutputT> outputReceiver() {
+      throw new UnsupportedOperationException("OutputReceiver is for testing only.");
+    }
+
+    @Override
+    public WindowingInternals<InputT, OutputT> windowingInternals() {
+      throw new UnsupportedOperationException("WindowingInternals are unsupported.");
+    }
+
+    @Override
+    public <RestrictionT> RestrictionTracker<RestrictionT> restrictionTracker() {
+      throw new UnsupportedOperationException(
+          "Cannot access RestrictionTracker outside of @ProcessElement method.");
+    }
+
+    @Override
+    public State state(String stateId) {
+      throw new UnsupportedOperationException(
+          "Cannot access state outside of @ProcessElement and @OnTimer methods.");
+    }
+
+    @Override
+    public Timer timer(String timerId) {
+      throw new UnsupportedOperationException(
+          "Cannot access timers outside of @ProcessElement and @OnTimer methods.");
+    }
   }
 
   /**
@@ -378,8 +421,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
    * @param <InputT> the type of the {@link DoFn} (main) input elements
    * @param <OutputT> the type of the {@link DoFn} (main) output elements
    */
-  private static class DoFnProcessContext<InputT, OutputT>
-      extends DoFn<InputT, OutputT>.ProcessContext {
+  private class DoFnProcessContext<InputT, OutputT> extends DoFn<InputT, OutputT>.ProcessContext
+      implements DoFn.ExtraContextFactory<InputT, OutputT> {
 
     final DoFn<InputT, OutputT> fn;
     final DoFnContext<InputT, OutputT> context;
@@ -497,25 +540,20 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
             String name, CombineFn<AggregatorInputT, ?, AggregatorOutputT> combiner) {
       return context.createAggregator(name, combiner);
     }
-  }
-
-  private class DoFnExtraContextFactory<InputT, OutputT>
-      implements DoFn.ExtraContextFactory<InputT, OutputT> {
-
-    /** The windows of the current element. */
-    private final Collection<? extends BoundedWindow> windows;
-
-    /** The pane of the current element. */
-    private final PaneInfo pane;
-
-    public DoFnExtraContextFactory(Collection<? extends BoundedWindow> windows, PaneInfo pane) {
-      this.windows = windows;
-      this.pane = pane;
-    }
 
     @Override
     public BoundedWindow window() {
-      return Iterables.getOnlyElement(windows);
+      return Iterables.getOnlyElement(windowedValue.getWindows());
+    }
+
+    @Override
+    public DoFn<InputT, OutputT>.Context context(DoFn<InputT, OutputT> doFn) {
+      return this;
+    }
+
+    @Override
+    public DoFn<InputT, OutputT>.ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
+      return this;
     }
 
     @Override
@@ -548,12 +586,12 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
       return new WindowingInternals<InputT, OutputT>() {
         @Override
         public Collection<? extends BoundedWindow> windows() {
-          return windows;
+          return windowedValue.getWindows();
         }
 
         @Override
         public PaneInfo pane() {
-          return pane;
+          return windowedValue.getPane();
         }
 
         @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
@@ -289,8 +289,8 @@ public class SplittableParDo<
       // producing a limited amount of output.
       DoFn.ProcessContinuation cont =
           invoker.invokeProcessElement(
-              makeContext(c, elementAndRestriction.element(), tracker, residual),
-              wrapTracker(tracker));
+              wrapTracker(
+                  tracker, makeContext(c, elementAndRestriction.element(), tracker, residual)));
       if (residual[0] == null) {
         // This means the call completed unsolicited, and the context produced by makeContext()
         // did not take a checkpoint. Take one now.
@@ -392,23 +392,37 @@ public class SplittableParDo<
     }
 
     /** Creates an {@link DoFn.ExtraContextFactory} that provides just the given tracker. */
-    private DoFn.ExtraContextFactory<InputT, OutputT> wrapTracker(final TrackerT tracker) {
-      return new ExtraContextFactoryForTracker<>(tracker);
+    private DoFn.ExtraContextFactory<InputT, OutputT> wrapTracker(
+        TrackerT tracker, DoFn<InputT, OutputT>.ProcessContext processContext) {
+      return new ExtraContextFactoryForTracker<>(tracker, processContext);
     }
 
     private static class ExtraContextFactoryForTracker<
             InputT, OutputT, TrackerT extends RestrictionTracker<?>>
         implements DoFn.ExtraContextFactory<InputT, OutputT> {
       private final TrackerT tracker;
+      private final DoFn<InputT, OutputT>.ProcessContext processContext;
 
-      ExtraContextFactoryForTracker(TrackerT tracker) {
+      ExtraContextFactoryForTracker(
+          TrackerT tracker, DoFn<InputT, OutputT>.ProcessContext processContext) {
         this.tracker = tracker;
+        this.processContext = processContext;
       }
 
       @Override
       public BoundedWindow window() {
         // DoFnSignatures should have verified that this DoFn doesn't access extra context.
         throw new IllegalStateException("Unexpected extra context access on a splittable DoFn");
+      }
+
+      @Override
+      public DoFn.Context context(DoFn<InputT, OutputT> doFn) {
+        return processContext;
+      }
+
+      @Override
+      public DoFn.ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
+        return processContext;
       }
 
       @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -352,6 +352,16 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
     BoundedWindow window();
 
     /**
+     * Provide a {@link DoFn.Context} to use with the given {@link DoFn}.
+     */
+    DoFn<InputT, OutputT>.Context context(DoFn<InputT, OutputT> doFn);
+
+    /**
+     * Provide a {@link DoFn.ProcessContext} to use with the given {@link DoFn}.
+     */
+    DoFn<InputT, OutputT>.ProcessContext processContext(DoFn<InputT, OutputT> doFn);
+
+    /**
      * A placeholder for testing purposes.
      */
     InputProvider<InputT> inputProvider();
@@ -407,7 +417,17 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   public static class FakeExtraContextFactory<InputT, OutputT>
       implements ExtraContextFactory<InputT, OutputT> {
     @Override
+    public DoFn<InputT, OutputT>.ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
+      return null;
+    }
+
+    @Override
     public BoundedWindow window() {
+      return null;
+    }
+
+    @Override
+    public DoFn<InputT, OutputT>.Context context(DoFn<InputT, OutputT> doFn) {
       return null;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnAdapters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnAdapters.java
@@ -20,6 +20,8 @@ package org.apache.beam.sdk.transforms;
 import java.io.IOException;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
+import org.apache.beam.sdk.transforms.DoFn.Context;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
@@ -228,7 +230,7 @@ public class DoFnAdapters {
     @Override
     public void processElement(ProcessContext c) throws Exception {
       ProcessContextAdapter<InputT, OutputT> adapter = new ProcessContextAdapter<>(fn, c);
-      invoker.invokeProcessElement(adapter, adapter);
+      invoker.invokeProcessElement(adapter);
     }
 
     @Override
@@ -324,6 +326,17 @@ public class DoFnAdapters {
     }
 
     @Override
+    public Context context(DoFn<InputT, OutputT> doFn) {
+      return this;
+    }
+
+    @Override
+    public ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
+      throw new UnsupportedOperationException(
+          "Can only get a ProcessContext in processElement");
+    }
+
+    @Override
     public WindowingInternals<InputT, OutputT> windowingInternals() {
       // The OldDoFn doesn't allow us to ask for these outside ProcessElements, so this
       // should be unreachable.
@@ -358,8 +371,7 @@ public class DoFnAdapters {
   }
 
   /**
-   * Wraps an {@link OldDoFn.ProcessContext} as a {@link DoFn.ExtraContextFactory} inside a {@link
-   * DoFn.ProcessElement} method.
+   * Wraps an {@link OldDoFn.ProcessContext} as a {@link DoFn.ExtraContextFactory} method.
    */
   private static class ProcessContextAdapter<InputT, OutputT>
       extends DoFn<InputT, OutputT>.ProcessContext
@@ -427,6 +439,16 @@ public class DoFnAdapters {
     @Override
     public BoundedWindow window() {
       return context.window();
+    }
+
+    @Override
+    public Context context(DoFn<InputT, OutputT> doFn) {
+      return this;
+    }
+
+    @Override
+    public ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
+      return this;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -44,13 +44,11 @@ public interface DoFnInvoker<InputT, OutputT> {
   /**
    * Invoke the {@link DoFn.ProcessElement} method on the bound {@link DoFn}.
    *
-   * @param c The {@link DoFn.ProcessContext} to invoke the fn with.
    * @param extra Factory for producing extra parameter objects (such as window), if necessary.
    * @return The {@link DoFn.ProcessContinuation} returned by the underlying method, or {@link
    *     DoFn.ProcessContinuation#stop()} if it returns {@code void}.
    */
-  DoFn.ProcessContinuation invokeProcessElement(
-      DoFn<InputT, OutputT>.ProcessContext c, DoFn.ExtraContextFactory<InputT, OutputT> extra);
+  DoFn.ProcessContinuation invokeProcessElement(DoFn.ExtraContextFactory<InputT, OutputT> extra);
 
   /** Invoke the {@link DoFn.GetInitialRestriction} method on the bound {@link DoFn}. */
   <RestrictionT> RestrictionT invokeGetInitialRestriction(InputT element);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
@@ -101,9 +101,12 @@ public class DoFnInvokers {
 
     @Override
     public DoFn.ProcessContinuation invokeProcessElement(
-        DoFn<InputT, OutputT>.ProcessContext c, ExtraContextFactory<InputT, OutputT> extra) {
+        ExtraContextFactory<InputT, OutputT> extra) {
+      // The outer DoFn is immaterial - it exists only to avoid typing InputT and OutputT repeatedly
+      DoFn<InputT, OutputT>.ProcessContext newCtx =
+          extra.processContext(new DoFn<InputT, OutputT>() {});
       OldDoFn<InputT, OutputT>.ProcessContext oldCtx =
-          DoFnAdapters.adaptProcessContext(fn, c, extra);
+          DoFnAdapters.adaptProcessContext(fn, newCtx, extra);
       try {
         fn.processElement(oldCtx);
         return DoFn.ProcessContinuation.stop();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
@@ -35,28 +35,6 @@ public class DoFnSignaturesProcessElementTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testMissingProcessContext() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Must take ProcessContext<> as the first argument");
-
-    analyzeProcessElementMethod(
-        new AnonymousMethod() {
-          private void method() {}
-        });
-  }
-
-  @Test
-  public void testBadProcessContextType() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Must take ProcessContext<> as the first argument");
-
-    analyzeProcessElementMethod(
-        new AnonymousMethod() {
-          private void method(String s) {}
-        });
-  }
-
-  @Test
   public void testBadExtraProcessContextType() throws Exception {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -90,7 +90,7 @@ public class DoFnSignaturesSplittableDoFnTest {
   @Test
   public void testSplittableProcessElementMustNotHaveOtherParams() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("must not have any extra arguments");
+    thrown.expectMessage("must have only ProcessContext and RestrictionTracker parameters");
 
     DoFnSignature.ProcessElementMethod signature =
         analyzeProcessElementMethod(

--- a/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnInvokersBenchmark.java
+++ b/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnInvokersBenchmark.java
@@ -83,7 +83,7 @@ public class DoFnInvokersBenchmark {
 
   @Benchmark
   public String invokeDoFnWithContext() throws Exception {
-    invoker.invokeProcessElement(stubDoFnContext, extraContextFactory);
+    invoker.invokeProcessElement(extraContextFactory);
     return stubDoFnContext.output;
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Before this change, `ProcessContext` and `Context` were special-cased, while other parameters were treated generically. After this change, all parameters receive the same dynamic treatment. Thus a user need not request these parameters, the runner can save the effort of constructing them, and we can migrate towards less "all-in-one" parameters.

I changed only the analysis and code generation a bit to remove special casing, but did not write new delegations that would actually add dynamic parameter generation to methods that do not already have them, so only `@ProcessElement` and `@OnTimer` are affected.