### PR TITLE
[BEAM-1038] Allow stateful DoFn in DataflowRunner

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -78,7 +78,6 @@
             <id>runnable-on-service-tests</id>
             <configuration>
               <excludedGroups>
-                org.apache.beam.sdk.testing.UsesStatefulParDo,
                 org.apache.beam.sdk.testing.UsesSplittableParDo
               </excludedGroups>
               <excludes>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Confirmed that the post commit should succeed, via the following command:

```
mvn verify \
    --batch-mode \
    --errors \
    --projects runners/google-cloud-dataflow-java \
    -DforkCount=0 \
    -DfailIfNoTests=false \
    -Dtest=org.apache.beam.sdk.transforms.ParDoTest \
    -DrunnableOnServicePipelineOptions='[
        "--runner=org.apache.beam.runners.dataflow.testing.TestDataflowRunner",
        "--project=...",
        "--tempRoot=..." ]'
```

with output ending in:

```
Running org.apache.beam.sdk.transforms.ParDoTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 273.736 sec - in org.apache.beam.sdk.transforms.ParDoTest

```