### PR TITLE
[BEAM-1078] [Docs] - Modifying the links in JavaDocs to point to the Beam github repo rather than GCP

### DIFF
--- a/.travis/README.md
+++ b/.travis/README.md
@@ -19,5 +19,5 @@
 
 # Travis Scripts
 
-This directory contains scripts used for [Travis CI](https://travis-ci.org/GoogleCloudPlatform/DataflowJavaSDK)
+This directory contains scripts used for [Travis CI](https://travis-ci.org/apache/incubator-beam/)
 testing.

--- a/examples/java/src/main/java/org/apache/beam/examples/complete/README.md
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/README.md
@@ -22,34 +22,34 @@
 This directory contains end-to-end example pipelines that perform complex data processing tasks. They include:
 
 <ul>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/complete/AutoComplete.java">AutoComplete</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/complete/AutoComplete.java">AutoComplete</a>
   &mdash; An example that computes the most popular hash tags for every
   prefix, which can be used for auto-completion. Demonstrates how to use the
   same pipeline in both streaming and batch, combiners, and composite
   transforms.</li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/complete/StreamingWordExtract.java">StreamingWordExtract</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/complete/StreamingWordExtract.java">StreamingWordExtract</a>
   &mdash; A streaming pipeline example that inputs lines of text from a Cloud
   Pub/Sub topic, splits each line into individual words, capitalizes those
   words, and writes the output to a BigQuery table.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/complete/TfIdf.java">TfIdf</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/complete/TfIdf.java">TfIdf</a>
   &mdash; An example that computes a basic TF-IDF search table for a directory or
   Cloud Storage prefix. Demonstrates joining data, side inputs, and logging.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/complete/TopWikipediaSessions.java">TopWikipediaSessions</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/complete/TopWikipediaSessions.java">TopWikipediaSessions</a>
   &mdash; An example that reads Wikipedia edit data from Cloud Storage and
   computes the user with the longest string of edits separated by no more than
   an hour within each month. Demonstrates using Cloud Dataflow
   <code>Windowing</code> to perform time-based aggregations of data.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/complete/TrafficMaxLaneFlow.java">TrafficMaxLaneFlow</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/complete/TrafficMaxLaneFlow.java">TrafficMaxLaneFlow</a>
   &mdash; A streaming Beam Example using BigQuery output in the
   <code>traffic sensor</code> domain. Demonstrates the Cloud Dataflow streaming
   runner, sliding windows, Cloud Pub/Sub topic ingestion, the use of the
   <code>AvroCoder</code> to encode a custom class, and custom
   <code>Combine</code> transforms.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/complete/TrafficRoutes.java">TrafficRoutes</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/complete/TrafficRoutes.java">TrafficRoutes</a>
   &mdash; A streaming Beam Example using BigQuery output in the
   <code>traffic sensor</code> domain. Demonstrates the Cloud Dataflow streaming
   runner, <code>GroupByKey</code>, keyed state, sliding windows, and Cloud
@@ -57,6 +57,6 @@ This directory contains end-to-end example pipelines that perform complex data p
   </li>
   </ul>
 
-See the [documentation](https://cloud.google.com/dataflow/getting-started) and the [Examples
+See the [documentation](http://beam.incubator.apache.org/get-started/quickstart/) and the [Examples
 README](../../../../../../../../../README.md) for
 information about how to run these examples.

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/README.md
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/README.md
@@ -24,12 +24,12 @@ commonly-used data analysis patterns that you would likely incorporate into a
 larger Dataflow pipeline. They include:
 
  <ul>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/BigQueryTornadoes.java">BigQueryTornadoes</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/BigQueryTornadoes.java">BigQueryTornadoes</a>
   &mdash; An example that reads the public samples of weather data from Google
   BigQuery, counts the number of tornadoes that occur in each month, and
   writes the results to BigQuery. Demonstrates reading/writing BigQuery,
   counting a <code>PCollection</code>, and user-defined <code>PTransforms</code>.</li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/CombinePerKeyExamples.java">CombinePerKeyExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/CombinePerKeyExamples.java">CombinePerKeyExamples</a>
   &mdash; An example that reads the public &quot;Shakespeare&quot; data, and for
   each word in the dataset that exceeds a given length, generates a string
   containing the list of play names in which that word appears.
@@ -39,13 +39,13 @@ larger Dataflow pipeline. They include:
   </li>
   <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/DatastoreWordCount.java">DatastoreWordCount</a>
   &mdash; An example that shows you how to read from Google Cloud Datastore.</li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/DeDupExample.java">DeDupExample</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/e04cd47ddf8fb5f04f1f684219724031179a55ec/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java">DistinctExample</a>
   &mdash; An example that uses Shakespeare's plays as plain text files, and
   removes duplicate lines across all the files. Demonstrates the
   <code>Distinct</code>, <code>TextIO.Read</code>,
   and <code>TextIO.Write</code> transforms, and how to wire transforms together.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/FilterExamples.java">FilterExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java">FilterExamples</a>
   &mdash; An example that shows different approaches to filtering, including
   selection and projection. It also shows how to dynamically set parameters
   by defining and using new pipeline options, and use how to use a value derived
@@ -53,14 +53,14 @@ larger Dataflow pipeline. They include:
   <code>Options</code> configuration, and using pipeline-derived data as a side
   input.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/JoinExamples.java">JoinExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/JoinExamples.java">JoinExamples</a>
   &mdash; An example that shows how to join two collections. It uses a
   sample of the <a href="http://goo.gl/OB6oin">GDELT &quot;world event&quot;
   data</a>, joining the event <code>action</code> country code against a table
   that maps country codes to country names. Demonstrates the <code>Join</code>
   operation, and using multiple input sources.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/MaxPerKeyExamples.java">MaxPerKeyExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/MaxPerKeyExamples.java">MaxPerKeyExamples</a>
   &mdash; An example that reads the public samples of weather data from BigQuery,
   and finds the maximum temperature (<code>mean_temp</code>) for each month.
   Demonstrates the <code>Max</code> statistical combination transform, and how to
@@ -68,6 +68,6 @@ larger Dataflow pipeline. They include:
   </li>
   </ul>
 
-See the [documentation](https://cloud.google.com/dataflow/getting-started) and the [Examples
+See the [documentation](http://beam.incubator.apache.org/get-started/quickstart/) and the [Examples
 README](../../../../../../../../../README.md) for
 information about how to run these examples.

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/README.md
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/README.md
@@ -24,12 +24,12 @@ commonly-used data analysis patterns that you would likely incorporate into a
 larger Dataflow pipeline. They include:
 
  <ul>
-  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/BigQueryTornadoes.java">BigQueryTornadoes</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/BigQueryTornadoes.java">BigQueryTornadoes</a>
   &mdash; An example that reads the public samples of weather data from Google
   BigQuery, counts the number of tornadoes that occur in each month, and
   writes the results to BigQuery. Demonstrates reading/writing BigQuery,
   counting a <code>PCollection</code>, and user-defined <code>PTransforms</code>.</li>
-  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/CombinePerKeyExamples.java">CombinePerKeyExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/CombinePerKeyExamples.java">CombinePerKeyExamples</a>
   &mdash; An example that reads the public &quot;Shakespeare&quot; data, and for
   each word in the dataset that exceeds a given length, generates a string
   containing the list of play names in which that word appears.
@@ -39,13 +39,13 @@ larger Dataflow pipeline. They include:
   </li>
   <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/DatastoreWordCount.java">DatastoreWordCount</a>
   &mdash; An example that shows you how to read from Google Cloud Datastore.</li>
-  <li><a href="https://github.com/apache/incubator-beam/blob/e04cd47ddf8fb5f04f1f684219724031179a55ec/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java">DistinctExample</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java">DistinctExample</a>
   &mdash; An example that uses Shakespeare's plays as plain text files, and
   removes duplicate lines across all the files. Demonstrates the
   <code>Distinct</code>, <code>TextIO.Read</code>,
   and <code>TextIO.Write</code> transforms, and how to wire transforms together.
   </li>
-  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java">FilterExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java">FilterExamples</a>
   &mdash; An example that shows different approaches to filtering, including
   selection and projection. It also shows how to dynamically set parameters
   by defining and using new pipeline options, and use how to use a value derived
@@ -53,14 +53,14 @@ larger Dataflow pipeline. They include:
   <code>Options</code> configuration, and using pipeline-derived data as a side
   input.
   </li>
-  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/JoinExamples.java">JoinExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/JoinExamples.java">JoinExamples</a>
   &mdash; An example that shows how to join two collections. It uses a
   sample of the <a href="http://goo.gl/OB6oin">GDELT &quot;world event&quot;
   data</a>, joining the event <code>action</code> country code against a table
   that maps country codes to country names. Demonstrates the <code>Join</code>
   operation, and using multiple input sources.
   </li>
-  <li><a href="https://github.com/apache/incubator-beam/blob/ee6ad2fe416cd499aa1b6e2a51aa64da0805cc5c/examples/java/src/main/java/org/apache/beam/examples/cookbook/MaxPerKeyExamples.java">MaxPerKeyExamples</a>
+  <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/MaxPerKeyExamples.java">MaxPerKeyExamples</a>
   &mdash; An example that reads the public samples of weather data from BigQuery,
   and finds the maximum temperature (<code>mean_temp</code>) for each month.
   Demonstrates the <code>Max</code> statistical combination transform, and how to

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/ApiSurfaceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/ApiSurfaceTest.java
@@ -85,8 +85,7 @@ public class ApiSurfaceTest {
           inPackage("com.google.cloud.bigtable.config"),
           equalTo(BigtableInstanceName.class),
           equalTo(BigtableTableName.class),
-          // https://github.com/GoogleCloudPlatform/cloud-bigtable-client/pull/1056
-          inPackage("com.google.common.collect"), // via Bigtable, PR above out to fix.
+          inPackage("com.google.common.collect"),
           inPackage("com.google.datastore.v1"),
           inPackage("com.google.protobuf"),
           inPackage("com.google.type"),


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   https://issues.apache.org/jira/browse/BEAM-1078
     Description:
1) Changed the links to point to the master of the incubator-beam github repository.
2) Haven't changed one of the links since the pull request is still pending (https://github.com/GoogleCloudPlatform/DataflowJavaSDK/pull/41)
3) Haven't changed the DatastoreWordCount.java link in the cookbook/README.md since BEAM-498 is still pending and it has replaced DatastoreWordCount with DoFn. Awaiting @kennknowles ' response on that one.


 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

