### PR TITLE
Ignore UsesStatefulParDo Tests in Flink Streaming Runner

### DIFF
--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -79,6 +79,7 @@
                 </goals>
                 <configuration>
                   <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
+                  <excludedGroups>org.apache.beam.sdk.testing.UsesStatefulParDo</excludedGroups>
                   <parallel>none</parallel>
                   <failIfNoTests>true</failIfNoTests>
                   <dependenciesToScan>


### PR DESCRIPTION
Until we fix BEAM-1036 we need to ignore those tests. Before, only the tests for the batch runner ignored them.