### PR TITLE
[BEAM-551] Add DisplayData handling of ValueProvider<String>

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -866,9 +866,9 @@ public class DisplayData implements Serializable {
   /**
    * Create a display item for the specified key and {@link ValueProvider}.
    */
-  public static ItemSpec<String> item(String key, ValueProvider<String> value) {
+  public static ItemSpec<String> item(String key, @Nullable ValueProvider<?> value) {
     return item(key, Type.STRING, value.isAccessible()
-        ? value.get() : value.toString());
+        ? value.get().toString() : value.toString());
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -866,7 +866,7 @@ public class DisplayData implements Serializable {
   /**
    * Create a display item for the specified key and {@link ValueProvider}.
    */
-  public static ItemSpec<String> item(String key, @Nullable ValueProvider<?> value) {
+  public static ItemSpec<String> item(String key, ValueProvider<?> value) {
     return item(key, Type.STRING, value.isAccessible()
         ? value.get().toString() : value.toString());
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -860,6 +861,14 @@ public class DisplayData implements Serializable {
    */
   public static ItemSpec<String> item(String key, @Nullable String value) {
     return item(key, Type.STRING, value);
+  }
+
+  /**
+   * Create a display item for the specified key and {@link ValueProvider}.
+   */
+  public static ItemSpec<String> item(String key, ValueProvider<String> value) {
+    return item(key, Type.STRING, value.isAccessible()
+        ? value.get() : value.toString());
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -866,7 +866,7 @@ public class DisplayData implements Serializable {
   /**
    * Create a display item for the specified key and {@link ValueProvider}.
    */
-  public static ItemSpec item(String key, ValueProvider<?> value) {
+  public static ItemSpec<?> item(String key, ValueProvider<?> value) {
     if (value.isAccessible()) {
       Object got = value.get();
       Type type = inferType(got);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -866,9 +866,16 @@ public class DisplayData implements Serializable {
   /**
    * Create a display item for the specified key and {@link ValueProvider}.
    */
-  public static ItemSpec<String> item(String key, ValueProvider<?> value) {
-    return item(key, Type.STRING, value.isAccessible()
-        ? value.get().toString() : value.toString());
+  public static ItemSpec item(String key, ValueProvider<?> value) {
+    if (value.isAccessible()) {
+      Object got = value.get();
+      Type type = inferType(got);
+      if (type == null) {
+        throw new RuntimeException(String.format("Unknown value type: %s", got));
+      }
+      return item(key, type, got);
+    }
+    return item(key, Type.STRING, value.toString());
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -167,6 +167,30 @@ public class DisplayDataTest implements Serializable {
   }
 
   @Test
+  public void testStaticValueProviderDate() {
+    final Instant value = Instant.now();
+    DisplayData data =
+        DisplayData.from(new HasDisplayData() {
+              @Override
+              public void populateDisplayData(DisplayData.Builder builder) {
+                builder.add(DisplayData.item(
+                    "foo", StaticValueProvider.of(value)));
+              }
+            });
+
+    @SuppressWarnings("unchecked")
+    DisplayData.Item item = (DisplayData.Item) data.items().toArray()[0];
+
+    @SuppressWarnings("unchecked")
+    Matcher<Item> matchesAllOf = Matchers.allOf(
+        hasKey("foo"),
+        hasType(DisplayData.Type.TIMESTAMP),
+        hasValue(ISO_FORMATTER.print(value)));
+
+    assertThat(item, matchesAllOf);
+  }
+
+  @Test
   public void testStaticValueProviderString() {
     DisplayData data =
         DisplayData.from(new HasDisplayData() {
@@ -193,7 +217,7 @@ public class DisplayDataTest implements Serializable {
             });
 
     assertThat(data.items(), hasSize(1));
-    assertThat(data, hasDisplayItem("foo", "1"));
+    assertThat(data, hasDisplayItem("foo", 1));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -53,6 +53,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.display.DisplayData.Item;
@@ -162,6 +164,45 @@ public class DisplayDataTest implements Serializable {
 
     assertThat(data.items(), hasSize(1));
     assertThat(data, hasDisplayItem("foo", "bar"));
+  }
+
+  @Test
+  public void testStaticValueProvider() {
+    DisplayData data =
+        DisplayData.from(new HasDisplayData() {
+              @Override
+              public void populateDisplayData(DisplayData.Builder builder) {
+                builder.add(DisplayData.item(
+                    "foo", StaticValueProvider.of("bar")));
+              }
+            });
+
+    assertThat(data.items(), hasSize(1));
+    assertThat(data, hasDisplayItem("foo", "bar"));
+  }
+
+  @Test
+  public void testInaccessibleValueProvider() {
+    DisplayData data =
+        DisplayData.from(new HasDisplayData() {
+              @Override
+              public void populateDisplayData(DisplayData.Builder builder) {
+                builder.add(DisplayData.item(
+                    "foo", new ValueProvider<String>() {
+                        @Override
+                        public boolean isAccessible() { return false; }
+
+                        @Override
+                        public String get() { return "bar"; }
+
+                        @Override
+                        public String toString() { return "toString"; }
+                      }));
+              }
+            });
+
+    assertThat(data.items(), hasSize(1));
+    assertThat(data, hasDisplayItem("foo", "toString"));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -167,7 +167,7 @@ public class DisplayDataTest implements Serializable {
   }
 
   @Test
-  public void testStaticValueProvider() {
+  public void testStaticValueProviderString() {
     DisplayData data =
         DisplayData.from(new HasDisplayData() {
               @Override
@@ -179,6 +179,21 @@ public class DisplayDataTest implements Serializable {
 
     assertThat(data.items(), hasSize(1));
     assertThat(data, hasDisplayItem("foo", "bar"));
+  }
+
+  @Test
+  public void testStaticValueProviderInt() {
+    DisplayData data =
+        DisplayData.from(new HasDisplayData() {
+              @Override
+              public void populateDisplayData(DisplayData.Builder builder) {
+                builder.add(DisplayData.item(
+                    "foo", StaticValueProvider.of(1)));
+              }
+            });
+
+    assertThat(data.items(), hasSize(1));
+    assertThat(data, hasDisplayItem("foo", "1"));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -190,13 +190,19 @@ public class DisplayDataTest implements Serializable {
                 builder.add(DisplayData.item(
                     "foo", new ValueProvider<String>() {
                         @Override
-                        public boolean isAccessible() { return false; }
+                        public boolean isAccessible() {
+                          return false;
+                        }
 
                         @Override
-                        public String get() { return "bar"; }
+                        public String get() {
+                          return "bar";
+                        }
 
                         @Override
-                        public String toString() { return "toString"; }
+                        public String toString() {
+                          return "toString";
+                        }
                       }));
               }
             });


### PR DESCRIPTION
R: @dhalperi 

Notes:
- An alternative would be to accept ValueProvider<T> and call T.toString() if isAccessible
- The parameter is not marked @Nullable because the DisplayData code calls checkNotNull
