### PR TITLE
[BEAM-1104] Don't incorrectly log error in MetricsEnvironment

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsEnvironment.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricsEnvironment.java
@@ -56,7 +56,7 @@ public class MetricsEnvironment {
    */
   @Nullable
   public static MetricsContainer setCurrentContainer(@Nullable MetricsContainer container) {
-    MetricsContainer previous = getCurrentContainer();
+    MetricsContainer previous = CONTAINER_FOR_THREAD.get();
     if (container == null) {
       CONTAINER_FOR_THREAD.remove();
     } else {


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [*] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [*] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [*] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [*] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Using getCurrentContainer() logs an error if metrics are not supported.
This is because it acts as the common point of access for user code that
reports metrics.

It should not be used within setCurrentContainer(), because the first
container being set will have a null previous-current-container, which
will cause the error to be incorrectly logged.