### PR TITLE
[BEAM-985] Fix shared state across retry decorated functions

### DIFF
--- a/sdks/python/apache_beam/utils/retry.py
+++ b/sdks/python/apache_beam/utils/retry.py
@@ -149,12 +149,10 @@ def with_exponential_backoff(
 
   def real_decorator(fun):
     """The real decorator whose purpose is to return the wrapped function."""
-
-    retry_intervals = iter(
-        FuzzedExponentialIntervals(
-            initial_delay_secs, num_retries, fuzz=0.5 if fuzz else 0))
-
     def wrapper(*args, **kwargs):
+      retry_intervals = iter(
+          FuzzedExponentialIntervals(
+              initial_delay_secs, num_retries, fuzz=0.5 if fuzz else 0))
       while True:
         try:
           return fun(*args, **kwargs)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The fix was fairly straight forward and just needed to move the generator inside the wrapped function.

R: @aaltay @chamikaramj  PTAL