### PR TITLE
[BEAM-362] Remove deprecated AggregatorFactory from SDK

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/resources/org/apache/beam/runners/dataflow/dataflow.properties
+++ b/runners/google-cloud-dataflow-java/src/main/resources/org/apache/beam/runners/dataflow/dataflow.properties
@@ -18,6 +18,6 @@
 
 environment.major.version=6
 
-worker.image.batch=dataflow.gcr.io/v1beta3/beam-java-batch:beam-master-20161216
+worker.image.batch=dataflow.gcr.io/v1beta3/beam-java-batch:beam-master-20161220
 
-worker.image.streaming=dataflow.gcr.io/v1beta3/beam-java-streaming:beam-master-20161216
+worker.image.streaming=dataflow.gcr.io/v1beta3/beam-java-streaming:beam-master-20161220

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Aggregator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Aggregator.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.transforms;
 
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
-import org.apache.beam.sdk.util.ExecutionContext;
 
 /**
  * An {@code Aggregator<InputT>} enables monitoring of values of type {@code InputT},
@@ -68,22 +67,4 @@ public interface Aggregator<InputT, OutputT> {
    * aggregator.
    */
   CombineFn<InputT, ?, OutputT> getCombineFn();
-
-  /**
-   * @deprecated this is for use only by runners and exists only for a migration period. Please
-   * use the identical interface in org.apache.beam.runners.core
-   */
-  @Deprecated
-  interface AggregatorFactory {
-    /**
-     * Create an aggregator with the given {@code name} and {@link CombineFn}.
-     *
-     *  <p>This method is called to create an aggregator for a {@link DoFn}. It receives the
-     *  class of the {@link DoFn} being executed and the context of the step it is being
-     *  executed in.
-     */
-    <InputT, AccumT, OutputT> Aggregator<InputT, OutputT> createAggregatorForDoFn(
-        Class<?> fnClass, ExecutionContext.StepContext stepContext,
-        String aggregatorName, CombineFn<InputT, AccumT, OutputT> combine);
-  }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The reason this change actually adds real value is that it is the last reference to `ExecutionContext` in the SDK. After this PR, we can move all that to runners-core, which in turn starts to unblock moving `StateInternals` and `TimerInternals` to runners-core. I haven't included that here since it will require a Dataflow worker process while this will go right in.

R: @lukecwik (randomly selected committer)