### PR TITLE
Adds TransformEvaluator.startBundle()

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
@@ -120,6 +120,11 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(WindowedValue<BoundedSourceShard<OutputT>> element)
         throws Exception {
       BoundedSource<OutputT> source = element.getValue().getSource();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManagerRemovingTransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManagerRemovingTransformEvaluator.java
@@ -44,6 +44,16 @@ class DoFnLifecycleManagerRemovingTransformEvaluator<InputT> implements Transfor
   }
 
   @Override
+  public void startBundle() throws Exception {
+    try {
+      underlying.startBundle();
+    } catch (Exception e) {
+      onException(e, "Exception encountered while cleaning up after starting a bundle");
+      throw e;
+    }
+  }
+
+  @Override
   public void processElement(WindowedValue<InputT> element) throws Exception {
     try {
       underlying.processElement(element);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EmptyTransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EmptyTransformEvaluator.java
@@ -40,6 +40,9 @@ final class EmptyTransformEvaluator<T> implements TransformEvaluator<T> {
   }
 
   @Override
+  public void startBundle() throws Exception {}
+
+  @Override
   public void processElement(WindowedValue<T> element) throws Exception {}
 
   @Override

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/FlattenEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/FlattenEvaluatorFactory.java
@@ -72,6 +72,11 @@ class FlattenEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(WindowedValue<InputT> element) {
       outputBundle.add(element);
     }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupAlsoByWindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupAlsoByWindowEvaluatorFactory.java
@@ -156,6 +156,11 @@ class GroupAlsoByWindowEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(WindowedValue<KeyedWorkItem<K, V>> element) throws Exception {
       KeyedWorkItem<K, V> workItem = element.getValue();
       K key = workItem.key();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
@@ -120,6 +120,11 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(WindowedValue<KV<K, V>> element) {
       KV<K, V> kv = element.getValue();
       K key = kv.getKey();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -78,12 +78,6 @@ class ParDoEvaluator<InputT, OutputT> implements TransformEvaluator<InputT> {
     PushbackSideInputDoFnRunner<InputT, OutputT> runner =
         PushbackSideInputDoFnRunner.create(underlying, sideInputs, sideInputReader);
 
-    try {
-      runner.startBundle();
-    } catch (Exception e) {
-      throw UserCodeException.wrap(e);
-    }
-
     return new ParDoEvaluator<>(
         evaluationContext,
         runner,
@@ -118,6 +112,15 @@ class ParDoEvaluator<InputT, OutputT> implements TransformEvaluator<InputT> {
     this.stepContext = stepContext;
     this.aggregatorChanges = aggregatorChanges;
     this.unprocessedElements = ImmutableList.builder();
+  }
+
+  @Override
+  public void startBundle() {
+    try {
+      fnRunner.startBundle();
+    } catch (Exception e) {
+      throw UserCodeException.wrap(e);
+    }
   }
 
   @Override

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/PassthroughTransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/PassthroughTransformEvaluator.java
@@ -37,6 +37,11 @@ class PassthroughTransformEvaluator<InputT> implements TransformEvaluator<InputT
   }
 
   @Override
+  public void startBundle() throws Exception {
+    // No-op.
+  }
+
+  @Override
   public void processElement(WindowedValue<InputT> element) throws Exception {
     output.add(element);
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactory.java
@@ -215,6 +215,11 @@ final class StatefulParDoEvaluatorFactory<K, InputT, OutputT> implements Transfo
     }
 
     @Override
+    public void startBundle() throws Exception {
+      delegateEvaluator.startBundle();
+    }
+
+    @Override
     public void processElement(WindowedValue<KV<K, Iterable<InputT>>> gbkResult) throws Exception {
 
       for (InputT value : gbkResult.getValue().getValue()) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
@@ -94,6 +94,11 @@ class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(WindowedValue<TestStreamIndex<T>> element) throws Exception {
       TestStreamIndex<T> streamIndex = element.getValue();
       List<Event<T>> events = streamIndex.getTestStream().getEvents();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluator.java
@@ -21,12 +21,17 @@ import org.apache.beam.runners.direct.DirectRunner.CommittedBundle;
 import org.apache.beam.sdk.util.WindowedValue;
 
 /**
- * An evaluator of a specific application of a transform. Will be used for at least one
+ * An evaluator of a specific application of a transform. Will be used for at exactly one
  * {@link CommittedBundle}.
  *
  * @param <InputT> the type of elements that will be passed to {@link #processElement}
  */
 public interface TransformEvaluator<InputT> {
+  /**
+   * Start processing the bundle of this {@link TransformEvaluator}.
+   */
+  void startBundle() throws Exception;
+
   /**
    * Process an element in the input {@link CommittedBundle}.
    *

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutor.java
@@ -104,6 +104,8 @@ class TransformExecutor<T> implements Runnable {
         return;
       }
 
+      evaluator.startBundle();
+
       processElements(evaluator, metricsContainer, enforcements);
 
       finishBundle(evaluator, metricsContainer, enforcements);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -113,6 +113,11 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(
         WindowedValue<UnboundedSourceShard<OutputT, CheckpointMarkT>> element) throws IOException {
       UncommittedBundle<OutputT> output = evaluationContext.createBundle(transform.getOutput());

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ViewEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ViewEvaluatorFactory.java
@@ -74,6 +74,11 @@ class ViewEvaluatorFactory implements TransformEvaluatorFactory {
       private final List<WindowedValue<InT>> elements = new ArrayList<>();
 
       @Override
+      public void startBundle() throws Exception {
+        // No-op.
+      }
+
+      @Override
       public void processElement(WindowedValue<Iterable<InT>> element) {
         for (InT input : element.getValue()) {
           elements.add(element.withValue(input));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -85,6 +85,11 @@ class WindowEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    public void startBundle() throws Exception {
+      // No-op.
+    }
+
+    @Override
     public void processElement(WindowedValue<InputT> compressedElement) throws Exception {
       for (WindowedValue<InputT> element : compressedElement.explodeWindows()) {
         Collection<? extends BoundedWindow> windows = assignWindows(windowFn, element);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
@@ -107,6 +107,7 @@ public class BoundedReadEvaluatorFactoryTest {
     for (CommittedBundle<?> shardBundle : initialInputs) {
       TransformEvaluator<?> evaluator =
           factory.forApplication(longs.getProducingTransformInternal(), null);
+      evaluator.startBundle();
       for (WindowedValue<?> shard : shardBundle.getElements()) {
         evaluator.processElement((WindowedValue) shard);
       }
@@ -155,6 +156,7 @@ public class BoundedReadEvaluatorFactoryTest {
       Collection<CommittedBundle<?>> newUnreadInputs = new ArrayList<>();
       for (CommittedBundle<?> shardBundle : unreadInputs) {
         TransformEvaluator<Long> evaluator = factory.forApplication(transform, null);
+        evaluator.startBundle();
         for (WindowedValue<?> shard : shardBundle.getElements()) {
           evaluator.processElement((WindowedValue) shard);
         }
@@ -204,6 +206,7 @@ public class BoundedReadEvaluatorFactoryTest {
     for (CommittedBundle<?> shardBundle : initialInputs) {
       TransformEvaluator<?> evaluator =
           factory.forApplication(transform, null);
+      evaluator.startBundle();
       for (WindowedValue<?> shard : shardBundle.getElements()) {
         evaluator.processElement((WindowedValue) shard);
       }
@@ -272,6 +275,7 @@ public class BoundedReadEvaluatorFactoryTest {
 
     TransformEvaluator<BoundedSourceShard<Long>> evaluator =
         factory.forApplication(longs.getProducingTransformInternal(), shards);
+    evaluator.startBundle();
     for (WindowedValue<BoundedSourceShard<Long>> shard : shards.getElements()) {
       UncommittedBundle<Long> outputBundle = bundleFactory.createBundle(longs);
       when(context.createBundle(longs)).thenReturn(outputBundle);
@@ -307,6 +311,7 @@ public class BoundedReadEvaluatorFactoryTest {
     TransformEvaluator<BoundedSourceShard<Long>> evaluator =
         factory.forApplication(
             sourceTransform, bundleFactory.createRootBundle().commit(Instant.now()));
+    evaluator.startBundle();
     evaluator.processElement(WindowedValue.valueInGlobalWindow(BoundedSourceShard.of(source)));
     evaluator.finishBundle();
     CommittedBundle<Long> committed = output.commit(Instant.now());
@@ -328,6 +333,7 @@ public class BoundedReadEvaluatorFactoryTest {
     TransformEvaluator<BoundedSourceShard<Long>> evaluator =
         factory.forApplication(
             sourceTransform, bundleFactory.createRootBundle().commit(Instant.now()));
+    evaluator.startBundle();
     evaluator.processElement(WindowedValue.valueInGlobalWindow(BoundedSourceShard.of(source)));
     evaluator.finishBundle();
     CommittedBundle<Long> committed = output.commit(Instant.now());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
@@ -73,6 +73,8 @@ public class FlattenEvaluatorFactoryTest {
         factory.forApplication(flattened.getProducingTransformInternal(), leftBundle);
     TransformEvaluator<Integer> rightSideEvaluator =
         factory.forApplication(flattened.getProducingTransformInternal(), rightBundle);
+    leftSideEvaluator.startBundle();
+    rightSideEvaluator.startBundle();
 
     leftSideEvaluator.processElement(WindowedValue.valueInGlobalWindow(1));
     rightSideEvaluator.processElement(WindowedValue.valueInGlobalWindow(-1));
@@ -131,6 +133,7 @@ public class FlattenEvaluatorFactoryTest {
             flattened.getProducingTransformInternal(),
             bundleFactory.createRootBundle().commit(BoundedWindow.TIMESTAMP_MAX_VALUE));
 
+    emptyEvaluator.startBundle();
     TransformResult<Integer> leftSideResult = emptyEvaluator.finishBundle();
 
     CommittedBundle<?> outputBundle =

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyEvaluatorFactoryTest.java
@@ -99,6 +99,8 @@ public class GroupByKeyEvaluatorFactoryTest {
         new GroupByKeyOnlyEvaluatorFactory(evaluationContext)
             .forApplication(groupedKvs.getProducingTransformInternal(), inputBundle);
 
+    evaluator.startBundle();
+
     evaluator.processElement(WindowedValue.valueInGlobalWindow(firstFoo));
     evaluator.processElement(WindowedValue.valueInGlobalWindow(secondFoo));
     evaluator.processElement(WindowedValue.valueInGlobalWindow(thirdFoo));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactoryTest.java
@@ -93,6 +93,8 @@ public class GroupByKeyOnlyEvaluatorFactoryTest {
             .forApplication(
                 groupedKvs.getProducingTransformInternal(), inputBundle);
 
+    evaluator.startBundle();
+
     evaluator.processElement(WindowedValue.valueInGlobalWindow(firstFoo));
     evaluator.processElement(WindowedValue.valueInGlobalWindow(secondFoo));
     evaluator.processElement(WindowedValue.valueInGlobalWindow(thirdFoo));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoEvaluatorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoEvaluatorTest.java
@@ -109,6 +109,7 @@ public class ParDoEvaluatorTest {
             ImmutableList.of(nonGlobalWindow, GlobalWindow.INSTANCE),
             PaneInfo.NO_FIRING);
 
+    evaluator.startBundle();
     evaluator.processElement(first);
     evaluator.processElement(second);
     evaluator.processElement(third);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactoryTest.java
@@ -275,6 +275,7 @@ public class StatefulParDoEvaluatorFactoryTest implements Serializable {
             .commit(Instant.now());
     TransformEvaluator<KV<String, Iterable<Integer>>> evaluator =
         factory.forApplication(producingTransform, inputBundle);
+    evaluator.startBundle();
     evaluator.processElement(gbkOutputElement);
 
     // This should push back every element as a KV<String, Iterable<Integer>>

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactoryTest.java
@@ -89,6 +89,7 @@ public class TestStreamEvaluatorFactoryTest {
 
     TransformEvaluator<TestStreamIndex<Integer>> firstEvaluator =
         factory.forApplication(streamVals.getProducingTransformInternal(), initialBundle);
+    firstEvaluator.startBundle();
     firstEvaluator.processElement(Iterables.getOnlyElement(initialBundle.getElements()));
     TransformResult<TestStreamIndex<Integer>> firstResult = firstEvaluator.finishBundle();
 
@@ -102,6 +103,7 @@ public class TestStreamEvaluatorFactoryTest {
         initialBundle.withElements(Collections.singleton(firstResidual));
     TransformEvaluator<TestStreamIndex<Integer>> secondEvaluator =
         factory.forApplication(streamVals.getProducingTransformInternal(), secondBundle);
+    secondEvaluator.startBundle();
     secondEvaluator.processElement(firstResidual);
     TransformResult<TestStreamIndex<Integer>> secondResult = secondEvaluator.finishBundle();
 
@@ -115,6 +117,7 @@ public class TestStreamEvaluatorFactoryTest {
         secondBundle.withElements(Collections.singleton(secondResidual));
     TransformEvaluator<TestStreamIndex<Integer>> thirdEvaluator =
         factory.forApplication(streamVals.getProducingTransformInternal(), thirdBundle);
+    thirdEvaluator.startBundle();
     thirdEvaluator.processElement(secondResidual);
     TransformResult<TestStreamIndex<Integer>> thirdResult = thirdEvaluator.finishBundle();
 
@@ -129,6 +132,7 @@ public class TestStreamEvaluatorFactoryTest {
         thirdBundle.withElements(Collections.singleton(thirdResidual));
     TransformEvaluator<TestStreamIndex<Integer>> fourthEvaluator =
         factory.forApplication(streamVals.getProducingTransformInternal(), fourthBundle);
+    fourthEvaluator.startBundle();
     fourthEvaluator.processElement(thirdResidual);
     TransformResult<TestStreamIndex<Integer>> fourthResult = fourthEvaluator.finishBundle();
 
@@ -143,6 +147,7 @@ public class TestStreamEvaluatorFactoryTest {
         thirdBundle.withElements(Collections.singleton(fourthResidual));
     TransformEvaluator<TestStreamIndex<Integer>> fifthEvaluator =
         factory.forApplication(streamVals.getProducingTransformInternal(), fifthBundle);
+    fifthEvaluator.startBundle();
     fifthEvaluator.processElement(fourthResidual);
     TransformResult<TestStreamIndex<Integer>> fifthResult = fifthEvaluator.finishBundle();
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/TransformExecutorTest.java
@@ -97,9 +97,15 @@ public class TransformExecutorTest {
   public void callWithNullInputBundleFinishesBundleAndCompletes() throws Exception {
     final TransformResult<Object> result =
         StepTransformResult.withoutHold(created.getProducingTransformInternal()).build();
+    final AtomicBoolean startCalled = new AtomicBoolean(false);
     final AtomicBoolean finishCalled = new AtomicBoolean(false);
     TransformEvaluator<Object> evaluator =
         new TransformEvaluator<Object>() {
+          @Override
+          public void startBundle() throws Exception {
+            startCalled.set(true);
+          }
+
           @Override
           public void processElement(WindowedValue<Object> element) throws Exception {
             throw new IllegalArgumentException("Shouldn't be called");
@@ -124,8 +130,12 @@ public class TransformExecutorTest {
             created.getProducingTransformInternal(),
             completionCallback,
             transformEvaluationState);
+
+    assertThat(startCalled.get(), is(false));
+
     executor.run();
 
+    assertThat(startCalled.get(), is(true));
     assertThat(finishCalled.get(), is(true));
     assertThat(completionCallback.handledResult, Matchers.<TransformResult<?>>equalTo(result));
     assertThat(completionCallback.handledException, is(nullValue()));
@@ -159,9 +169,11 @@ public class TransformExecutorTest {
     TransformEvaluator<String> evaluator =
         new TransformEvaluator<String>() {
           @Override
+          public void startBundle() throws Exception { }
+
+          @Override
           public void processElement(WindowedValue<String> element) throws Exception {
             elementsProcessed.add(element);
-            return;
           }
 
           @Override
@@ -205,6 +217,9 @@ public class TransformExecutorTest {
     TransformEvaluator<String> evaluator =
         new TransformEvaluator<String>() {
           @Override
+          public void startBundle() throws Exception { }
+
+          @Override
           public void processElement(WindowedValue<String> element) throws Exception {
             throw exception;
           }
@@ -244,6 +259,9 @@ public class TransformExecutorTest {
     TransformEvaluator<String> evaluator =
         new TransformEvaluator<String>() {
           @Override
+          public void startBundle() throws Exception { }
+
+          @Override
           public void processElement(WindowedValue<String> element) throws Exception {}
 
           @Override
@@ -281,6 +299,9 @@ public class TransformExecutorTest {
 
     TransformEvaluator<Object> evaluator =
         new TransformEvaluator<Object>() {
+          @Override
+          public void startBundle() throws Exception { }
+
           @Override
           public void processElement(WindowedValue<Object> element) throws Exception {}
 
@@ -340,6 +361,9 @@ public class TransformExecutorTest {
     TransformEvaluator<Object> evaluator =
         new TransformEvaluator<Object>() {
           @Override
+          public void startBundle() throws Exception { }
+
+          @Override
           public void processElement(WindowedValue<Object> element) throws Exception {}
 
           @Override
@@ -395,6 +419,9 @@ public class TransformExecutorTest {
 
     TransformEvaluator<Object> evaluator =
         new TransformEvaluator<Object>() {
+          @Override
+          public void startBundle() throws Exception { }
+
           @Override
           public void processElement(WindowedValue<Object> element) throws Exception {
             testLatch.countDown();

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
@@ -158,6 +158,7 @@ public class UnboundedReadEvaluatorFactoryTest {
         factory.forApplication(
             longs.getProducingTransformInternal(), inputShards);
 
+    evaluator.startBundle();
     evaluator.processElement((WindowedValue) Iterables.getOnlyElement(inputShards.getElements()));
     TransformResult<? super UnboundedSourceShard<Long, ?>> result = evaluator.finishBundle();
 
@@ -203,6 +204,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     TransformEvaluator<UnboundedSourceShard<Long, TestCheckpointMark>> evaluator =
         factory.forApplication(sourceTransform, inputBundle);
 
+    evaluator.startBundle();
     for (WindowedValue<?> value : inputBundle.getElements()) {
       evaluator.processElement(
           (WindowedValue<UnboundedSourceShard<Long, TestCheckpointMark>>) value);
@@ -220,6 +222,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     WindowedValue<UnboundedSourceShard<Long, TestCheckpointMark>> residual =
         (WindowedValue<UnboundedSourceShard<Long, TestCheckpointMark>>)
             Iterables.getOnlyElement(result.getUnprocessedElements());
+    secondEvaluator.startBundle();
     secondEvaluator.processElement(residual);
     secondEvaluator.finishBundle();
     assertThat(
@@ -246,6 +249,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     CommittedBundle<?> inputBundle = Iterables.getOnlyElement(initialInputs);
     TransformEvaluator<UnboundedSourceShard<Long, TestCheckpointMark>> evaluator =
         factory.forApplication(sourceTransform, inputBundle);
+    evaluator.startBundle();
     for (WindowedValue<?> value : inputBundle.getElements()) {
       evaluator.processElement(
           (WindowedValue<UnboundedSourceShard<Long, TestCheckpointMark>>) value);
@@ -262,6 +266,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     WindowedValue<UnboundedSourceShard<Long, TestCheckpointMark>> residual =
         (WindowedValue<UnboundedSourceShard<Long, TestCheckpointMark>>)
             Iterables.getOnlyElement(result.getUnprocessedElements());
+    secondEvaluator.startBundle();
     secondEvaluator.processElement(residual);
 
     TransformResult<UnboundedSourceShard<Long, TestCheckpointMark>> secondResult =
@@ -311,6 +316,7 @@ public class UnboundedReadEvaluatorFactoryTest {
         .getInitialInputs(pcollection.getProducingTransformInternal(), 1);
     TransformEvaluator<UnboundedSourceShard<Long, TestCheckpointMark>> evaluator =
         factory.forApplication(sourceTransform, inputBundle);
+    evaluator.startBundle();
     evaluator.processElement(shard);
     TransformResult<UnboundedSourceShard<Long, TestCheckpointMark>> result =
         evaluator.finishBundle();
@@ -322,6 +328,7 @@ public class UnboundedReadEvaluatorFactoryTest {
 
     TransformEvaluator<UnboundedSourceShard<Long, TestCheckpointMark>> secondEvaluator =
         factory.forApplication(sourceTransform, residual);
+    secondEvaluator.startBundle();
     secondEvaluator.processElement(Iterables.getOnlyElement(residual.getElements()));
     secondEvaluator.finishBundle();
 
@@ -354,6 +361,7 @@ public class UnboundedReadEvaluatorFactoryTest {
         new UnboundedReadEvaluatorFactory(context, 0.0 /* never reuse */);
     TransformEvaluator<UnboundedSourceShard<Long, TestCheckpointMark>> evaluator =
         factory.forApplication(sourceTransform, inputBundle);
+    evaluator.startBundle();
     evaluator.processElement(shard);
     TransformResult<UnboundedSourceShard<Long, TestCheckpointMark>> result =
         evaluator.finishBundle();
@@ -365,6 +373,7 @@ public class UnboundedReadEvaluatorFactoryTest {
 
     TransformEvaluator<UnboundedSourceShard<Long, TestCheckpointMark>> secondEvaluator =
         factory.forApplication(sourceTransform, residual);
+    secondEvaluator.startBundle();
     secondEvaluator.processElement(Iterables.getOnlyElement(residual.getElements()));
     secondEvaluator.finishBundle();
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
@@ -77,6 +77,7 @@ public class ViewEvaluatorFactoryTest {
         new ViewEvaluatorFactory(context)
             .forApplication(view.getProducingTransformInternal(), inputBundle);
 
+    evaluator.startBundle();
     evaluator.processElement(
         WindowedValue.<Iterable<String>>valueInGlobalWindow(ImmutableList.of("foo", "bar")));
     assertThat(viewWriter.latest, nullValue());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -310,6 +310,7 @@ public class WindowEvaluatorFactoryTest {
         factory.forApplication(
             AppliedPTransform.of("Window", input, windowed, windowTransform), inputBundle);
 
+    evaluator.startBundle();
     evaluator.processElement(valueInGlobalWindow);
     evaluator.processElement(valueInGlobalAndTwoIntervalWindows);
     evaluator.processElement(valueInIntervalWindow);


### PR DESCRIPTION
For symmetry with finishBundle() and to allow decoupling creation of
a ParDoEvaluator from the time it calls fn.startBundle().

R: @tgroh 