### PR TITLE
Restore StateContexts.windowOnly for temporary compatibility

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/StateContexts.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/StateContexts.java
@@ -42,22 +42,45 @@ public class StateContexts {
         @Override
         public BoundedWindow window() {
           throw new IllegalArgumentException("cannot call window() in a null context");
-        }};
+        }
+      };
 
-  /**
-   * Returns a fake {@link StateContext}.
-   */
+  /** Returns a fake {@link StateContext}. */
   @SuppressWarnings("unchecked")
   public static <W extends BoundedWindow> StateContext<W> nullContext() {
     return (StateContext<W>) NULL_CONTEXT;
   }
 
   /**
-   * Deprecated, do not use.
-   *
-   * <p>This exists only for temporary compatibility with Dataflow worker and should be deleted
-   * once a worker image is released that uses runners-core build after
-   * https://github.com/apache/incubator-beam/pull/1353.
+   * @deprecated This exists only for temporary compatibility with Dataflow worker and should be
+   *     deleted once a worker image is released that uses runners-core build after
+   *     https://github.com/apache/incubator-beam/pull/1353.
+   */
+  @Deprecated
+  public static <W extends BoundedWindow> StateContext<W> windowOnly(final W window) {
+    return new StateContext<W>() {
+      @Override
+      public PipelineOptions getPipelineOptions() {
+        throw new IllegalArgumentException(
+            "cannot call getPipelineOptions() in a window only context");
+      }
+
+      @Override
+      public <T> T sideInput(PCollectionView<T> view) {
+        throw new IllegalArgumentException("cannot call sideInput() in a window only context");
+      }
+
+      @Override
+      public W window() {
+        return window;
+      }
+    };
+  }
+
+  /**
+   * @deprecated This exists only for temporary compatibility with Dataflow worker and should be
+   *     deleted once a worker image is released that uses runners-core build after
+   *     https://github.com/apache/incubator-beam/pull/1353.
    */
   @Deprecated
   public static <W extends BoundedWindow> StateContext<W> createFromComponents(


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This addresses the postcommit failure here: https://builds.apache.org/job/beam_PostCommit_RunnableOnService_GoogleCloudDataflow/1600/org.apache.beam$beam-runners-google-cloud-dataflow-java/testReport/junit/org.apache.beam.sdk.transforms/CombineTest/testSessionsCombineWithContext/

R: @davorbonaci @jkff 