### PR TITLE
Support @ValidatesRunner(RunnableOnService) in Python [2/2]

### DIFF
--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test Pipeline, a wrapper of Pipeline for test purpose"""
+
+import argparse
+
+from apache_beam.pipeline import Pipeline
+from apache_beam.utils.options import PipelineOptions
+
+
+class TestPipeline(Pipeline):
+  """TestPipeline class is used inside of Beam tests that can be configured to
+  run against pipeline runner.
+
+  It has a functionality to parse arguments from command line and build pipeline
+  options for tests who runs against a pipeline runner and utilizes resources
+  of the pipeline runner. Those test functions are recommended to be tagged by
+  @attr("ValidatesRunner") annotation.
+
+  In order to configure the test with customized pipeline options from command
+  line, system argument 'test-options' can be used to obtains a list of pipeline
+  options. If no options specified, default value will be used.
+
+  For example, use following command line to execute all ValidatesRunner tests::
+
+    python setup.py nosetests -a ValidatesRunner \
+        --test-options="--runner DirectPipelineRunner \
+                        --job_name myJobName \
+                        --num_workers 1"
+
+  For example, use assert_that for test validation::
+
+    pipeline = TestPipeline()
+    pcoll = ...
+    assert_that(pcoll, equal_to(...))
+    pipeline.run()
+  """
+
+  def __init__(self, runner=None, options=None, argv=None):
+    if options is None:
+      options = self.create_pipeline_opt_from_args()
+    super(TestPipeline, self).__init__(runner, options, argv)
+
+  def create_pipeline_opt_from_args(self):
+    """Create a pipeline options from command line argument: --test-options"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--test-options',
+                        type=str,
+                        action='store',
+                        help='only run tests providing service options')
+    known, unused_argv = parser.parse_known_args()
+
+    options = []
+    if known.test_options:
+      options = known.test_options.split()
+
+    return PipelineOptions(options)

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -18,6 +18,7 @@
 """Test Pipeline, a wrapper of Pipeline for test purpose"""
 
 import argparse
+import shlex
 
 from apache_beam.pipeline import Pipeline
 from apache_beam.utils.options import PipelineOptions
@@ -33,15 +34,15 @@ class TestPipeline(Pipeline):
   @attr("ValidatesRunner") annotation.
 
   In order to configure the test with customized pipeline options from command
-  line, system argument 'test-options' can be used to obtains a list of pipeline
-  options. If no options specified, default value will be used.
+  line, system argument 'test-pipeline-options' can be used to obtains a list
+  of pipeline options. If no options specified, default value will be used.
 
   For example, use following command line to execute all ValidatesRunner tests::
 
     python setup.py nosetests -a ValidatesRunner \
-        --test-options="--runner DirectPipelineRunner \
-                        --job_name myJobName \
-                        --num_workers 1"
+        --test-pipeline-options="--runner=DirectPipelineRunner \
+                                 --job_name=myJobName \
+                                 --num_workers=1"
 
   For example, use assert_that for test validation::
 
@@ -57,16 +58,19 @@ class TestPipeline(Pipeline):
     super(TestPipeline, self).__init__(runner, options, argv)
 
   def create_pipeline_opt_from_args(self):
-    """Create a pipeline options from command line argument: --test-options"""
+    """Create a pipeline options from command line argument:
+    --test-pipeline-options
+    """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--test-options',
+    parser.add_argument('--test-pipeline-options',
                         type=str,
                         action='store',
                         help='only run tests providing service options')
     known, unused_argv = parser.parse_known_args()
 
-    options = []
-    if known.test_options:
-      options = known.test_options.split()
+    if known.test_pipeline_options:
+      options = shlex.split(known.test_pipeline_options)
+    else:
+      options = []
 
     return PipelineOptions(options)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

 - Create TestPipeline class which is a wrapper of Pipeline to construct beam pipeline and will only used in test (ValidatesRunner test and E2E integration test).
 - Provide a small set of examples that how to build ValidatesRunner tests.
 - Currently, the default runner is DirectRunner if it's not specified in command line.

Test done by running all unit test + ValidatesRunner test locally. 
A subset of ValidatesRunner tests run successfully on Dataflow service.