### PR TITLE
Fixes couple of issues of FileBasedSource.

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -543,7 +543,7 @@ class TestFileBasedSource(unittest.TestCase):
         return DummyCoder()
 
     pattern, expected_data = write_pattern([34, 66, 40, 24, 24, 12])
-    assert len(expected_data) == 200
+    self.assertEqual(200, len(expected_data))
     fbs = FileBasedSourceWithCoder(pattern)
     splits = [split for split in fbs.split(desired_bundle_size=50)]
     self.assertTrue(len(splits))

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -533,7 +533,7 @@ class TestFileBasedSource(unittest.TestCase):
     assert_that(pcoll, equal_to(lines))
     pipeline.run()
 
-  def splits_get_coder_from_fbs(self):
+  def test_splits_get_coder_from_fbs(self):
     class DummyCoder(object):
       val = 12345
 

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -533,6 +533,23 @@ class TestFileBasedSource(unittest.TestCase):
     assert_that(pcoll, equal_to(lines))
     pipeline.run()
 
+  def splits_get_coder_from_fbs(self):
+    class DummyCoder(object):
+      val = 12345
+
+    class FileBasedSourceWithCoder(LineSource):
+
+      def default_output_coder(self):
+        return DummyCoder()
+
+    pattern, expected_data = write_pattern([34, 66, 40, 24, 24, 12])
+    assert len(expected_data) == 200
+    fbs = FileBasedSourceWithCoder(pattern)
+    splits = [split for split in fbs.split(desired_bundle_size=50)]
+    self.assertTrue(len(splits))
+    for split in splits:
+      self.assertEqual(DummyCoder.val, split.source.default_output_coder().val)
+
 
 class TestSingleFileSource(unittest.TestCase):
 
@@ -684,7 +701,6 @@ class TestSingleFileSource(unittest.TestCase):
       data_from_split = [data for data in source.read(range_tracker)]
       read_data.extend(data_from_split)
     self.assertItemsEqual(expected_data[2:9], read_data)
-
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
(1) Updates code so that a user-specified coder properly gets set to splits.

(2) Currently each SingleFileSource takes a reference to FileBasedSource while  FileBasedSource takes a reference to Concatsource.  ConcatSource has a reference to list of SingleFileSources. This results in quadratic space complexity when serializing splits of a FileBasedSource. This CL fixes this by making sure that FileBasedSource is cloned before taking a reference to  ConcatSource