### PR TITLE
[BEAM-646] Add Parameters to finishSpecifying

### DIFF
--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslatorTest.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.Create;
@@ -286,21 +287,22 @@ public class ParDoBoundTranslatorTest {
                 Arrays.asList(sideInput1, sideInput2),
                 Arrays.<TupleTag<String>>asList())));
 
-     outputs.get(mainOutputTag).apply(ParDo.of(new EmbeddedCollector()));
-     ApexRunnerResult result = (ApexRunnerResult) pipeline.run();
+    outputs.get(mainOutputTag).apply(ParDo.of(new EmbeddedCollector()));
+    outputs.get(sideOutputTag).setCoder(VoidCoder.of());
+    ApexRunnerResult result = (ApexRunnerResult) pipeline.run();
 
-     HashSet<String> expected = Sets.newHashSet("processing: 3: [11, 222]",
-         "processing: -42: [11, 222]", "processing: 666: [11, 222]");
-     long timeout = System.currentTimeMillis() + TIMEOUT_MILLIS;
-     while (System.currentTimeMillis() < timeout) {
-       if (EmbeddedCollector.RESULTS.containsAll(expected)) {
-         break;
-       }
-       LOG.info("Waiting for expected results.");
-       Thread.sleep(SLEEP_MILLIS);
-     }
-     result.cancel();
-     Assert.assertEquals(Sets.newHashSet(expected), EmbeddedCollector.RESULTS);
+    HashSet<String> expected = Sets.newHashSet("processing: 3: [11, 222]",
+        "processing: -42: [11, 222]", "processing: 666: [11, 222]");
+    long timeout = System.currentTimeMillis() + TIMEOUT_MILLIS;
+    while (System.currentTimeMillis() < timeout) {
+      if (EmbeddedCollector.RESULTS.containsAll(expected)) {
+        break;
+      }
+      LOG.info("Waiting for expected results.");
+      Thread.sleep(SLEEP_MILLIS);
+    }
+    result.cancel();
+    Assert.assertEquals(Sets.newHashSet(expected), EmbeddedCollector.RESULTS);
   }
 
   private static class TestMultiOutputWithSideInputsFn extends DoFn<Integer, String> {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -301,7 +301,6 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
     MetricsEnvironment.setMetricsSupported(true);
     DirectGraphVisitor graphVisitor = new DirectGraphVisitor();
     pipeline.traverseTopologically(graphVisitor);
-    graphVisitor.finishSpecifyingRemainder();
 
     @SuppressWarnings("rawtypes")
     KeyedPValueTrackingVisitor keyedPValueVisitor = KeyedPValueTrackingVisitor.create();

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/FlattenEvaluatorFactoryTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Iterables;
 import org.apache.beam.runners.direct.DirectRunner.CommittedBundle;
 import org.apache.beam.runners.direct.DirectRunner.UncommittedBundle;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.Create;
@@ -124,6 +125,7 @@ public class FlattenEvaluatorFactoryTest {
     PCollectionList<Integer> list = PCollectionList.empty(p);
 
     PCollection<Integer> flattened = list.apply(Flatten.<Integer>pCollections());
+    flattened.setCoder(VarIntCoder.of());
 
     EvaluationContext evaluationContext = mock(EvaluationContext.class);
     when(evaluationContext.createBundle(flattened))

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/ForceStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/ForceStreamingTest.java
@@ -23,10 +23,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.IOException;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedReadFromUnboundedSource;
+import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.io.Read;
-import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.TransformHierarchy;
@@ -59,7 +58,7 @@ public class ForceStreamingTest {
     // apply the BoundedReadFromUnboundedSource.
     @SuppressWarnings("unchecked")
     BoundedReadFromUnboundedSource boundedRead =
-        Read.from(new FakeUnboundedSource()).withMaxNumRecords(-1);
+        Read.from(CountingSource.unbounded()).withMaxNumRecords(-1);
     //noinspection unchecked
     pipeline.apply(boundedRead);
 
@@ -86,38 +85,4 @@ public class ForceStreamingTest {
     }
 
   }
-
-  /**
-   * A fake {@link UnboundedSource} to satisfy the compiler.
-   */
-  private static class FakeUnboundedSource extends UnboundedSource {
-
-    @Override
-    public List<? extends UnboundedSource> generateInitialSplits(
-        int desiredNumSplits,
-        PipelineOptions options) throws Exception {
-      return null;
-    }
-
-    @Override
-    public UnboundedReader createReader(
-        PipelineOptions options,
-        CheckpointMark checkpointMark) throws IOException {
-      return null;
-    }
-
-    @Override
-    public Coder getCheckpointMarkCoder() {
-      return null;
-    }
-
-    @Override
-    public void validate() { }
-
-    @Override
-    public Coder getDefaultOutputCoder() {
-      return null;
-    }
-  }
-
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/ForceStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/ForceStreamingTest.java
@@ -21,12 +21,10 @@ package org.apache.beam.runners.spark;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
-import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.BoundedReadFromUnboundedSource;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.io.Read;
-import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.transforms.PTransform;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -171,6 +171,8 @@ public class Pipeline {
    * Runs the {@link Pipeline} using its {@link PipelineRunner}.
    */
   public PipelineResult run() {
+    // Ensure all of the nodes are fully specified before a PipelineRunner gets access to the
+    // pipeline.
     LOG.debug("Running {} via {}", this, runner);
     try {
       return runner.run(this);
@@ -281,6 +283,7 @@ public class Pipeline {
    * <p>Typically invoked by {@link PipelineRunner} subclasses.
    */
   public void traverseTopologically(PipelineVisitor visitor) {
+    // Ensure all nodes are fully specified before visiting the pipeline
     Set<PValue> visitedValues =
         // Visit all the transforms, which should implicitly visit all the values.
         transforms.visit(visitor);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformHierarchy.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformHierarchy.java
@@ -47,6 +47,7 @@ import org.apache.beam.sdk.values.TaggedPValue;
 public class TransformHierarchy {
   private final Node root;
   private final Map<POutput, Node> producers;
+  // A map of PValue to the PInput the producing PTransform is applied to
   private final Map<PValue, PInput> producerInput;
   // Maintain a stack based on the enclosing nodes
   private Node current;
@@ -101,7 +102,6 @@ public class TransformHierarchy {
           "Producer unknown for input %s",
           inputValue.getValue());
     }
-    current.input.finishSpecifying();
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
@@ -154,10 +154,24 @@ public class KeyedPCollectionTuple<K> implements PInput {
 
   @Override
   public void finishSpecifying() {
-    for (TaggedKeyedPCollection<K, ?> taggedPCollection : keyedCollections) {
-      taggedPCollection.pCollection.finishSpecifying();
-    }
+    // TODO: Make sure key coder is consistent between PCollections. All component PCollections will
+    // have already been finished.
   }
+
+  private static <K, V> Coder<K> getKeyCoder(PCollection<KV<K, V>> pc) {
+    // TODO: This should already have run coder inference for output, but may not have been consumed
+    // as input yet (and won't be fully specified); This is fine
+
+    // Assumes that the PCollection uses a KvCoder.
+    Coder<?> entryCoder = pc.getCoder();
+    if (!(entryCoder instanceof KvCoder<?, ?>)) {
+      throw new IllegalArgumentException("PCollection does not use a KvCoder");
+    }
+    @SuppressWarnings("unchecked")
+    KvCoder<K, V> coder = (KvCoder<K, V>) entryCoder;
+    return coder.getKeyCoder();
+  }
+
 
   /////////////////////////////////////////////////////////////////////////////
 
@@ -197,7 +211,7 @@ public class KeyedPCollectionTuple<K> implements PInput {
    */
   private final List<TaggedKeyedPCollection<K, ?>> keyedCollections;
 
-  private final Coder<K> keyCoder;
+  private Coder<K> keyCoder;
 
   private final CoGbkResultSchema schema;
 
@@ -219,20 +233,6 @@ public class KeyedPCollectionTuple<K> implements PInput {
     this.keyedCollections = keyedCollections;
     this.schema = new CoGbkResultSchema(tupleTagList);
     this.keyCoder = keyCoder;
-  }
-
-  private static <K, V> Coder<K> getKeyCoder(PCollection<KV<K, V>> pc) {
-    // Need to run coder inference on this PCollection before inspecting it.
-    pc.finishSpecifying();
-
-    // Assumes that the PCollection uses a KvCoder.
-    Coder<?> entryCoder = pc.getCoder();
-    if (!(entryCoder instanceof KvCoder<?, ?>)) {
-      throw new IllegalArgumentException("PCollection does not use a KvCoder");
-    }
-    @SuppressWarnings("unchecked")
-    KvCoder<K, V> coder = (KvCoder<K, V>) entryCoder;
-    return coder.getKeyCoder();
   }
 
   private static <K> List<TaggedKeyedPCollection<K, ?>> copyAddLast(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/KeyedPCollectionTuple.java
@@ -152,12 +152,6 @@ public class KeyedPCollectionTuple<K> implements PInput {
     return pipeline;
   }
 
-  @Override
-  public void finishSpecifying() {
-    // TODO: Make sure key coder is consistent between PCollections. All component PCollections will
-    // have already been finished.
-  }
-
   private static <K, V> Coder<K> getKeyCoder(PCollection<KV<K, V>> pc) {
     // TODO: This should already have run coder inference for output, but may not have been consumed
     // as input yet (and won't be fully specified); This is fine

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PBegin.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PBegin.java
@@ -69,11 +69,6 @@ public class PBegin implements PInput {
     return Collections.emptyList();
   }
 
-  @Override
-  public void finishSpecifying() {
-    // Nothing more to be done.
-  }
-
   /////////////////////////////////////////////////////////////////////////////
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionList.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionList.java
@@ -235,16 +235,12 @@ public class PCollectionList<T> implements PInput, POutput {
 
   @Override
   public void finishSpecifying() {
-    for (TaggedPValue pc : pcollections) {
-      pc.getValue().finishSpecifying();
-    }
+    // All component PCollections will have already been finished.
   }
 
   @Override
-  public void finishSpecifyingOutput() {
-    for (TaggedPValue pc : pcollections) {
-      pc.getValue().finishSpecifyingOutput();
-    }
+  public void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform) {
+    // All component PCollections will have already been finished.
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionList.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionList.java
@@ -234,11 +234,6 @@ public class PCollectionList<T> implements PInput, POutput {
   }
 
   @Override
-  public void finishSpecifying() {
-    // All component PCollections will have already been finished.
-  }
-
-  @Override
   public void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform) {
     // All component PCollections will have already been finished.
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
@@ -256,16 +256,12 @@ public class PCollectionTuple implements PInput, POutput {
 
   @Override
   public void finishSpecifying() {
-    for (PCollection<?> pc : pcollectionMap.values()) {
-      pc.finishSpecifying();
-    }
+    // All component PCollections will already have been finished
   }
 
   @Override
-  public void finishSpecifyingOutput() {
-    for (PCollection<?> pc : pcollectionMap.values()) {
-      pc.finishSpecifyingOutput();
-    }
+  public void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform) {
+    // All component PCollections will already have been finished
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionTuple.java
@@ -255,11 +255,6 @@ public class PCollectionTuple implements PInput, POutput {
   }
 
   @Override
-  public void finishSpecifying() {
-    // All component PCollections will already have been finished
-  }
-
-  @Override
   public void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform) {
     // All component PCollections will already have been finished
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PInput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PInput.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.values;
 
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.transforms.PTransform;
 
 /**
  * The interface for things that might be input to a
@@ -46,11 +47,12 @@ public interface PInput {
   List<TaggedPValue> expand();
 
   /**
-   * After building, finalizes this {@code PInput} to make it ready for
-   * being used as an input to a {@link org.apache.beam.sdk.transforms.PTransform}.
+   * After building, finalizes this {@code PInput} to make it ready for being used as an input to a
+   * {@link org.apache.beam.sdk.transforms.PTransform}.
    *
-   * <p>Automatically invoked whenever {@code apply()} is invoked on
-   * this {@code PInput}, so users do not normally call this explicitly.
+   * <p>Automatically invoked whenever {@code apply()} is invoked on this {@code PInput}, after
+   * {@link PValue#finishSpecifying(PInput, PTransform)} has been called on each component {@link
+   * PValue}, so users do not normally call this explicitly.
    */
   void finishSpecifying();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PInput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PInput.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.values;
 
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.transforms.PTransform;
 
 /**
  * The interface for things that might be input to a
@@ -45,14 +44,4 @@ public interface PInput {
    * <p>Not intended to be invoked directly by user code.
    */
   List<TaggedPValue> expand();
-
-  /**
-   * After building, finalizes this {@code PInput} to make it ready for being used as an input to a
-   * {@link org.apache.beam.sdk.transforms.PTransform}.
-   *
-   * <p>Automatically invoked whenever {@code apply()} is invoked on this {@code PInput}, after
-   * {@link PValue#finishSpecifying(PInput, PTransform)} has been called on each component {@link
-   * PValue}, so users do not normally call this explicitly.
-   */
-  void finishSpecifying();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutput.java
@@ -61,16 +61,15 @@ public interface POutput {
   void recordAsOutput(AppliedPTransform<?, ?, ?> transform);
 
   /**
-   * As part of applying the producing {@link PTransform}, finalizes this
-   * output to make it ready for being used as an input and for running.
+   * As part of applying the producing {@link PTransform}, finalizes this output to make it ready
+   * for being used as an input and for running.
    *
-   * <p>This includes ensuring that all {@link PCollection PCollections}
-   * have {@link org.apache.beam.sdk.coders.Coder Coders} specified or defaulted.
+   * <p>This includes ensuring that all {@link PCollection PCollections} have {@link
+   * org.apache.beam.sdk.coders.Coder Coders} specified or defaulted.
    *
-   * <p>Automatically invoked whenever this {@link POutput} is used
-   * as a {@link PInput} to another {@link PTransform}, or if never
-   * used as a {@link PInput}, when {@link Pipeline#run}
-   * is called, so users do not normally call this explicitly.
+   * <p>Automatically invoked whenever this {@link POutput} is output, after {@link
+   * PValue#finishSpecifyingOutput(PInput, PTransform)} has been called on each component {@link
+   * PValue} returned by {@link #expand()}.
    */
-  void finishSpecifyingOutput();
+  void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutput.java
@@ -71,5 +71,6 @@ public interface POutput {
    * PValue#finishSpecifyingOutput(PInput, PTransform)} has been called on each component {@link
    * PValue} returned by {@link #expand()}.
    */
+  @Deprecated
   void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutput.java
@@ -70,6 +70,8 @@ public interface POutput {
    * <p>Automatically invoked whenever this {@link POutput} is output, after {@link
    * PValue#finishSpecifyingOutput(PInput, PTransform)} has been called on each component {@link
    * PValue} returned by {@link #expand()}.
+   *
+   * @deprecated see BEAM-1199
    */
   @Deprecated
   void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutputValueBase.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/POutputValueBase.java
@@ -89,12 +89,12 @@ public abstract class POutputValueBase implements POutput {
   }
 
   /**
-   * Default behavior for {@link #finishSpecifyingOutput()} is
+   * Default behavior for {@link #finishSpecifyingOutput(PInput, PTransform)}} is
    * to do nothing. Override if your {@link PValue} requires
    * finalization.
    */
   @Override
-  public void finishSpecifyingOutput() { }
+  public void finishSpecifyingOutput(PInput input, PTransform<?, ?> transform) { }
 
   /**
    * The {@link PTransform} that produces this {@link POutputValueBase}.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValue.java
@@ -36,6 +36,7 @@ public interface PValue extends POutput, PInput {
    *
    * <p>For internal use only.
    */
+  @Deprecated
   AppliedPTransform<?, ?, ?> getProducingTransformInternal();
 
   /**
@@ -46,4 +47,18 @@ public interface PValue extends POutput, PInput {
    */
   @Deprecated
   List<TaggedPValue> expand();
+
+  /**
+   * After building, finalizes this {@code PInput} to make it ready for being used as an input to a
+   * {@link org.apache.beam.sdk.transforms.PTransform}.
+   *
+   * <p>Automatically invoked whenever {@code apply()} is invoked on this {@code PValue}, after
+   * {@link PValue#finishSpecifying(PInput, PTransform)} has been called on each component {@link
+   * PValue}, so users do not normally call this explicitly.
+   *
+   * @param upstreamInput the {@link PInput} the {@link PTransform} was applied to to produce this
+   *     output
+   * @param upstreamTransform the {@link PTransform} that produced this {@link PValue}
+   */
+  void finishSpecifying(PInput upstreamInput, PTransform<?, ?> upstreamTransform);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValue.java
@@ -49,7 +49,7 @@ public interface PValue extends POutput, PInput {
   List<TaggedPValue> expand();
 
   /**
-   * After building, finalizes this {@code PInput} to make it ready for being used as an input to a
+   * After building, finalizes this {@code PValue} to make it ready for being used as an input to a
    * {@link org.apache.beam.sdk.transforms.PTransform}.
    *
    * <p>Automatically invoked whenever {@code apply()} is invoked on this {@code PValue}, after

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValueBase.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValueBase.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.values;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -139,7 +141,15 @@ public abstract class PValueBase extends POutputValueBase implements PValue {
 
   @Override
   public void finishSpecifying() {
-    finishSpecifyingOutput();
+    checkState(
+        finishedSpecifying,
+        "%s must be finished specifying with finishSpecifying(PInput, PTransform) before any "
+            + "calls to finishSpecifying()",
+        getClass().getSimpleName());
+  }
+
+  @Override
+  public void finishSpecifying(PInput input, PTransform<?, ?> transform) {
     finishedSpecifying = true;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValueBase.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValueBase.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.values;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -137,15 +135,6 @@ public abstract class PValueBase extends POutputValueBase implements PValue {
   @Override
   public final List<TaggedPValue> expand() {
     return Collections.singletonList(TaggedPValue.of(tag, this));
-  }
-
-  @Override
-  public void finishSpecifying() {
-    checkState(
-        finishedSpecifying,
-        "%s must be finished specifying with finishSpecifying(PInput, PTransform) before any "
-            + "calls to finishSpecifying()",
-        getClass().getSimpleName());
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformHierarchyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformHierarchyTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,9 +33,9 @@ import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -54,13 +55,11 @@ import org.junit.runners.JUnit4;
  * Tests for {@link TransformHierarchy}.
  */
 @RunWith(JUnit4.class)
-public class TransformHierarchyTest {
+public class TransformHierarchyTest implements Serializable {
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+  @Rule public transient ExpectedException thrown = ExpectedException.none();
 
-  @Rule public final TestPipeline pipeline = TestPipeline.create();
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
-  private TransformHierarchy hierarchy;
-
+  private transient TransformHierarchy hierarchy;
 
   @Before
   public void setup() {
@@ -162,18 +161,21 @@ public class TransformHierarchyTest {
         PCollection.createPrimitiveOutputInternal(
             pipeline, WindowingStrategy.globalDefault(), IsBounded.BOUNDED);
 
-    MapElements<Long, Long> map = MapElements.via(new SimpleFunction<Long, Long>() {
-      @Override
-      public Long apply(Long input) {
-        return input;
-      }
-    });
+    ParDo.Bound<Long, Long> pardo =
+        ParDo.of(
+            new DoFn<Long, Long>() {
+              @ProcessElement
+              public void processElement(ProcessContext ctxt) {
+                ctxt.output(ctxt.element());
+              }
+            });
 
     PCollection<Long> mapped =
         PCollection.createPrimitiveOutputInternal(
             pipeline, WindowingStrategy.globalDefault(), IsBounded.BOUNDED);
 
     TransformHierarchy.Node compositeNode = hierarchy.pushNode("Create", begin, create);
+    hierarchy.finishSpecifyingInput();
     assertThat(hierarchy.getCurrent(), equalTo(compositeNode));
     assertThat(compositeNode.getInputs(), Matchers.emptyIterable());
     assertThat(compositeNode.getTransform(), Matchers.<PTransform<?, ?>>equalTo(create));
@@ -183,6 +185,7 @@ public class TransformHierarchyTest {
 
     TransformHierarchy.Node primitiveNode = hierarchy.pushNode("Create/Read", begin, read);
     assertThat(hierarchy.getCurrent(), equalTo(primitiveNode));
+    hierarchy.finishSpecifyingInput();
     hierarchy.setOutput(created);
     hierarchy.popNode();
     assertThat(
@@ -199,7 +202,8 @@ public class TransformHierarchyTest {
     assertThat(hierarchy.getProducer(created), equalTo(primitiveNode));
     hierarchy.popNode();
 
-    TransformHierarchy.Node otherPrimitive = hierarchy.pushNode("ParDo", created, map);
+    TransformHierarchy.Node otherPrimitive = hierarchy.pushNode("ParDo", created, pardo);
+    hierarchy.finishSpecifyingInput();
     hierarchy.setOutput(mapped);
     hierarchy.popNode();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -1147,15 +1147,16 @@ public class ParDoTest implements Serializable {
 
     final TupleTag<Integer> mainOutputTag = new TupleTag<Integer>("main");
     final TupleTag<TestDummy> sideOutputTag = new TupleTag<TestDummy>("unregisteredSide");
-    PCollectionTuple outputTuple = input.apply(ParDo.of(new SideOutputDummyFn(sideOutputTag))
-        .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag)));
+    ParDo.BoundMulti<Integer, Integer> pardo = ParDo.of(new SideOutputDummyFn(sideOutputTag))
+        .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag));
+    PCollectionTuple outputTuple = input.apply(pardo);
 
     outputTuple.get(sideOutputTag).setCoder(new TestDummyCoder());
 
     outputTuple.get(sideOutputTag).apply(View.<TestDummy>asSingleton());
 
     assertEquals(new TestDummyCoder(), outputTuple.get(sideOutputTag).getCoder());
-    outputTuple.get(sideOutputTag).finishSpecifyingOutput(); // Check for crashes
+    outputTuple.get(sideOutputTag).finishSpecifyingOutput(input, pardo); // Check for crashes
     assertEquals(new TestDummyCoder(),
         outputTuple.get(sideOutputTag).getCoder()); // Check for corruption
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/TypedPValueTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/TypedPValueTest.java
@@ -159,13 +159,16 @@ public class TypedPValueTest {
 
   @Test
   public void testFinishSpecifyingShouldFailIfNoCoderInferrable() {
+    p.enableAbandonedNodeEnforcement(false);
+    PCollection<Integer> created = p.apply(Create.of(1, 2, 3));
+    ParDo.Bound<Integer, EmptyClass> uninferrableParDo = ParDo.of(new EmptyClassDoFn());
     PCollection<EmptyClass> unencodable =
-        p.apply(Create.of(1, 2, 3)).apply(ParDo.of(new EmptyClassDoFn()));
+        created.apply(uninferrableParDo);
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Unable to return a default Coder");
     thrown.expectMessage("Inferring a Coder from the CoderRegistry failed");
 
-    unencodable.finishSpecifying();
+    unencodable.finishSpecifying(created, uninferrableParDo);
   }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
This removes use of getProducingTransformInternal() in TypedPValue.

Ensure that all nodes are finished specifying before a call to
`Pipeline#traverseTopologically` or `PipelineRunner#run`. This ensures
that all nodes are fully specified without requiring the `PipelineRunner`
to do so explicitly.

Use Coder Inference rather than explicitly setting Coders within
DirectRunner overrides.