### PR TITLE
[BEAM-625] Peak memory reduction in Avro and Pickler.

### DIFF
--- a/sdks/python/apache_beam/internal/pickler.py
+++ b/sdks/python/apache_beam/internal/pickler.py
@@ -191,19 +191,19 @@ def dumps(o):
     dill.dill._trace(False)  # pylint: disable=protected-access
 
   # Compress as compactly as possible to decrease peak memory usage (of multiple
-  # in-memory copies). Also use a separate statement in order to decrease peak
-  # memory usage (by allowing unneeded data to go out of scope).
-  s = zlib.compress(s, 9)
+  # in-memory copies) and free up some possibly large and no-longer-needed
+  # memory.
+  c = zlib.compress(s, 9)
+  del s
 
-  return base64.b64encode(s)
+  return base64.b64encode(c)
 
 
 def loads(encoded):
-  s = base64.b64decode(encoded)
+  c = base64.b64decode(encoded)
 
-  # Separate statement in order to decrease peak memory usage (by allowing
-  # unneeded data to go out of scope).
-  s = zlib.decompress(s)
+  s = zlib.decompress(c)
+  del c  # Free up some possibly large and no-longer-needed memory.
 
   try:
     return dill.loads(s)

--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -176,7 +176,7 @@ class _AvroBlock(object):
     # Decompress data early on (if needed) and thus decrease the number of
     # parallel copies of the data in memory at any given in time during
     # block iteration.
-    self._block_bytes = self._decompress_bytes(block_bytes, codec)
+    self._decompressed_block_bytes = self._decompress_bytes(block_bytes, codec)
     self._num_records = num_records
     self._schema = schema.parse(schema_string)
 
@@ -208,7 +208,8 @@ class _AvroBlock(object):
     return self._num_records
 
   def records(self):
-    decoder = avroio.BinaryDecoder(StringIO.StringIO(self._block_bytes))
+    decoder = avroio.BinaryDecoder(
+        StringIO.StringIO(self._decompressed_block_bytes))
     reader = avroio.DatumReader(
         writers_schema=self._schema, readers_schema=self._schema)
 

--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -173,20 +173,23 @@ class _AvroBlock(object):
   """Represents a block of an Avro file."""
 
   def __init__(self, block_bytes, num_records, codec, schema_string):
-    self._block_bytes = block_bytes
+    # Decompress data early on (if needed) and thus decrease the number of
+    # parallel copies of the data in memory at any given in time during
+    # block iteration.
+    self._block_bytes = self._decompress_bytes(block_bytes, codec)
     self._num_records = num_records
-    self._codec = codec
     self._schema = schema.parse(schema_string)
 
-  def _decompress_bytes(self, data):
-    if self._codec == 'null':
+  @staticmethod
+  def _decompress_bytes(data, codec):
+    if codec == 'null':
       return data
-    elif self._codec == 'deflate':
+    elif codec == 'deflate':
       # zlib.MAX_WBITS is the window size. '-' sign indicates that this is
       # raw data (without headers). See zlib and Avro documentations for more
       # details.
       return zlib.decompress(data, -zlib.MAX_WBITS)
-    elif self._codec == 'snappy':
+    elif codec == 'snappy':
       # Snappy is an optional avro codec.
       # See Snappy and Avro documentation for more details.
       try:
@@ -199,14 +202,13 @@ class _AvroBlock(object):
       avroio.BinaryDecoder(StringIO.StringIO(data[-4:])).check_crc32(result)
       return result
     else:
-      raise ValueError('Unknown codec: %r', self._codec)
+      raise ValueError('Unknown codec: %r', codec)
 
   def num_records(self):
     return self._num_records
 
   def records(self):
-    decompressed_bytes = self._decompress_bytes(self._block_bytes)
-    decoder = avroio.BinaryDecoder(StringIO.StringIO(decompressed_bytes))
+    decoder = avroio.BinaryDecoder(StringIO.StringIO(self._block_bytes))
     reader = avroio.DatumReader(
         writers_schema=self._schema, readers_schema=self._schema)
 


### PR DESCRIPTION
Decreasing the number of copies of things in scope for reduced peak memory utilization in Avro and Pickler.