### PR TITLE
[BEAM-1139] Add no-arg constructor for UnboundedReadFromBoundedSource

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/UnboundedReadFromBoundedSource.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/UnboundedReadFromBoundedSource.java
@@ -118,6 +118,11 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
   public static class BoundedToUnboundedSourceAdapter<T>
       extends UnboundedSource<T, BoundedToUnboundedSourceAdapter.Checkpoint<T>> {
 
+    @SuppressWarnings("unused") // for Kryo
+    private BoundedToUnboundedSourceAdapter() {
+      this.boundedSource = null;
+    }
+
     private BoundedSource<T> boundedSource;
 
     public BoundedToUnboundedSourceAdapter(BoundedSource<T> boundedSource) {


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This allows Kryo to work with the type, currently required by the Apex runner.

This seems to be failing in precommit reliably.