### PR TITLE
[BEAM-1160] Fail to split in FileBasedSource if filePattern expands to empty

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -331,7 +331,13 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       try {
         checkState(fileOrPatternSpec.isAccessible(),
                    "Bundle splitting should only happen at execution time.");
-        for (final String file : FileBasedSource.expandFilePattern(fileOrPatternSpec.get())) {
+        Collection<String> expandedFiles =
+            FileBasedSource.expandFilePattern(fileOrPatternSpec.get());
+        if (expandedFiles.isEmpty()) {
+          throw new IllegalArgumentException(
+              String.format("Unable to find any files matching %s", fileOrPatternSpec.get()));
+        }
+        for (final String file : expandedFiles) {
           futures.add(createFutureForFileSplit(file, desiredBundleSizeBytes, options, service));
         }
         List<? extends FileBasedSource<T>> splitResults =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -333,10 +333,8 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
                    "Bundle splitting should only happen at execution time.");
         Collection<String> expandedFiles =
             FileBasedSource.expandFilePattern(fileOrPatternSpec.get());
-        if (expandedFiles.isEmpty()) {
-          throw new IllegalArgumentException(
-              String.format("Unable to find any files matching %s", fileOrPatternSpec.get()));
-        }
+        checkArgument(!expandedFiles.isEmpty(),
+            "Unable to find any files matching %s", fileOrPatternSpec.get());
         for (final String file : expandedFiles) {
           futures.add(createFutureForFileSplit(file, desiredBundleSizeBytes, options, service));
         }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
@@ -59,6 +59,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -73,6 +74,7 @@ public class FileBasedSourceTest {
   Random random = new Random(0L);
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   /**
    * If {@code splitHeader} is null, this is just a simple line-based reader. Otherwise, the file is
@@ -415,6 +417,16 @@ public class FileBasedSourceTest {
         new TestFileBasedSource(file0.getParent() + "/" + "file*", Long.MAX_VALUE, null);
     List<? extends BoundedSource<String>> splits = source.splitIntoBundles(Long.MAX_VALUE, null);
     assertEquals(numFiles, splits.size());
+  }
+
+  @Test
+  public void testSplittingFailsOnEmptyFileExpansion() throws Exception {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    String missingFilePath = tempFolder.newFolder().getAbsolutePath() + "/missing.txt";
+    TestFileBasedSource source = new TestFileBasedSource(missingFilePath, Long.MAX_VALUE, null);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(String.format("Unable to find any files matching %s", missingFilePath));
+    source.splitIntoBundles(1234, options);
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Typically, input file patterns are validated during Pipeline
construction, but standard Read transforms include an option to disable
validation. This is generally useful but can lead to cases where a
Pipeline executes successfully with empty inputs.

This changes the behavior to fail execution on empty file-based inputs
even when validation is disabled.