### PR TITLE
[BEAM-986] Deprecate TimerCallback and InMemoryTimerInternals methods using it.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -47,7 +47,6 @@ import org.apache.beam.sdk.util.WindowingInternals;
 import org.apache.beam.sdk.util.state.InMemoryStateInternals;
 import org.apache.beam.sdk.util.state.InMemoryTimerInternals;
 import org.apache.beam.sdk.util.state.StateInternals;
-import org.apache.beam.sdk.util.state.TimerCallback;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TupleTag;
@@ -472,19 +471,14 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
     return extractAggregatorValue(agg.getName(), agg.getCombineFn());
   }
 
-  private static TimerCallback collectInto(final List<TimerInternals.TimerData> firedTimers) {
-    return new TimerCallback() {
-      @Override
-      public void onTimer(TimerInternals.TimerData timer) throws Exception {
-        firedTimers.add(timer);
-      }
-    };
-  }
-
   public List<TimerInternals.TimerData> advanceInputWatermark(Instant newWatermark) {
     try {
+      timerInternals.advanceInputWatermark(newWatermark);
       final List<TimerInternals.TimerData> firedTimers = new ArrayList<>();
-      timerInternals.advanceInputWatermark(collectInto(firedTimers), newWatermark);
+      TimerInternals.TimerData timer;
+      while ((timer = timerInternals.removeNextEventTimer()) != null) {
+        firedTimers.add(timer);
+      }
       return firedTimers;
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -493,8 +487,12 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
 
   public List<TimerInternals.TimerData> advanceProcessingTime(Instant newProcessingTime) {
     try {
+      timerInternals.advanceProcessingTime(newProcessingTime);
       final List<TimerInternals.TimerData> firedTimers = new ArrayList<>();
-      timerInternals.advanceProcessingTime(collectInto(firedTimers), newProcessingTime);
+      TimerInternals.TimerData timer;
+      while ((timer = timerInternals.removeNextProcessingTimer()) != null) {
+        firedTimers.add(timer);
+      }
       return firedTimers;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
@@ -111,7 +111,7 @@ public class InMemoryTimerInternals implements TimerInternals {
 
   @Override
   public void setTimer(TimerData timerData) {
-    WindowTracing.trace("TestTimerInternals.setTimer: {}", timerData);
+    WindowTracing.trace("{}.setTimer: {}", getClass().getSimpleName(), timerData);
     if (existingTimers.add(timerData)) {
       queue(timerData.getDomain()).add(timerData);
     }
@@ -124,7 +124,7 @@ public class InMemoryTimerInternals implements TimerInternals {
 
   @Override
   public void deleteTimer(TimerData timer) {
-    WindowTracing.trace("TestTimerInternals.deleteTimer: {}", timer);
+    WindowTracing.trace("{}.deleteTimer: {}", getClass().getSimpleName(), timer);
     existingTimers.remove(timer);
     queue(timer.getDomain()).remove(timer);
   }
@@ -150,7 +150,7 @@ public class InMemoryTimerInternals implements TimerInternals {
     return MoreObjects.toStringHelper(getClass())
         .add("watermarkTimers", watermarkTimers)
         .add("processingTimers", processingTimers)
-        .add("synchronizedProcessingTimers", processingTimers)
+        .add("synchronizedProcessingTimers", synchronizedProcessingTimers)
         .add("inputWatermarkTime", inputWatermarkTime)
         .add("outputWatermarkTime", outputWatermarkTime)
         .add("processingTime", processingTime)
@@ -166,9 +166,8 @@ public class InMemoryTimerInternals implements TimerInternals {
         inputWatermarkTime,
         newInputWatermark);
     WindowTracing.trace(
-        "InMemoryTimerInternals.advanceInputWatermark: from {} to {}",
-        inputWatermarkTime,
-        newInputWatermark);
+        "{}.advanceInputWatermark: from {} to {}",
+        getClass().getSimpleName(), inputWatermarkTime, newInputWatermark);
     inputWatermarkTime = newInputWatermark;
   }
 
@@ -178,9 +177,8 @@ public class InMemoryTimerInternals implements TimerInternals {
     final Instant adjustedOutputWatermark;
     if (newOutputWatermark.isAfter(inputWatermarkTime)) {
       WindowTracing.trace(
-          "InMemoryTimerInternals.advanceOutputWatermark: clipping output watermark from {} to {}",
-          newOutputWatermark,
-          inputWatermarkTime);
+          "{}.advanceOutputWatermark: clipping output watermark from {} to {}",
+          getClass().getSimpleName(), newOutputWatermark, inputWatermarkTime);
       adjustedOutputWatermark = inputWatermarkTime;
     } else {
       adjustedOutputWatermark = newOutputWatermark;
@@ -192,9 +190,8 @@ public class InMemoryTimerInternals implements TimerInternals {
         outputWatermarkTime,
         adjustedOutputWatermark);
     WindowTracing.trace(
-        "InMemoryTimerInternals.advanceOutputWatermark: from {} to {}",
-        outputWatermarkTime,
-        adjustedOutputWatermark);
+        "{}.advanceOutputWatermark: from {} to {}",
+        getClass().getSimpleName(), outputWatermarkTime, adjustedOutputWatermark);
     outputWatermarkTime = adjustedOutputWatermark;
   }
 
@@ -206,9 +203,8 @@ public class InMemoryTimerInternals implements TimerInternals {
         processingTime,
         newProcessingTime);
     WindowTracing.trace(
-        "InMemoryTimerInternals.advanceProcessingTime: from {} to {}",
-        processingTime,
-        newProcessingTime);
+        "{}.advanceProcessingTime: from {} to {}",
+        getClass().getSimpleName(), processingTime, newProcessingTime);
     processingTime = newProcessingTime;
   }
 
@@ -221,9 +217,8 @@ public class InMemoryTimerInternals implements TimerInternals {
         processingTime,
         newSynchronizedProcessingTime);
     WindowTracing.trace(
-        "InMemoryTimerInternals.advanceProcessingTime: from {} to {}",
-        synchronizedProcessingTime,
-        newSynchronizedProcessingTime);
+        "{}.advanceProcessingTime: from {} to {}",
+        getClass().getSimpleName(), synchronizedProcessingTime, newSynchronizedProcessingTime);
     synchronizedProcessingTime = newSynchronizedProcessingTime;
   }
 
@@ -233,8 +228,8 @@ public class InMemoryTimerInternals implements TimerInternals {
     TimerData timer = removeNextTimer(inputWatermarkTime, TimeDomain.EVENT_TIME);
     if (timer != null) {
       WindowTracing.trace(
-          "InMemoryTimerInternals.removeNextEventTimer: firing {} at {}",
-          timer, inputWatermarkTime);
+          "{}.removeNextEventTimer: firing {} at {}",
+          getClass().getSimpleName(), timer, inputWatermarkTime);
     }
     return timer;
   }
