### PR TITLE
BEAM-1018: updated getEstimatedSizeBytes to use Number.longValue()

### DIFF
--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -224,7 +224,7 @@ public class MongoDbIO {
       BasicDBObject stat = new BasicDBObject();
       stat.append("collStats", spec.collection());
       Document stats = mongoDatabase.runCommand(stat);
-      return Long.parseLong(stats.get("size").toString());
+      return stats.get("size", Number.class).longValue();
     }
 
     @Override


### PR DESCRIPTION
Updated BoundedMongoDbSource.getEstimatesSizeBytes to use more generic `Number` class and then return `longValue()`. For smaller collections the `size` is returned as Long but for larger collections, the `size` can be returned using scientific notation.

