### PR TITLE
Remove dependency on findbugs annotations artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,12 +390,6 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>${grpc.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -473,10 +467,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava-jdk5</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
 
@@ -500,10 +490,6 @@
           <exclusion>
             <groupId>com.google.guava</groupId>
             <artifactId>guava-jdk5</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -664,7 +650,7 @@
 
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
-        <artifactId>annotations</artifactId>
+        <artifactId>jsr305</artifactId>
         <version>${findbugs.version}</version>
       </dependency>
 
@@ -672,24 +658,12 @@
         <groupId>com.google.cloud.bigdataoss</groupId>
         <artifactId>gcsio</artifactId>
         <version>${google-cloud-bigdataoss.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>com.google.cloud.bigdataoss</groupId>
         <artifactId>util</artifactId>
         <version>${google-cloud-bigdataoss.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -829,12 +803,6 @@
         <artifactId>guava-testlib</artifactId>
         <version>${guava.version}</version>
         <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/runners/apex/pom.xml
+++ b/runners/apex/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
 		<!-- javax.annotation.Nullable -->
        <groupId>com.google.code.findbugs</groupId>
-       <artifactId>annotations</artifactId>
+       <artifactId>jsr305</artifactId>
     </dependency>
 
     <!-- Test scoped -->

--- a/runners/core-java/pom.xml
+++ b/runners/core-java/pom.xml
@@ -132,7 +132,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/PaneInfoTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/PaneInfoTracker.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.core;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo.PaneInfoCoder;
@@ -71,8 +70,6 @@ public class PaneInfoTracker {
 
     return new ReadableState<PaneInfo>() {
       @Override
-      @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-          justification = "prefetch side effect")
       public ReadableState<PaneInfo> readLater() {
         previousPaneFuture.readLater();
         return this;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SystemReduceFn.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SystemReduceFn.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.core;
 
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.Combine.KeyedCombineFn;
@@ -116,8 +115,6 @@ public abstract class SystemReduceFn<K, InputT, AccumT, OutputT, W extends Bound
   }
 
   @Override
-  @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-    justification = "prefetch side effect")
   public void prefetchOnTrigger(StateAccessor<K> state) {
     state.access(bufferTag).readLater();
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.core;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -465,8 +464,6 @@ class WatermarkHold<W extends BoundedWindow> implements Serializable {
     final WatermarkHoldState<BoundedWindow> extraHoldState = context.state().access(EXTRA_HOLD_TAG);
     return new ReadableState<OldAndNewHolds>() {
       @Override
-      @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-        justification = "")
       public ReadableState<OldAndNewHolds> readLater() {
         elementHoldState.readLater();
         extraHoldState.readLater();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.core.triggers;
 
 import com.google.common.collect.ImmutableList;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -162,8 +161,6 @@ public abstract class AfterDelayFromFirstElementStateMachine extends OnceTrigger
   }
 
   @Override
-  @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification =
-      "prefetch side effect")
   public void prefetchOnElement(StateAccessor<?> state) {
     state.access(DELAYED_UNTIL_TAG).readLater();
   }
@@ -220,8 +217,6 @@ public abstract class AfterDelayFromFirstElementStateMachine extends OnceTrigger
   }
 
   @Override
-  @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification =
-      "prefetch side effect")
   public void prefetchShouldFire(StateAccessor<?> state) {
     state.access(DELAYED_UNTIL_TAG).readLater();
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterPaneStateMachine.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.core.triggers;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Objects;
 import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnceTriggerStateMachine;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -88,8 +87,6 @@ private static final StateTag<Object, AccumulatorCombiningState<Long, long[], Lo
   }
 
   @Override
-  @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification =
-      "prefetch side effect")
   public void prefetchShouldFire(StateAccessor<?> state) {
     state.access(ELEMENTS_IN_PANE_TAG).readLater();
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachines.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachines.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.core.triggers;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -97,32 +96,26 @@ public class TriggerStateMachines {
       }
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private TriggerStateMachine evaluateSpecific(DefaultTrigger v) {
       return DefaultTriggerStateMachine.of();
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private TriggerStateMachine evaluateSpecific(ReshuffleTrigger v) {
       return new ReshuffleTriggerStateMachine();
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(AfterWatermark.FromEndOfWindow v) {
       return AfterWatermarkStateMachine.pastEndOfWindow();
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(NeverTrigger v) {
       return NeverStateMachine.ever();
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(AfterSynchronizedProcessingTime v) {
       return new AfterSynchronizedProcessingTimeStateMachine();
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(AfterFirst v) {
       List<OnceTriggerStateMachine> subStateMachines =
           Lists.newArrayListWithCapacity(v.subTriggers().size());
@@ -132,7 +125,6 @@ public class TriggerStateMachines {
       return AfterFirstStateMachine.of(subStateMachines);
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(AfterAll v) {
       List<OnceTriggerStateMachine> subStateMachines =
           Lists.newArrayListWithCapacity(v.subTriggers().size());
@@ -142,12 +134,10 @@ public class TriggerStateMachines {
       return AfterAllStateMachine.of(subStateMachines);
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(AfterPane v) {
       return AfterPaneStateMachine.elementCountAtLeast(v.getElementCount());
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private TriggerStateMachine evaluateSpecific(AfterWatermark.AfterWatermarkEarlyAndLate v) {
       AfterWatermarkStateMachine.AfterWatermarkEarlyAndLate machine =
           AfterWatermarkStateMachine.pastEndOfWindow()
@@ -159,7 +149,6 @@ public class TriggerStateMachines {
       return machine;
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private TriggerStateMachine evaluateSpecific(AfterEach v) {
       List<TriggerStateMachine> subStateMachines =
           Lists.newArrayListWithCapacity(v.subTriggers().size());
@@ -171,24 +160,20 @@ public class TriggerStateMachines {
       return AfterEachStateMachine.inOrder(subStateMachines);
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private TriggerStateMachine evaluateSpecific(Repeatedly v) {
       return RepeatedlyStateMachine.forever(stateMachineForTrigger(v.getRepeatedTrigger()));
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private TriggerStateMachine evaluateSpecific(OrFinallyTrigger v) {
       return new OrFinallyStateMachine(
           stateMachineForTrigger(v.getMainTrigger()),
           stateMachineForOnceTrigger(v.getUntilTrigger()));
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(AfterProcessingTime v) {
       return evaluateSpecific((AfterDelayFromFirstElement) v);
     }
 
-    @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private OnceTriggerStateMachine evaluateSpecific(final AfterDelayFromFirstElement v) {
       return new AfterDelayFromFirstElementStateMachineAdapter(v);
     }

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -180,7 +180,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -242,7 +242,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -27,16 +27,174 @@
   <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
 
   <!--
-          Baseline issues below. No new issues should be added to this list. Instead, suppress
-          the issue inline using @SuppressFBWarnings and a documented reason, or (preferably) fix
-          the issue.
+          Suppressed findbugs issues. All new issues should include a comment why they're
+          suppressed.
+
+          Suppressions should go in this file rather than inline using @SuppressFBWarnings to avoid
+          unapproved artifact license.
         -->
   <Match>
-    <Class name="org.apache.beam.sdk.coders.JAXBCoder"/>
-    <Method name="getContext"/>
-    <Bug pattern="DC_DOUBLECHECK"/>
-    <!--[BEAM-398] Possible double check of field-->
+    <Class name="org.apache.beam.sdk.coders.AvroCoder$SerializableSchemaSupplier"/>
+    <Field name="schema"/>
+    <Bug pattern="SE_BAD_FIELD"/>
+    <!--
+    writeReplace makes this object serializable. This is a limitation of FindBugs as discussed here:
+     http://stackoverflow.com/questions/26156523/is-writeobject-not-neccesary-using-the-serialization-proxy-pattern
+    -->
   </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.coders.InstantCoder$LexicographicLongConverter"/>
+    <Bug pattern="HE_INHERITS_EQUALS_USE_HASHCODE"/>
+    <!-- Converter overrides .equals() to add documentation but does not change behavior -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.testing.PAssert$PCollectionViewAssert"/>
+    <Method name="equals" />
+    <Bug pattern="EQ_UNUSUAL"/>
+    <!-- Unsupported operation -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.testing.PAssert$PCollectionContentsAssert"/>
+    <Method name="equals" />
+    <Bug pattern="EQ_UNUSUAL"/>
+    <!-- Unsupported operation -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.testing.SerializableMatchers$SerializableArrayViaCoder"/>
+    <Field name="value" />
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+    <!-- Cached value is lazily restored on read. -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.AttemptAndTimeBoundedExponentialBackOff"/>
+    <Method name="reset" />
+    <Bug pattern="UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR"/>
+    <!-- Explicitly handled in implementation. -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.ExposedByteArrayInputStream"/>
+    <Method name="readAll" />
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <!-- Returns internal buffer by design. -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.ExposedByteArrayOutputStream"/>
+    <Method name="toByteArray" />
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <!-- Returns internal buffer by design. -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.ExposedByteArrayOutputStream"/>
+    <Method name="toByteArray" />
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <!-- Returns internal buffer by design. -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.ExposedByteArrayOutputStream"/>
+    <Method name="writeAndOwn" />
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <!-- Takes ownership of input buffer -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.ZipFiles"/>
+    <Method name="zipDirectory" />
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    <!--
+      File.listFiles() will return null if the File instance is not a directory. Null dereference is
+      not a possibility here since we validate sourceDirectory is directory via
+      sourceDirectory.isDirectory()
+    -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.ZipFiles"/>
+    <Method name="zipDirectoryInternal" />
+    <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    <!--
+      File.listFiles() will return null if the File instance is not a directory. Null dereference is
+      not a possibility here since we validate sourceDirectory is directory via
+      sourceDirectory.isDirectory()
+    -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.sdk.util.state.StateMerging"/>
+    <Method name="prefetchRead" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch call readLater -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runner.core.PaneInfoTracker"/>
+    <Method name="getNextPaneInfo" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch side effect -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runner.core.SystemReduceFn"/>
+    <Method name="prefetchOnTrigger" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch side effect -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runner.core.WatermarkHold"/>
+    <Method name="extractAndRelease" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch call readLater -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runners.core.triggers.AfterDelayFromFirstElementStateMachine"/>
+    <Method name="prefetchOnElement" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch side effect -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runners.core.triggers.AfterDelayFromFirstElementStateMachine"/>
+    <Method name="prefetchShouldFire" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch side effect -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runners.core.triggers.AfterPaneStateMachine"/>
+    <Method name="prefetchShouldFire" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+    <!-- prefetch side effect -->
+  </Match>
+
+  <Match>
+    <Class name="org.apache.beam.runners.core.triggers.TriggerStateMachines$StateMachineConverter"/>
+    <Method name="evaluateSpecific" />
+    <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
+    <!-- Called via reflection -->
+  </Match>
+
+
+  <!--
+    Baseline issues. No new issues should be added below this line and all existing issues should
+    have an associated JIRA
+  -->
+
+  <Match>
+  <Class name="org.apache.beam.sdk.coders.JAXBCoder"/>
+  <Method name="getContext"/>
+  <Bug pattern="DC_DOUBLECHECK"/>
+  <!--[BEAM-398] Possible double check of field-->
+</Match>
   <Match>
     <Class name="org.apache.beam.sdk.io.range.OffsetRangeTracker"/>
     <Field name="done"/>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -341,7 +341,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -22,7 +22,6 @@ import static org.apache.beam.sdk.util.Structs.addString;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Supplier;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectStreamException;
@@ -214,10 +213,6 @@ public class AvroCoder<T> extends StandardCoder<T> {
    * Java's serialization and hence is able to encode the {@link Schema} object directly.
    */
   private static class SerializableSchemaSupplier implements Serializable, Supplier<Schema> {
-    @SuppressFBWarnings(justification = "writeReplace makes this object serializable. This is a "
-        + "limitation of FindBugs as discussed here: http://stackoverflow.com/questions/"
-        + "26156523/is-writeobject-not-neccesary-using-the-serialization-proxy-pattern",
-        value = "SE_BAD_FIELD")
     private final Schema schema;
     private SerializableSchemaSupplier(Schema schema) {
       this.schema = schema;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/InstantCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/InstantCoder.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.coders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.base.Converter;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -56,9 +55,6 @@ public class InstantCoder extends AtomicCoder<Instant> {
    * <p>This deliberately utilizes the well-defined overflow for {@code Long} values.
    * See http://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.18.2
    */
-  @SuppressFBWarnings(value = "HE_INHERITS_EQUALS_USE_HASHCODE",
-      justification = "Converter overrides .equals() to add documentation "
-          + "but does not change behavior")
   private static class LexicographicLongConverter extends Converter<Instant, Long> {
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -499,7 +498,6 @@ public class PAssert {
      */
     @Deprecated
     @Override
-    @SuppressFBWarnings(value = "EQ_UNUSUAL", justification = "Unsupported operation")
     public boolean equals(Object o) {
       throw new UnsupportedOperationException(
           "If you meant to test object equality, use .containsInAnyOrder instead.");
@@ -713,7 +711,6 @@ public class PAssert {
      */
     @Deprecated
     @Override
-    @SuppressFBWarnings(value = "EQ_UNUSUAL", justification = "Unsupported operation")
     public boolean equals(Object o) {
       throw new UnsupportedOperationException(
           String.format(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SerializableMatchers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SerializableMatchers.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.testing;
 
 import com.google.common.base.MoreObjects;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1147,8 +1146,6 @@ class SerializableMatchers implements Serializable {
   private static class SerializableArrayViaCoder<T> implements SerializableSupplier<T[]> {
     /** Cached value that is not serialized. */
     @Nullable
-    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
-        justification = "Cached value is lazily restored on read.")
     private transient T[] value;
 
     /** The bytes of {@link #value} when encoded via {@link #coder}. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/AttemptAndTimeBoundedExponentialBackOff.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/AttemptAndTimeBoundedExponentialBackOff.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.api.client.util.BackOff;
 import com.google.api.client.util.NanoClock;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -130,8 +129,6 @@ public class AttemptAndTimeBoundedExponentialBackOff extends AttemptBoundedExpon
   }
 
   @Override
-  @SuppressFBWarnings(value = "UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR",
-      justification = "Explicitly handled in implementation.")
   public void reset() {
     // reset() is called in the constructor of the parent class before resetPolicy and nanoClock are
     // set.  In this case, we call the parent class's reset() method and return.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayInputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayInputStream.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.util;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -33,7 +32,6 @@ public class ExposedByteArrayInputStream extends ByteArrayInputStream{
   /**
    * Read all remaining bytes.
    */
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Returns internal buffer by design")
   public byte[] readAll() throws IOException {
     if (pos == 0 && count == buf.length) {
       pos = count;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayOutputStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ExposedByteArrayOutputStream.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.util;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -63,7 +62,6 @@ public class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
    *
    * <p><i>Note: After passing any byte array to this method, it must not be modified again.</i>
    */
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Takes ownership of input buffer")
   public void writeAndOwn(byte[] b) throws IOException {
     if (b.length == 0) {
       return;
@@ -93,7 +91,6 @@ public class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
   }
 
   @Override
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Returns internal buffer by design")
   public byte[] toByteArray() {
     // Note: count == buf.length is not a correct criteria to "return buf;", because the internal
     // buf may be reused after reset().

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ZipFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ZipFiles.java
@@ -26,7 +26,6 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
 import com.google.common.io.Closer;
 import com.google.common.io.Files;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -226,10 +225,6 @@ public final class ZipFiles {
    * @throws IOException the zipping failed, e.g. because the input was not
    *     readable.
    */
-  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
-      justification = "File.listFiles() will return null if the File instance is not a directory. "
-          + "Null dereference is not a possibility here since we validate sourceDirectory is "
-          + "directory via sourceDirectory.isDirectory()")
   public static void zipDirectory(
       File sourceDirectory,
       OutputStream outputStream) throws IOException {
@@ -262,10 +257,6 @@ public final class ZipFiles {
    * @throws IOException the zipping failed, e.g. because the output was not
    *     writeable.
    */
-  @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
-      justification = "File.listFiles() will return null if the File instance is not a directory. "
-          + "Null dereference is not a possibility here since we validate inputFile is directory "
-          + "via inputFile.isDirectory()")
   private static void zipDirectoryInternal(
       File inputFile,
       String directoryName,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/StateMerging.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/StateMerging.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.util.state;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -191,8 +190,6 @@ public class StateMerging {
     }
   }
 
-  @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-      justification = "prefetch call readLater")
   private static void prefetchRead(ReadableState<?> source) {
     source.readLater();
   }

--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -133,24 +133,12 @@
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-protos</artifactId>
       <version>${bigtable.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-client-core</artifactId>
       <version>${bigtable.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -195,7 +183,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/hdfs/pom.xml
+++ b/sdks/java/io/hdfs/pom.xml
@@ -70,7 +70,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/jdbc/pom.xml
+++ b/sdks/java/io/jdbc/pom.xml
@@ -65,7 +65,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/jms/pom.xml
+++ b/sdks/java/io/jms/pom.xml
@@ -91,7 +91,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/sdks/java/io/kafka/pom.xml
+++ b/sdks/java/io/kafka/pom.xml
@@ -98,7 +98,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <!-- test dependencies-->

--- a/sdks/java/io/kinesis/pom.xml
+++ b/sdks/java/io/kinesis/pom.xml
@@ -123,7 +123,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/io/mongodb/pom.xml
+++ b/sdks/java/io/mongodb/pom.xml
@@ -69,7 +69,7 @@
 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The findbugs annotations artifact has an incompatible license and cannot
be included within Beam. We were previously referencing it for the
@SuppressFBWarning annotation for inline FindBugs suppression.

This change moves inline suppressions out to the existing
findbugs-filter.xml file. While not ideal as it removes the suppressions
from the offending context, it allows us to drop our dependency on the
incompatible artifact.

We are also referencing the @Nullable attribute from findbugs. This is
now source from findbugs jsr305, which does have a compatible license.