### PR TITLE
[BEAM-1149] SimpleDoFnRunner observes window if SideInputReader is nonempty

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -114,7 +114,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
       WindowingStrategy<?, ?> windowingStrategy) {
     this.fn = fn;
     this.signature = DoFnSignatures.getSignature(fn.getClass());
-    this.observesWindow = signature.processElement().observesWindow();
+    this.observesWindow = signature.processElement().observesWindow() || !sideInputReader.isEmpty();
     this.invoker = DoFnInvokers.invokerFor(fn);
     this.outputManager = outputManager;
     this.mainOutputTag = mainOutputTag;


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @amitsela 

This is a quick fix. There is some redundancy with `PushbackSideInputDoFnRunner`.

Confirmed that the following run - which is only run on postcommit - fails on `master` and succeeds with this PR:

```
mvn --batch-mode --errors verify -pl runners/spark \
    -Prunnable-on-service-tests -Plocal-runnable-on-service-tests \
    -D test=ParDoTest \
    -D mdep.analyze.skip=true \
    -D failIfNoTests=false \
    -D forkCount=0 \
    -D runnableOnServicePipelineOptions='[
      "--runner=TestSparkRunner",
      "--streaming=false",
      "--enableSparkMetricSinks=false"
    ]'
```
