### PR TITLE
Fix typo in mvn command args in Apex postcommit Jenkins job

### DIFF
--- a/.jenkins/job_beam_PostCommit_Java_RunnableOnService_Apex.groovy
+++ b/.jenkins/job_beam_PostCommit_Java_RunnableOnService_Apex.groovy
@@ -36,6 +36,6 @@ mavenJob('beam_PostCommit_Java_RunnableOnService_Apex') {
       --also-make \
       --batch-mode \
       --errors \
-      --profile runnable-on-service-tests \
-      --profile local-runnable-on-service-tests''')
+      --activate-profiles runnable-on-service-tests \
+      --activate-profiles local-runnable-on-service-tests''')
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: anyone

Tested that this actually runs so kicking the seed job should fix up the postcommit for Apex.