### PR TITLE
[BEAM-498] Rename DoFn.ExtraContextFactory to DoFn.ArgumentProvider

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -179,7 +179,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
    * @param <OutputT> the type of the {@link DoFn} (main) output elements
    */
   private static class DoFnContext<InputT, OutputT> extends DoFn<InputT, OutputT>.Context
-      implements DoFn.ExtraContextFactory<InputT, OutputT> {
+      implements DoFn.ArgumentProvider<InputT, OutputT> {
     private static final int MAX_SIDE_OUTPUTS = 1000;
 
     final PipelineOptions options;
@@ -422,7 +422,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
    * @param <OutputT> the type of the {@link DoFn} (main) output elements
    */
   private class DoFnProcessContext<InputT, OutputT> extends DoFn<InputT, OutputT>.ProcessContext
-      implements DoFn.ExtraContextFactory<InputT, OutputT> {
+      implements DoFn.ArgumentProvider<InputT, OutputT> {
 
     final DoFn<InputT, OutputT> fn;
     final DoFnContext<InputT, OutputT> context;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
@@ -391,19 +391,23 @@ public class SplittableParDo<
       };
     }
 
-    /** Creates an {@link DoFn.ExtraContextFactory} that provides just the given tracker. */
-    private DoFn.ExtraContextFactory<InputT, OutputT> wrapTracker(
+    /**
+     * Creates an {@link DoFn.ArgumentProvider} that provides the given tracker as well as the given
+     * {@link ProcessContext} (which is also provided when a {@link Context} is requested.
+     */
+    private DoFn.ArgumentProvider<InputT, OutputT> wrapTracker(
         TrackerT tracker, DoFn<InputT, OutputT>.ProcessContext processContext) {
-      return new ExtraContextFactoryForTracker<>(tracker, processContext);
+
+      return new ArgumentProviderForTracker<>(tracker, processContext);
     }
 
-    private static class ExtraContextFactoryForTracker<
+    private static class ArgumentProviderForTracker<
             InputT, OutputT, TrackerT extends RestrictionTracker<?>>
-        implements DoFn.ExtraContextFactory<InputT, OutputT> {
+        implements DoFn.ArgumentProvider<InputT, OutputT> {
       private final TrackerT tracker;
       private final DoFn<InputT, OutputT>.ProcessContext processContext;
 
-      ExtraContextFactoryForTracker(
+      ArgumentProviderForTracker(
           TrackerT tracker, DoFn<InputT, OutputT>.ProcessContext processContext) {
         this.tracker = tracker;
         this.processContext = processContext;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -341,7 +341,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <p>In the case of {@link ProcessElement} it is called once per invocation of
    * {@link ProcessElement}.
    */
-  public interface ExtraContextFactory<InputT, OutputT> {
+  public interface ArgumentProvider<InputT, OutputT> {
     /**
      * Construct the {@link BoundedWindow} to use within a {@link DoFn} that
      * needs it. This is called if the {@link ProcessElement} method has a parameter of type
@@ -413,9 +413,9 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
     T get();
   }
 
-  /** For testing only, this {@link ExtraContextFactory} returns {@code null} for all parameters. */
-  public static class FakeExtraContextFactory<InputT, OutputT>
-      implements ExtraContextFactory<InputT, OutputT> {
+  /** For testing only, this {@link ArgumentProvider} returns {@code null} for all parameters. */
+  public static class FakeArgumentProvider<InputT, OutputT>
+      implements ArgumentProvider<InputT, OutputT> {
     @Override
     public DoFn<InputT, OutputT>.ProcessContext processContext(DoFn<InputT, OutputT> doFn) {
       return null;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnAdapters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnAdapters.java
@@ -77,7 +77,7 @@ public class DoFnAdapters {
   public static <InputT, OutputT> OldDoFn<InputT, OutputT>.ProcessContext adaptProcessContext(
       OldDoFn<InputT, OutputT> fn,
       final DoFn<InputT, OutputT>.ProcessContext c,
-      final DoFn.ExtraContextFactory<InputT, OutputT> extra) {
+      final DoFn.ArgumentProvider<InputT, OutputT> extra) {
     return fn.new ProcessContext() {
       @Override
       public InputT element() {
@@ -270,12 +270,12 @@ public class DoFnAdapters {
   }
 
   /**
-   * Wraps an {@link OldDoFn.Context} as a {@link DoFn.ExtraContextFactory} inside a {@link
+   * Wraps an {@link OldDoFn.Context} as a {@link DoFn.ArgumentProvider} inside a {@link
    * DoFn.StartBundle} or {@link DoFn.FinishBundle} method, which means the extra context is
    * unavailable.
    */
   private static class ContextAdapter<InputT, OutputT> extends DoFn<InputT, OutputT>.Context
-      implements DoFn.ExtraContextFactory<InputT, OutputT> {
+      implements DoFn.ArgumentProvider<InputT, OutputT> {
 
     private OldDoFn<InputT, OutputT>.Context context;
 
@@ -371,11 +371,11 @@ public class DoFnAdapters {
   }
 
   /**
-   * Wraps an {@link OldDoFn.ProcessContext} as a {@link DoFn.ExtraContextFactory} method.
+   * Wraps an {@link OldDoFn.ProcessContext} as a {@link DoFn.ArgumentProvider} method.
    */
   private static class ProcessContextAdapter<InputT, OutputT>
       extends DoFn<InputT, OutputT>.ProcessContext
-      implements DoFn.ExtraContextFactory<InputT, OutputT> {
+      implements DoFn.ArgumentProvider<InputT, OutputT> {
 
     private OldDoFn<InputT, OutputT>.ProcessContext context;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyOnTimerInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyOnTimerInvokerFactory.java
@@ -176,7 +176,7 @@ class ByteBuddyOnTimerInvokerFactory implements OnTimerInvokerFactory {
             .withParameter(fnClass)
             .intercept(new InvokerConstructor())
 
-            //   public invokeOnTimer(ExtraContextFactory) {
+            //   public invokeOnTimer(DoFn.ArgumentProvider) {
             //     this.delegate.<@OnTimer method>(... pass the right args ...)
             //   }
             .method(ElementMatchers.named("invokeOnTimer"))
@@ -211,7 +211,7 @@ class ByteBuddyOnTimerInvokerFactory implements OnTimerInvokerFactory {
     @Override
     protected StackManipulation beforeDelegation(MethodDescription instrumentedMethod) {
       // Parameters of the wrapper invoker method:
-      //   ExtraContextFactory.
+      //   DoFn.ArgumentProvider
       // Parameters of the wrapped DoFn method:
       //   a dynamic set of allowed "extra" parameters in any order subject to
       //   validation prior to getting the DoFnSignature

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -48,7 +48,7 @@ public interface DoFnInvoker<InputT, OutputT> {
    * @return The {@link DoFn.ProcessContinuation} returned by the underlying method, or {@link
    *     DoFn.ProcessContinuation#stop()} if it returns {@code void}.
    */
-  DoFn.ProcessContinuation invokeProcessElement(DoFn.ExtraContextFactory<InputT, OutputT> extra);
+  DoFn.ProcessContinuation invokeProcessElement(DoFn.ArgumentProvider<InputT, OutputT> extra);
 
   /** Invoke the {@link DoFn.GetInitialRestriction} method on the bound {@link DoFn}. */
   <RestrictionT> RestrictionT invokeGetInitialRestriction(InputT element);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokers.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFn.ExtraContextFactory;
 import org.apache.beam.sdk.transforms.DoFnAdapters;
 import org.apache.beam.sdk.transforms.OldDoFn;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
@@ -101,7 +100,7 @@ public class DoFnInvokers {
 
     @Override
     public DoFn.ProcessContinuation invokeProcessElement(
-        ExtraContextFactory<InputT, OutputT> extra) {
+        DoFn.ArgumentProvider<InputT, OutputT> extra) {
       // The outer DoFn is immaterial - it exists only to avoid typing InputT and OutputT repeatedly
       DoFn<InputT, OutputT>.ProcessContext newCtx =
           extra.processContext(new DoFn<InputT, OutputT>() {});

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/OnTimerInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/OnTimerInvoker.java
@@ -23,5 +23,5 @@ import org.apache.beam.sdk.transforms.DoFn;
 interface OnTimerInvoker<InputT, OutputT> {
 
   /** Invoke the {@link DoFn.OnTimer} method in the provided context. */
-  void invokeOnTimer(DoFn.ExtraContextFactory<InputT, OutputT> extra);
+  void invokeOnTimer(DoFn.ArgumentProvider<InputT, OutputT> extra);
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/OnTimerInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/OnTimerInvokersTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFn.ExtraContextFactory;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.TimeDomain;
 import org.apache.beam.sdk.util.TimerSpec;
@@ -44,16 +43,16 @@ public class OnTimerInvokersTest {
 
   @Mock private BoundedWindow mockWindow;
 
-  @Mock private ExtraContextFactory<String, String> mockExtraContextFactory;
+  @Mock private DoFn.ArgumentProvider<String, String> mockArgumentProvider;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(mockExtraContextFactory.window()).thenReturn(mockWindow);
+    when(mockArgumentProvider.window()).thenReturn(mockWindow);
   }
 
   private void invokeOnTimer(DoFn<String, String> fn, String timerId) {
-    OnTimerInvokers.forTimer(fn, timerId).invokeOnTimer(mockExtraContextFactory);
+    OnTimerInvokers.forTimer(fn, timerId).invokeOnTimer(mockArgumentProvider);
   }
 
   @Test

--- a/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnInvokersBenchmark.java
+++ b/sdks/java/microbenchmarks/src/main/java/org/apache/beam/sdk/microbenchmarks/transforms/DoFnInvokersBenchmark.java
@@ -21,7 +21,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFn.ExtraContextFactory;
+import org.apache.beam.sdk.transforms.DoFn.FakeArgumentProvider;
 import org.apache.beam.sdk.transforms.DoFnAdapters;
 import org.apache.beam.sdk.transforms.OldDoFn;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
@@ -56,8 +56,8 @@ public class DoFnInvokersBenchmark {
   private StubOldDoFnProcessContext stubOldDoFnContext =
       new StubOldDoFnProcessContext(oldDoFn, ELEMENT);
   private StubDoFnProcessContext stubDoFnContext = new StubDoFnProcessContext(doFn, ELEMENT);
-  private ExtraContextFactory<String, String> extraContextFactory =
-      new DoFn.FakeExtraContextFactory<>();
+  private DoFn.ArgumentProvider<String, String> argumentProvider =
+      new FakeArgumentProvider<>();
 
   private OldDoFn<String, String> adaptedDoFnWithContext;
 
@@ -83,7 +83,7 @@ public class DoFnInvokersBenchmark {
 
   @Benchmark
   public String invokeDoFnWithContext() throws Exception {
-    invoker.invokeProcessElement(extraContextFactory);
+    invoker.invokeProcessElement(argumentProvider);
     return stubDoFnContext.output;
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @bjchambers 

I think we've discussed this before. Big picture: now we can treat all dynamic methods uniformly, and use `DoFnSignatures` and `ParDo` to do the needed validation. I think since all arguments to methods fall into the "extra" category, we can save some typing and use more conventional vocabulary.