@@ -245,8 +240,8 @@ public class InMemoryTimerInternals implements TimerInternals {
     TimerData timer = removeNextTimer(processingTime, TimeDomain.PROCESSING_TIME);
     if (timer != null) {
       WindowTracing.trace(
-          "InMemoryTimerInternals.removeNextProcessingTimer: firing {} at {}",
-          timer, processingTime);
+          "{}.removeNextProcessingTimer: firing {} at {}",
+          getClass().getSimpleName(), timer, processingTime);
     }
     return timer;
   }
@@ -258,8 +253,8 @@ public class InMemoryTimerInternals implements TimerInternals {
         synchronizedProcessingTime, TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
     if (timer != null) {
       WindowTracing.trace(
-          "InMemoryTimerInternals.removeNextSynchronizedProcessingTimer: firing {} at {}",
-          timer, synchronizedProcessingTime);
+          "{}.removeNextSynchronizedProcessingTimer: firing {} at {}",
+          getClass().getSimpleName(), timer, synchronizedProcessingTime);
     }
     return timer;
   }
@@ -321,7 +316,8 @@ public class InMemoryTimerInternals implements TimerInternals {
     TimerData timer;
     while ((timer = removeNextTimer(currentTime, domain)) != null) {
       WindowTracing.trace(
-          "InMemoryTimerInternals.advanceAndFire: firing {} at {}", timer, currentTime);
+          "{}.advanceAndFire: firing {} at {}",
+          getClass().getSimpleName(), timer, currentTime);
       timerCallback.onTimer(timer);
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
@@ -50,7 +50,7 @@ public class InMemoryTimerInternals implements TimerInternals {
   private PriorityQueue<TimerData> synchronizedProcessingTimers = new PriorityQueue<>(11);
 
   /** Current input watermark. */
-  @Nullable private Instant inputWatermarkTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
+  private Instant inputWatermarkTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
 
   /** Current output watermark. */
   @Nullable private Instant outputWatermarkTime = null;
@@ -59,7 +59,7 @@ public class InMemoryTimerInternals implements TimerInternals {
   private Instant processingTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
 
   /** Current synchronized processing time. */
-  @Nullable private Instant synchronizedProcessingTime = null;
+  private Instant synchronizedProcessingTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
 
   @Override
   @Nullable
@@ -142,7 +142,7 @@ public class InMemoryTimerInternals implements TimerInternals {
 
   @Override
   public Instant currentInputWatermarkTime() {
-    return checkNotNull(inputWatermarkTime);
+    return inputWatermarkTime;
   }
 
   @Override
@@ -197,6 +197,7 @@ public class InMemoryTimerInternals implements TimerInternals {
 
   /** Advances processing time to the given value. */
   public void advanceProcessingTime(Instant newProcessingTime) throws Exception {
+    checkNotNull(newProcessingTime);
     checkState(
         !newProcessingTime.isBefore(processingTime),
         "Cannot move processing time backwards from %s to %s",
@@ -211,6 +212,7 @@ public class InMemoryTimerInternals implements TimerInternals {
   /** Advances synchronized processing time to the given value. */
   public void advanceSynchronizedProcessingTime(Instant newSynchronizedProcessingTime)
       throws Exception {
+    checkNotNull(newSynchronizedProcessingTime);
     checkState(
         !newSynchronizedProcessingTime.isBefore(synchronizedProcessingTime),
         "Cannot move processing time backwards from %s to %s",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
@@ -46,6 +46,9 @@ public class InMemoryTimerInternals implements TimerInternals {
   /** Pending processing time timers, in timestamp order. */
   private PriorityQueue<TimerData> processingTimers = new PriorityQueue<>(11);
 
+  /** Pending synchronized processing time timers, in timestamp order. */
+  private PriorityQueue<TimerData> synchronizedProcessingTimers = new PriorityQueue<>(11);
+
   /** Current input watermark. */
   @Nullable private Instant inputWatermarkTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
 
@@ -76,8 +79,10 @@ public class InMemoryTimerInternals implements TimerInternals {
         data = watermarkTimers.peek();
         break;
       case PROCESSING_TIME:
-      case SYNCHRONIZED_PROCESSING_TIME:
         data = processingTimers.peek();
+        break;
+      case SYNCHRONIZED_PROCESSING_TIME:
+        data = synchronizedProcessingTimers.peek();
         break;
       default:
         throw new IllegalArgumentException("Unexpected time domain: " + domain);
@@ -90,8 +95,9 @@ public class InMemoryTimerInternals implements TimerInternals {
       case EVENT_TIME:
         return watermarkTimers;
       case PROCESSING_TIME:
-      case SYNCHRONIZED_PROCESSING_TIME:
         return processingTimers;
+      case SYNCHRONIZED_PROCESSING_TIME:
+        return synchronizedProcessingTimers;
       default:
         throw new IllegalArgumentException("Unexpected time domain: " + domain);
     }
@@ -144,15 +150,15 @@ public class InMemoryTimerInternals implements TimerInternals {
     return MoreObjects.toStringHelper(getClass())
         .add("watermarkTimers", watermarkTimers)
         .add("processingTimers", processingTimers)
+        .add("synchronizedProcessingTimers", processingTimers)
         .add("inputWatermarkTime", inputWatermarkTime)
         .add("outputWatermarkTime", outputWatermarkTime)
         .add("processingTime", processingTime)
         .toString();
   }
 
-  /** Advances input watermark to the given value and fires event-time timers accordingly. */
-  public void advanceInputWatermark(
-      TimerCallback timerCallback, Instant newInputWatermark) throws Exception {
+  /** Advances input watermark to the given value. */
+  public void advanceInputWatermark(Instant newInputWatermark) throws Exception {
     checkNotNull(newInputWatermark);
     checkState(
         !newInputWatermark.isBefore(inputWatermarkTime),
@@ -160,11 +166,10 @@ public class InMemoryTimerInternals implements TimerInternals {
         inputWatermarkTime,
         newInputWatermark);
     WindowTracing.trace(
-        "TestTimerInternals.advanceInputWatermark: from {} to {}",
+        "InMemoryTimerInternals.advanceInputWatermark: from {} to {}",
         inputWatermarkTime,
         newInputWatermark);
     inputWatermarkTime = newInputWatermark;
-    advanceAndFire(timerCallback, newInputWatermark, TimeDomain.EVENT_TIME);
   }
 
   /** Advances output watermark to the given value. */
@@ -173,7 +178,7 @@ public class InMemoryTimerInternals implements TimerInternals {
     final Instant adjustedOutputWatermark;
     if (newOutputWatermark.isAfter(inputWatermarkTime)) {
       WindowTracing.trace(
-          "TestTimerInternals.advanceOutputWatermark: clipping output watermark from {} to {}",
+          "InMemoryTimerInternals.advanceOutputWatermark: clipping output watermark from {} to {}",
           newOutputWatermark,
           inputWatermarkTime);
       adjustedOutputWatermark = inputWatermarkTime;
@@ -187,34 +192,28 @@ public class InMemoryTimerInternals implements TimerInternals {
         outputWatermarkTime,
         adjustedOutputWatermark);
     WindowTracing.trace(
-        "TestTimerInternals.advanceOutputWatermark: from {} to {}",
+        "InMemoryTimerInternals.advanceOutputWatermark: from {} to {}",
         outputWatermarkTime,
         adjustedOutputWatermark);
     outputWatermarkTime = adjustedOutputWatermark;
   }
 
-  /** Advances processing time to the given value and fires processing-time timers accordingly. */
-  public void advanceProcessingTime(
-      TimerCallback timerCallback, Instant newProcessingTime) throws Exception {
+  /** Advances processing time to the given value. */
+  public void advanceProcessingTime(Instant newProcessingTime) throws Exception {
     checkState(
         !newProcessingTime.isBefore(processingTime),
         "Cannot move processing time backwards from %s to %s",
         processingTime,
         newProcessingTime);
     WindowTracing.trace(
-        "TestTimerInternals.advanceProcessingTime: from {} to {}",
+        "InMemoryTimerInternals.advanceProcessingTime: from {} to {}",
         processingTime,
         newProcessingTime);
     processingTime = newProcessingTime;
-    advanceAndFire(timerCallback, newProcessingTime, TimeDomain.PROCESSING_TIME);
   }
 
-  /**
-   * Advances synchronized processing time to the given value and fires processing-time timers
-   * accordingly.
-   */
-  public void advanceSynchronizedProcessingTime(
-      TimerCallback timerCallback, Instant newSynchronizedProcessingTime)
+  /** Advances synchronized processing time to the given value. */
+  public void advanceSynchronizedProcessingTime(Instant newSynchronizedProcessingTime)
       throws Exception {
     checkState(
         !newSynchronizedProcessingTime.isBefore(synchronizedProcessingTime),
@@ -222,23 +221,105 @@ public class InMemoryTimerInternals implements TimerInternals {
         processingTime,
         newSynchronizedProcessingTime);
     WindowTracing.trace(
-        "TestTimerInternals.advanceProcessingTime: from {} to {}",
+        "InMemoryTimerInternals.advanceProcessingTime: from {} to {}",
         synchronizedProcessingTime,
         newSynchronizedProcessingTime);
     synchronizedProcessingTime = newSynchronizedProcessingTime;
+  }
+
+  /** Returns the next eligible event time timer, if none returns null. */
+  @Nullable
+  public TimerData removeNextEventTimer() {
+    TimerData timer = removeNextTimer(inputWatermarkTime, TimeDomain.EVENT_TIME);
+    if (timer != null) {
+      WindowTracing.trace(
+          "InMemoryTimerInternals.removeNextEventTimer: firing {} at {}",
+          timer, inputWatermarkTime);
+    }
+    return timer;
+  }
+
+  /** Returns the next eligible processing time timer, if none returns null. */
+  @Nullable
+  public TimerData removeNextProcessingTimer() {
+    TimerData timer = removeNextTimer(processingTime, TimeDomain.PROCESSING_TIME);
+    if (timer != null) {
+      WindowTracing.trace(
+          "InMemoryTimerInternals.removeNextProcessingTimer: firing {} at {}",
+          timer, processingTime);
+    }
+    return timer;
+  }
+
+  /** Returns the next eligible synchronized processing time timer, if none returns null. */
+  @Nullable
+  public TimerData removeNextSynchronizedProcessingTimer() {
+    TimerData timer = removeNextTimer(
+        synchronizedProcessingTime, TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
+    if (timer != null) {
+      WindowTracing.trace(
+          "InMemoryTimerInternals.removeNextSynchronizedProcessingTimer: firing {} at {}",
+          timer, synchronizedProcessingTime);
+    }
+    return timer;
+  }
+
+  @Nullable
+  private TimerData removeNextTimer(Instant currentTime, TimeDomain domain) {
+    PriorityQueue<TimerData> queue = queue(domain);
+    if (!queue.isEmpty() && currentTime.isAfter(queue.peek().getTimestamp())) {
+      TimerData timer = queue.remove();
+      existingTimers.remove(timer);
+      return timer;
+    } else {
+      return null;
+    }
+  }
+
+  /** Advances input watermark to the given value and fires event-time timers accordingly.
+   *
+   *  @deprecated Use advanceInputWatermark without callback and fireEventTimers.
+   */
+  @Deprecated
+  public void advanceInputWatermark(
+      TimerCallback timerCallback, Instant newInputWatermark) throws Exception {
+    advanceInputWatermark(newInputWatermark);
+    advanceAndFire(timerCallback, newInputWatermark, TimeDomain.EVENT_TIME);
+  }
+
+  /** Advances processing time to the given value and fires processing-time timers accordingly.
+   *
+   *  @deprecated Use advanceProcessingTime without callback and fireProcessingTimers.
+   */
+  @Deprecated
+  public void advanceProcessingTime(
+      TimerCallback timerCallback, Instant newProcessingTime) throws Exception {
+    advanceProcessingTime(newProcessingTime);
+    advanceAndFire(timerCallback, newProcessingTime, TimeDomain.PROCESSING_TIME);
+  }
+
+  /**
+   * Advances synchronized processing time to the given value and fires processing-time timers
+   * accordingly.
+   *
+   *  @deprecated Use advanceInputWatermark without callback and fireSynchronizedProcessingTimers.
+   */
+  @Deprecated
+  public void advanceSynchronizedProcessingTime(
+      TimerCallback timerCallback, Instant newSynchronizedProcessingTime)
+      throws Exception {
+    advanceSynchronizedProcessingTime(newSynchronizedProcessingTime);
     advanceAndFire(
         timerCallback, newSynchronizedProcessingTime, TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
   }
 
+  @Deprecated
   private void advanceAndFire(
       TimerCallback timerCallback, Instant currentTime, TimeDomain domain)
       throws Exception {
     checkNotNull(timerCallback);
-    PriorityQueue<TimerData> queue = queue(domain);
-    while (!queue.isEmpty() && currentTime.isAfter(queue.peek().getTimestamp())) {
-      // Remove before firing, so that if the callback adds another identical
-      // timer we don't remove it.
-      TimerData timer = queue.remove();
+    TimerData timer;
+    while ((timer = removeNextTimer(currentTime, domain)) != null) {
       WindowTracing.trace(
           "InMemoryTimerInternals.advanceAndFire: firing {} at {}", timer, currentTime);
       timerCallback.onTimer(timer);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
@@ -214,7 +214,7 @@ public class InMemoryTimerInternals implements TimerInternals {
     checkState(
         !newSynchronizedProcessingTime.isBefore(synchronizedProcessingTime),
         "Cannot move processing time backwards from %s to %s",
-        processingTime,
+        synchronizedProcessingTime,
         newSynchronizedProcessingTime);
     WindowTracing.trace(
         "{}.advanceProcessingTime: from {} to {}",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/TimerCallback.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/TimerCallback.java
@@ -22,7 +22,7 @@ import org.apache.beam.sdk.util.TimerInternals;
 /**
  * A callback that processes a {@link TimerInternals.TimerData TimerData}.
  *
- * @deprecated Use TimerInternals.advanceTime and removeTimers instead of callback.
+ * @deprecated Use InMemoryTimerInternals advance and remove methods instead of callback.
  */
 @Deprecated
 public interface TimerCallback {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/TimerCallback.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/TimerCallback.java
@@ -21,7 +21,10 @@ import org.apache.beam.sdk.util.TimerInternals;
 
 /**
  * A callback that processes a {@link TimerInternals.TimerData TimerData}.
+ *
+ * @deprecated Use TimerInternals.advanceTime and removeTimers instead of callback.
  */
+@Deprecated
 public interface TimerCallback {
   /** Processes the {@link TimerInternals.TimerData TimerData}. */
   void onTimer(TimerInternals.TimerData timer) throws Exception;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/state/InMemoryTimerInternalsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/state/InMemoryTimerInternalsTest.java
@@ -17,6 +17,10 @@
  */
 package org.apache.beam.sdk.util.state;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.times;
+
 import org.apache.beam.sdk.util.TimeDomain;
 import org.apache.beam.sdk.util.TimerInternals.TimerData;
 import org.joda.time.Instant;
@@ -53,6 +57,34 @@ public class InMemoryTimerInternalsTest {
     underTest.setTimer(processingTime1);
     underTest.setTimer(processingTime2);
 
+    underTest.advanceProcessingTime(new Instant(20));
+    assertEquals(processingTime1, underTest.removeNextProcessingTimer());
+    assertNull(underTest.removeNextProcessingTimer());
+
+    // Advancing just a little shouldn't refire
+    underTest.advanceProcessingTime(new Instant(21));
+    assertNull(underTest.removeNextProcessingTimer());
+
+    // Adding the timer and advancing a little should refire
+    underTest.setTimer(processingTime1);
+    assertEquals(processingTime1, underTest.removeNextProcessingTimer());
+    assertNull(underTest.removeNextProcessingTimer());
+
+    // And advancing the rest of the way should still have the other timer
+    underTest.advanceProcessingTime(new Instant(30));
+    assertEquals(processingTime2, underTest.removeNextProcessingTimer());
+    assertNull(underTest.removeNextProcessingTimer());
+  }
+
+  @Test
+  public void testFiringTimersWithCallback() throws Exception {
+    InMemoryTimerInternals underTest = new InMemoryTimerInternals();
+    TimerData processingTime1 = TimerData.of(NS1, new Instant(19), TimeDomain.PROCESSING_TIME);
+    TimerData processingTime2 = TimerData.of(NS1, new Instant(29), TimeDomain.PROCESSING_TIME);
+
+    underTest.setTimer(processingTime1);
+    underTest.setTimer(processingTime2);
+
     underTest.advanceProcessingTime(timerCallback, new Instant(20));
     Mockito.verify(timerCallback).onTimer(processingTime1);
     Mockito.verifyNoMoreInteractions(timerCallback);
@@ -63,8 +95,8 @@ public class InMemoryTimerInternalsTest {
 
     // Adding the timer and advancing a little should refire
     underTest.setTimer(processingTime1);
-    Mockito.verify(timerCallback).onTimer(processingTime1);
     underTest.advanceProcessingTime(timerCallback, new Instant(21));
+    Mockito.verify(timerCallback, times(2)).onTimer(processingTime1);
     Mockito.verifyNoMoreInteractions(timerCallback);
 
     // And advancing the rest of the way should still have the other timer
@@ -76,41 +108,42 @@ public class InMemoryTimerInternalsTest {
   @Test
   public void testTimerOrdering() throws Exception {
     InMemoryTimerInternals underTest = new InMemoryTimerInternals();
-    TimerData watermarkTime1 = TimerData.of(NS1, new Instant(19), TimeDomain.EVENT_TIME);
+    TimerData eventTime1 = TimerData.of(NS1, new Instant(19), TimeDomain.EVENT_TIME);
     TimerData processingTime1 = TimerData.of(NS1, new Instant(19), TimeDomain.PROCESSING_TIME);
-    TimerData watermarkTime2 = TimerData.of(NS1, new Instant(29), TimeDomain.EVENT_TIME);
+    TimerData eventTime2 = TimerData.of(NS1, new Instant(29), TimeDomain.EVENT_TIME);
     TimerData processingTime2 = TimerData.of(NS1, new Instant(29), TimeDomain.PROCESSING_TIME);
 
     underTest.setTimer(processingTime1);
-    underTest.setTimer(watermarkTime1);
+    underTest.setTimer(eventTime1);
     underTest.setTimer(processingTime2);
-    underTest.setTimer(watermarkTime2);
+    underTest.setTimer(eventTime2);
 
-    underTest.advanceInputWatermark(timerCallback, new Instant(30));
-    Mockito.verify(timerCallback).onTimer(watermarkTime1);
-    Mockito.verify(timerCallback).onTimer(watermarkTime2);
-    Mockito.verifyNoMoreInteractions(timerCallback);
+    underTest.advanceInputWatermark(new Instant(30));
+    assertEquals(eventTime1, underTest.removeNextEventTimer());
+    assertEquals(eventTime2, underTest.removeNextEventTimer());
+    assertNull(underTest.removeNextEventTimer());
 
-    underTest.advanceProcessingTime(timerCallback, new Instant(30));
-    Mockito.verify(timerCallback).onTimer(processingTime1);
-    Mockito.verify(timerCallback).onTimer(processingTime2);
-    Mockito.verifyNoMoreInteractions(timerCallback);
+    underTest.advanceProcessingTime(new Instant(30));
+    assertEquals(processingTime1, underTest.removeNextProcessingTimer());
+    assertEquals(processingTime2, underTest.removeNextProcessingTimer());
+    assertNull(underTest.removeNextProcessingTimer());
   }
 
   @Test
   public void testDeduplicate() throws Exception {
     InMemoryTimerInternals underTest = new InMemoryTimerInternals();
-    TimerData watermarkTime = TimerData.of(NS1, new Instant(19), TimeDomain.EVENT_TIME);
+    TimerData eventTime = TimerData.of(NS1, new Instant(19), TimeDomain.EVENT_TIME);
     TimerData processingTime = TimerData.of(NS1, new Instant(19), TimeDomain.PROCESSING_TIME);
-    underTest.setTimer(watermarkTime);
-    underTest.setTimer(watermarkTime);
+    underTest.setTimer(eventTime);
+    underTest.setTimer(eventTime);
     underTest.setTimer(processingTime);
     underTest.setTimer(processingTime);
-    underTest.advanceProcessingTime(timerCallback, new Instant(20));
-    underTest.advanceInputWatermark(timerCallback, new Instant(20));
+    underTest.advanceProcessingTime(new Instant(20));
+    underTest.advanceInputWatermark(new Instant(20));
 
-    Mockito.verify(timerCallback).onTimer(processingTime);
-    Mockito.verify(timerCallback).onTimer(watermarkTime);
-    Mockito.verifyNoMoreInteractions(timerCallback);
+    assertEquals(processingTime, underTest.removeNextProcessingTimer());
+    assertNull(underTest.removeNextProcessingTimer());
+    assertEquals(eventTime, underTest.removeNextEventTimer());
+    assertNull(underTest.removeNextEventTimer());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/state/InMemoryTimerInternalsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/state/InMemoryTimerInternalsTest.java
@@ -110,22 +110,36 @@ public class InMemoryTimerInternalsTest {
     InMemoryTimerInternals underTest = new InMemoryTimerInternals();
     TimerData eventTime1 = TimerData.of(NS1, new Instant(19), TimeDomain.EVENT_TIME);
     TimerData processingTime1 = TimerData.of(NS1, new Instant(19), TimeDomain.PROCESSING_TIME);
+    TimerData synchronizedProcessingTime1 = TimerData.of(
+        NS1, new Instant(19), TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
     TimerData eventTime2 = TimerData.of(NS1, new Instant(29), TimeDomain.EVENT_TIME);
     TimerData processingTime2 = TimerData.of(NS1, new Instant(29), TimeDomain.PROCESSING_TIME);
+    TimerData synchronizedProcessingTime2 = TimerData.of(
+        NS1, new Instant(29), TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
 
     underTest.setTimer(processingTime1);
     underTest.setTimer(eventTime1);
+    underTest.setTimer(synchronizedProcessingTime1);
     underTest.setTimer(processingTime2);
     underTest.setTimer(eventTime2);
+    underTest.setTimer(synchronizedProcessingTime2);
 
+    assertNull(underTest.removeNextEventTimer());
     underTest.advanceInputWatermark(new Instant(30));
     assertEquals(eventTime1, underTest.removeNextEventTimer());
     assertEquals(eventTime2, underTest.removeNextEventTimer());
     assertNull(underTest.removeNextEventTimer());
 
+    assertNull(underTest.removeNextProcessingTimer());
     underTest.advanceProcessingTime(new Instant(30));
     assertEquals(processingTime1, underTest.removeNextProcessingTimer());
     assertEquals(processingTime2, underTest.removeNextProcessingTimer());
+    assertNull(underTest.removeNextProcessingTimer());
+
+    assertNull(underTest.removeNextSynchronizedProcessingTimer());
+    underTest.advanceSynchronizedProcessingTime(new Instant(30));
+    assertEquals(synchronizedProcessingTime1, underTest.removeNextSynchronizedProcessingTimer());
+    assertEquals(synchronizedProcessingTime2, underTest.removeNextSynchronizedProcessingTimer());
     assertNull(underTest.removeNextProcessingTimer());
   }
 


### PR DESCRIPTION
Deprecate TimerCallback and InMemoryTimerInternals methods using it.
Instead separate advancing watermarks and removing eligible timers.
SDK changes necessary for improving ReduceFnRunner prefetching.

Hi @kennknowles , can you please take a look?  This is the sdk changes separated out from PR adding
prefetching.