### PR TITLE
Remove deprecated methods of InMemoryTimerInternals

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/InMemoryTimerInternals.java
@@ -273,17 +273,6 @@ public class InMemoryTimerInternals implements TimerInternals {
     }
   }
 
-  /** Advances input watermark to the given value and fires event-time timers accordingly.
-   *
-   *  @deprecated Use advanceInputWatermark without callback and fireEventTimers.
-   */
-  @Deprecated
-  public void advanceInputWatermark(
-      TimerCallback timerCallback, Instant newInputWatermark) throws Exception {
-    advanceInputWatermark(newInputWatermark);
-    advanceAndFire(timerCallback, newInputWatermark, TimeDomain.EVENT_TIME);
-  }
-
   /** Advances processing time to the given value and fires processing-time timers accordingly.
    *
    *  @deprecated Use advanceProcessingTime without callback and fireProcessingTimers.
@@ -293,21 +282,6 @@ public class InMemoryTimerInternals implements TimerInternals {
       TimerCallback timerCallback, Instant newProcessingTime) throws Exception {
     advanceProcessingTime(newProcessingTime);
     advanceAndFire(timerCallback, newProcessingTime, TimeDomain.PROCESSING_TIME);
-  }
-
-  /**
-   * Advances synchronized processing time to the given value and fires processing-time timers
-   * accordingly.
-   *
-   *  @deprecated Use advanceInputWatermark without callback and fireSynchronizedProcessingTimers.
-   */
-  @Deprecated
-  public void advanceSynchronizedProcessingTime(
-      TimerCallback timerCallback, Instant newSynchronizedProcessingTime)
-      throws Exception {
-    advanceSynchronizedProcessingTime(newSynchronizedProcessingTime);
-    advanceAndFire(
-        timerCallback, newSynchronizedProcessingTime, TimeDomain.SYNCHRONIZED_PROCESSING_TIME);
   }
 
   @Deprecated


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @tweise just choosing reviewer at random
CC: @scwhittle for the deprecation which I think is now cleaned up

(no JIRA because it is just cleanup)