### PR TITLE
[BEAM-1033] Bigquery Verifier Retry When Query Failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <jackson.version>2.7.2</jackson.version>
     <findbugs.version>3.0.1</findbugs.version>
     <joda.version>2.4</joda.version>
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
     <mockito.version>1.9.5</mockito.version>
     <netty.version>4.1.3.Final</netty.version>
     <os-maven-plugin.version>1.4.0.Final</os-maven-plugin.version>

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/BigqueryMatcherTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/BigqueryMatcherTest.java
@@ -18,8 +18,6 @@
 package org.apache.beam.sdk.testing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -90,18 +88,15 @@ public class BigqueryMatcherTest {
     doReturn(mockBigqueryClient).when(matcher).newBigqueryClient(anyString());
     when(mockQuery.execute()).thenReturn(createResponseContainingTestData());
 
+    thrown.expect(AssertionError.class);
+    thrown.expectMessage("Total number of rows are: 1");
+    thrown.expectMessage("abc");
     try {
       assertThat(mockResult, matcher);
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage(), containsString("Total number of rows are: 1"));
-      assertThat(expected.getMessage(), containsString("abc"));
+    } finally {
       verify(matcher).newBigqueryClient(eq(appName));
       verify(mockJobs).query(eq(projectId), eq(new QueryRequest().setQuery(query)));
-      return;
     }
-    // Note that fail throws an AssertionError which is why it is placed out here
-    // instead of inside the try-catch block.
-    fail("AssertionError is expected.");
   }
 
   @Test
@@ -111,18 +106,15 @@ public class BigqueryMatcherTest {
     doReturn(mockBigqueryClient).when(matcher).newBigqueryClient(anyString());
     when(mockQuery.execute()).thenReturn(new QueryResponse().setJobComplete(false));
 
+    thrown.expect(AssertionError.class);
+    thrown.expectMessage("The query job hasn't completed.");
+    thrown.expectMessage("jobComplete=false");
     try {
       assertThat(mockResult, matcher);
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage(), containsString("The query job hasn't completed."));
-      assertThat(expected.getMessage(), containsString("jobComplete=false"));
+    } finally {
       verify(matcher).newBigqueryClient(eq(appName));
       verify(mockJobs).query(eq(projectId), eq(new QueryRequest().setQuery(query)));
-      return;
     }
-    // Note that fail throws an AssertionError which is why it is placed out here
-    // instead of inside the try-catch block.
-    fail("AssertionError is expected.");
   }
 
   @Test
@@ -131,23 +123,18 @@ public class BigqueryMatcherTest {
         new BigqueryMatcher(appName, projectId, query, "some-checksum"));
     when(mockQuery.execute()).thenThrow(new IOException());
 
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("Unable to get BigQuery response after retrying");
     try {
       matcher.queryWithRetries(
           mockBigqueryClient,
           new QueryRequest(),
           fastClock,
           BigqueryMatcher.BACKOFF_FACTORY.backoff());
-    } catch (RuntimeException expected) {
-      assertThat(
-          expected.getMessage(),
-          containsString("Unable to get BigQuery response after retrying"));
+    } finally {
       verify(mockJobs, atLeast(BigqueryMatcher.MAX_QUERY_RETRIES))
           .query(eq(projectId), eq(new QueryRequest()));
-      return;
     }
-    // Note that fail throws an RuntimeException which is why it is placed out here
-    // instead of inside the try-catch block.
-    fail("RuntimeException is expected.");
   }
 
   @Test
@@ -156,23 +143,18 @@ public class BigqueryMatcherTest {
         new BigqueryMatcher(appName, projectId, query, "some-checksum"));
     when(mockQuery.execute()).thenReturn(null);
 
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("Unable to get BigQuery response after retrying");
     try {
       matcher.queryWithRetries(
           mockBigqueryClient,
           new QueryRequest(),
           fastClock,
           BigqueryMatcher.BACKOFF_FACTORY.backoff());
-    } catch (RuntimeException expected) {
-      assertThat(
-          expected.getMessage(),
-          containsString("Unable to get BigQuery response after retrying"));
+    } finally {
       verify(mockJobs, atLeast(BigqueryMatcher.MAX_QUERY_RETRIES))
           .query(eq(projectId), eq(new QueryRequest()));
-      return;
     }
-    // Note that fail throws an RuntimeException which is why it is placed out here
-    // instead of inside the try-catch block.
-    fail("RuntimeException is expected.");
   }
 
   private QueryResponse createResponseContainingTestData() {

--- a/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
@@ -282,7 +282,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
     </dependency>
 
     <dependency>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -328,7 +328,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
     </dependency>
 
     <!-- The DirectRunner is needed for unit tests. -->


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Fix WordCountIT flaky in prostcommit build:

 - Add retry when query job failed.
 - check QueryResponse.jobComplete instead of rows. reference from https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#response