### PR TITLE
[BEAM-1109] Fix Python Postcommit Test Timeout

### DIFF
--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -72,7 +72,7 @@ SDK_LOCATION=$(find dist/apache-beam-sdk-*.tar.gz)
 
 # Run ValidatesRunner tests on Google Cloud Dataflow service
 python setup.py nosetests \
-  -a ValidatesRunner=test --test-pipeline-options=" \
+  -a ValidatesRunner --test-pipeline-options=" \
     --runner=BlockingDataflowPipelineRunner \
     --project=$PROJECT \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -71,11 +71,8 @@ python setup.py sdist
 SDK_LOCATION=$(find dist/apache-beam-sdk-*.tar.gz)
 
 # Run ValidatesRunner tests on Google Cloud Dataflow service
-# processes       -> number of processes to run tests in parallel
-# process-timeout -> test timeout in seconds
 python setup.py nosetests \
-  -a ValidatesRunner --processes=4 --process-timeout=360 \
-  --test-pipeline-options=" \
+  -a ValidatesRunner=test --test-pipeline-options=" \
     --runner=BlockingDataflowPipelineRunner \
     --project=$PROJECT \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

ValidatesRunner tests timeout since multiprocess configuration is not correct,  which makes all tests run sequentially and exceed 360s timeout limit. 

This PR removed multiprocess configurations, so current ValidatesRunner tests will run sequentially. The estimate running time may increase to ~50mins.