### PR TITLE
[BEAM-27] Support setting and deleting timers by ID in InMemoryTimerInternals

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
@@ -17,13 +17,15 @@
  */
 package org.apache.beam.runners.core;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.MoreObjects;
-import java.util.HashSet;
-import java.util.PriorityQueue;
-import java.util.Set;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.TimeDomain;
@@ -35,17 +37,17 @@ import org.joda.time.Instant;
 /** {@link TimerInternals} with all watermarks and processing clock simulated in-memory. */
 public class InMemoryTimerInternals implements TimerInternals {
 
-  /** At most one timer per timestamp is kept. */
-  private Set<TimerData> existingTimers = new HashSet<>();
+  /** The current set timers by namespace and ID. */
+  Table<StateNamespace, String, TimerData> existingTimers = HashBasedTable.create();
 
   /** Pending input watermark timers, in timestamp order. */
-  private PriorityQueue<TimerData> watermarkTimers = new PriorityQueue<>(11);
+  private NavigableSet<TimerData> watermarkTimers = new TreeSet<>();
 
   /** Pending processing time timers, in timestamp order. */
-  private PriorityQueue<TimerData> processingTimers = new PriorityQueue<>(11);
+  private NavigableSet<TimerData> processingTimers = new TreeSet<>();
 
   /** Pending synchronized processing time timers, in timestamp order. */
-  private PriorityQueue<TimerData> synchronizedProcessingTimers = new PriorityQueue<>(11);
+  private NavigableSet<TimerData> synchronizedProcessingTimers = new TreeSet<>();
 
   /** Current input watermark. */
   private Instant inputWatermarkTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
@@ -74,13 +76,13 @@ public class InMemoryTimerInternals implements TimerInternals {
     final TimerData data;
     switch (domain) {
       case EVENT_TIME:
-        data = watermarkTimers.peek();
+        data = watermarkTimers.first();
         break;
       case PROCESSING_TIME:
-        data = processingTimers.peek();
+        data = processingTimers.first();
         break;
       case SYNCHRONIZED_PROCESSING_TIME:
-        data = synchronizedProcessingTimers.peek();
+        data = synchronizedProcessingTimers.first();
         break;
       default:
         throw new IllegalArgumentException("Unexpected time domain: " + domain);
@@ -88,7 +90,7 @@ public class InMemoryTimerInternals implements TimerInternals {
     return (data == null) ? null : data.getTimestamp();
   }
 
-  private PriorityQueue<TimerData> queue(TimeDomain domain) {
+  private NavigableSet<TimerData> timersForDomain(TimeDomain domain) {
     switch (domain) {
       case EVENT_TIME:
         return watermarkTimers;
@@ -104,27 +106,45 @@ public class InMemoryTimerInternals implements TimerInternals {
   @Override
   public void setTimer(StateNamespace namespace, String timerId, Instant target,
       TimeDomain timeDomain) {
-    throw new UnsupportedOperationException("Setting a timer by ID is not yet supported.");
+    setTimer(TimerData.of(timerId, namespace, target, timeDomain));
   }
 
   @Override
   public void setTimer(TimerData timerData) {
     WindowTracing.trace("{}.setTimer: {}", getClass().getSimpleName(), timerData);
-    if (existingTimers.add(timerData)) {
-      queue(timerData.getDomain()).add(timerData);
+
+    @Nullable
+    TimerData existing = existingTimers.get(timerData.getNamespace(), timerData.getTimerId());
+    if (existing == null) {
+      existingTimers.put(timerData.getNamespace(), timerData.getTimerId(), timerData);
+      timersForDomain(timerData.getDomain()).add(timerData);
+    } else {
+      checkArgument(timerData.getDomain().equals(existing.getDomain()),
+          "Attempt to set %s for time domain %s, but it is already set for time domain %s",
+          timerData.getTimerId(), timerData.getDomain(), existing.getDomain());
+
+      if (!timerData.getTimestamp().equals(existing.getTimestamp())) {
+        NavigableSet<TimerData> timers = timersForDomain(timerData.getDomain());
+        timers.remove(existing);
+        timers.add(timerData);
+        existingTimers.put(timerData.getNamespace(), timerData.getTimerId(), timerData);
+      }
     }
   }
 
   @Override
   public void deleteTimer(StateNamespace namespace, String timerId) {
-    throw new UnsupportedOperationException("Canceling a timer by ID is not yet supported.");
+    TimerData existing = existingTimers.get(namespace, timerId);
+    if (existing != null) {
+      deleteTimer(existing);
+    }
   }
 
   @Override
   public void deleteTimer(TimerData timer) {
     WindowTracing.trace("{}.deleteTimer: {}", getClass().getSimpleName(), timer);
-    existingTimers.remove(timer);
-    queue(timer.getDomain()).remove(timer);
+    existingTimers.remove(timer.getNamespace(), timer.getTimerId());
+    timersForDomain(timer.getDomain()).remove(timer);
   }
 
   @Override
@@ -261,10 +281,11 @@ public class InMemoryTimerInternals implements TimerInternals {
 
   @Nullable
   private TimerData removeNextTimer(Instant currentTime, TimeDomain domain) {
-    PriorityQueue<TimerData> queue = queue(domain);
-    if (!queue.isEmpty() && currentTime.isAfter(queue.peek().getTimestamp())) {
-      TimerData timer = queue.remove();
-      existingTimers.remove(timer);
+    NavigableSet<TimerData> timers = timersForDomain(domain);
+
+    if (!timers.isEmpty() && currentTime.isAfter(timers.first().getTimestamp())) {
+      TimerData timer = timers.pollFirst();
+      existingTimers.remove(timer.getNamespace(), timer.getTimerId());
       return timer;
     } else {
       return null;


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This minor improvements brings `InMemoryTimerInternals` in line with the design for state and timers. I chose to just switch to `NavigableSet` instead of doing anything more fancy, and eagerly delete timers, presuming there might be memory pressure if I lazily delete them only when they are popped from the queue. We can revisit or make another implementation of TimerInternals if we need different performance characteristics.