### PR TITLE
[BEAM-863] FileBasedSink: ignore exceptions when removing temp output files for issues in Windows OS.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -482,7 +482,7 @@ public abstract class FileBasedSink<T> extends Sink<T> {
       try {
         matches.addAll(factory.match(factory.resolve(tempDir, "*")));
       } catch (Exception e) {
-        LOG.warn("Failed to match temporary outputs under: [{}].", tempDir);
+        LOG.warn("Failed to match temporary files under: [{}].", tempDir);
       }
       Set<String> allMatches = new HashSet<>(matches);
       allMatches.addAll(knownFiles);
@@ -492,6 +492,7 @@ public abstract class FileBasedSink<T> extends Sink<T> {
           tempDir,
           matches.size(),
           allMatches.size() - matches.size());
+      // Deletion of the temporary directory might fail, if not all temporary files are removed.
       try {
         factory.remove(allMatches);
         factory.remove(ImmutableList.of(tempDir));


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

WordCount with DirectRunner in Windows now can succeed (temp files and dir are also deleted correctly) with warning message:
Dec 13, 2016 12:00:48 AM org.apache.beam.sdk.io.FileBasedSink$FileBasedWriteOper
ation removeTemporaryFiles
WARNING: Failed to match temporary outputs under: [C:\Users\peihe\temp-beam-outp
ut-2016-12-348_00-00-35].



