### PR TITLE
Add support for date partitioned table names

### DIFF
--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -275,7 +275,9 @@ def _parse_table_reference(table, dataset=None, project=None):
       then the table argument must contain the entire table reference:
       'DATASET.TABLE' or 'PROJECT:DATASET.TABLE'. This argument can be a
       bigquery.TableReference instance in which case dataset and project are
-      ignored and the reference is returned as a result.
+      ignored and the reference is returned as a result.  Additionally, for date
+      partitioned tables, appending '$YYYYmmdd' to the table name is supported,
+      e.g. 'DATASET.TABLE$YYYYmmdd'.
     dataset: The ID of the dataset containing this table or null if the table
       reference is specified entirely by the table argument.
     project: The ID of the project containing this table or null if the table
@@ -300,7 +302,7 @@ def _parse_table_reference(table, dataset=None, project=None):
   # table name.
   if dataset is None:
     match = re.match(
-        r'^((?P<project>.+):)?(?P<dataset>\w+)\.(?P<table>\w+)$', table)
+        r'^((?P<project>.+):)?(?P<dataset>\w+)\.(?P<table>[\w\$]+)$', table)
     if not match:
       raise ValueError(
           'Expected a table reference (PROJECT:DATASET.TABLE or '

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -208,6 +208,14 @@ class TestBigQuerySource(unittest.TestCase):
     self.assertEqual(source.query, 'my_query')
     self.assertIsNone(source.table_reference)
 
+  def test_date_partitioned_table_name(self):
+    source = beam.io.BigQuerySource('dataset.table$20030102', validate=True)
+    dd = DisplayData.create_from(source)
+    expected_items = [
+        DisplayDataItemMatcher('validation', True),
+        DisplayDataItemMatcher('table', 'dataset.table$20030102')]
+    hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
+
 
 class TestBigQuerySink(unittest.TestCase):
 


### PR DESCRIPTION
These names have the format "tablename$YYYYmmdd".  Previously the dollar
sign caused this to be deemed invalid.