### PR TITLE
[BEAM-551] Fix handling of default values for RVPs

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -222,8 +222,16 @@ public interface ValueProvider<T> extends Serializable {
         Method method = klass.getMethod(methodName);
         PipelineOptions methodOptions = options.as(klass);
         InvocationHandler handler = Proxy.getInvocationHandler(methodOptions);
-        T value = ((ValueProvider<T>) handler.invoke(methodOptions, method, null)).get();
-        return firstNonNull(value, defaultValue);
+        ValueProvider<T> result =
+            (ValueProvider<T>) handler.invoke(methodOptions, method, null);
+        // Two cases: If we have deserialized a new value from JSON, it will
+        // be wrapped in a StaticValueProvider, which we can provide here.  If
+        // not, there was no JSON value, and we return the default, whether or
+        // not it is null.
+        if (result instanceof StaticValueProvider) {
+          return result.get();
+        }
+        return defaultValue;
       } catch (Throwable e) {
         throw new RuntimeException("Unable to load runtime value.", e);
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.options;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ValueProviderTest.java
@@ -149,6 +149,18 @@ public class ValueProviderTest {
     assertEquals("quux", provider.get());
   }
 
+  @Test
+  public void testDefaultRuntimeProviderWithoutOverride() throws Exception {
+    TestOptions runtime = PipelineOptionsFactory.as(TestOptions.class);
+    TestOptions options = PipelineOptionsFactory.as(TestOptions.class);
+    runtime.setOptionsId(options.getOptionsId());
+    RuntimeValueProvider.setRuntimeOptions(runtime);
+
+    ValueProvider<String> provider = options.getBar();
+    assertTrue(provider.isAccessible());
+    assertEquals("bar", provider.get());
+  }
+
   /** A test interface. */
   public interface BadOptionsRuntime extends PipelineOptions {
     RuntimeValueProvider<String> getBar();


### PR DESCRIPTION
Found a bug here, fixed an added a regression test.

R: @dhalperi 