### PR TITLE
[BEAM-1083]: Deleting the Weblink for the DatastoreWordCount based on BEAM-498

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/README.md
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/README.md
@@ -37,8 +37,6 @@ larger Dataflow pipeline. They include:
   transform, which lets you combine the values in a key-grouped
   <code>PCollection</code>.
   </li>
-  <li><a href="https://github.com/GoogleCloudPlatform/DataflowJavaSDK/blob/master/examples/src/main/java/com/google/cloud/dataflow/examples/cookbook/DatastoreWordCount.java">DatastoreWordCount</a>
-  &mdash; An example that shows you how to read from Google Cloud Datastore.</li>
   <li><a href="https://github.com/apache/incubator-beam/blob/master/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java">DistinctExample</a>
   &mdash; An example that uses Shakespeare's plays as plain text files, and
   removes duplicate lines across all the files. Demonstrates the


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

  JIRA Link:  https://issues.apache.org/jira/browse/BEAM-1083
 Removing the link for the DatastoreWordCount example in the README

 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

