### PR TITLE
Support @ValidatesRunner(RunnableOnService) in Python [1/2]

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -139,6 +139,6 @@ setuptools.setup(
     keywords=PACKAGE_KEYWORDS,
     entry_points={
         'nose.plugins.0.10': [
-            'beamTestPlugin = test_config:BeamTestPlugin'
+            'beam_test_plugin = test_config:BeamTestPlugin'
             ]}
     )

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -137,4 +137,8 @@ setuptools.setup(
         ],
     license='Apache License, Version 2.0',
     keywords=PACKAGE_KEYWORDS,
+    entry_points={
+        'nose.plugins.0.10': [
+            'beamTestPlugin = test_config:BeamTestPlugin'
+            ]}
     )

--- a/sdks/python/test_config.py
+++ b/sdks/python/test_config.py
@@ -32,13 +32,13 @@ class BeamTestPlugin(Plugin):
   """
 
   def options(self, parser, env):
-    """Add '--test-options' to command line option to avoid unrecognized
+    """Add '--test-pipeline-options' to command line option to avoid unrecognized
     option error thrown by nose.
 
     The value of this option will be processed by TestPipeline and used to
     build customized pipeline for ValidatesRunner tests.
     """
-    parser.add_option('--test-options',
+    parser.add_option('--test-pipeline-options',
                       action='store',
                       type=str,
                       help='providing pipeline options to run tests on runner')

--- a/sdks/python/test_config.py
+++ b/sdks/python/test_config.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test configurations for nose
+
+This module contains nose plugin hooks that configures Beam tests which
+includes ValidatesRunner test and E2E integration test.
+
+"""
+
+from nose.plugins import Plugin
+
+
+class BeamTestPlugin(Plugin):
+  """A nose plugin for Beam testing that registers command line options
+
+  This plugin is registered through setuptools in entry_points.
+  """
+
+  def options(self, parser, env):
+    """Add '--test-options' to command line option to avoid unrecognized
+    option error thrown by nose.
+
+    The value of this option will be processed by TestPipeline and used to
+    build customized pipeline for ValidatesRunner tests.
+    """
+    parser.add_option('--test-options',
+                      action='store',
+                      type=str,
+                      help='providing pipeline options to run tests on runner')

--- a/sdks/python/test_config.py
+++ b/sdks/python/test_config.py
@@ -32,8 +32,8 @@ class BeamTestPlugin(Plugin):
   """
 
   def options(self, parser, env):
-    """Add '--test-pipeline-options' to command line option to avoid unrecognized
-    option error thrown by nose.
+    """Add '--test-pipeline-options' to command line option to avoid
+    unrecognized option error thrown by nose.
 
     The value of this option will be processed by TestPipeline and used to
     build customized pipeline for ValidatesRunner tests.


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This PR is the half of the work to support @ValidatesRunner(RunnableOnService) test in Python SDK. Mainly about new nose dependency is introduced.

 - Register "--test-options" command line option to nose so that people can run ValidatesRunner (RunnableOnService) tests with specified pipeline options.
 - Wrap the new command line option as a nose plugin and register it to setuptools. This avoid unrecognized option error thrown from setuptools.

The second part is [PR1382](https://github.com/apache/incubator-beam/pull/1382)