### PR TITLE
[BEAM-1185] Remove the word 'Pipeline' from the PipelineRunner subclasses

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -171,7 +171,7 @@ the `|` operator is used to chain them.
 # Standard imports
 import apache_beam as beam
 # Create a pipeline executing on a direct runner (local, non-cloud).
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 # Create a PCollection with names and write it to a file.
 (p
  | 'add names' >> beam.Create(['Ann', 'Joe'])
@@ -186,7 +186,7 @@ The `Map` `PTransform` returns one output per input. It takes a callable that is
 
 ```python
 import apache_beam as beam
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 # Read a file containing names, add a greeting to each name, and write to a file.
 (p
  | 'load names' >> beam.Read(beam.io.TextFileSource('./names'))
@@ -204,7 +204,7 @@ The `FlatMap` transform returns zero to many output per input. It accepts a call
 
 ```python
 import apache_beam as beam
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 # Read a file containing names, add two greetings to each name, and write to a file.
 (p
  | 'load names' >> beam.Read(beam.io.TextFileSource('./names'))
@@ -222,7 +222,7 @@ a function using `yield`.
 
 ```python
 import apache_beam as beam
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 # Read a file containing names, add two greetings to each name
 # (with FlatMap using a yield generator), and write to a file.
 def add_greetings(name, messages):
@@ -243,7 +243,7 @@ This example shows how to read a text file from [Google Cloud Storage](https://c
 ```python
 import re
 import apache_beam as beam
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 (p
  | 'read' >> beam.Read(
     beam.io.TextFileSource('gs://dataflow-samples/shakespeare/kinglear.txt'))
@@ -260,7 +260,7 @@ This is a somewhat forced example of `GroupByKey` to count words as the previous
 ```python
 import re
 import apache_beam as beam
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 class MyCountTransform(beam.PTransform):
   def expand(self, pcoll):
     return (pcoll
@@ -286,7 +286,7 @@ of the data encoding.
 ```python
 import apache_beam as beam
 from apache_beam.typehints import typehints
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 (p
  | 'read' >> beam.Read(beam.io.TextFileSource('./names'))
  | 'add types' >> beam.Map(lambda x: (x, 1)).with_output_types(typehints.KV[str, int])
@@ -347,7 +347,7 @@ Combiner transforms use "reducing" functions, such as sum, min, or max, to combi
 
 ```python
 import apache_beam as beam
-p = beam.Pipeline('DirectPipelineRunner')
+p = beam.Pipeline('DirectRunner')
 
 SAMPLE_DATA = [('a', 1), ('b', 10), ('a', 2), ('a', 3), ('b', 20)]
 

--- a/sdks/python/apache_beam/examples/complete/autocomplete_test.py
+++ b/sdks/python/apache_beam/examples/complete/autocomplete_test.py
@@ -30,7 +30,7 @@ class AutocompleteTest(unittest.TestCase):
   WORDS = ['this', 'this', 'that', 'to', 'to', 'to']
 
   def test_top_prefixes(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     words = p | beam.Create(self.WORDS)
     result = words | autocomplete.TopPerPrefix(5)
     # values must be hashable for now

--- a/sdks/python/apache_beam/examples/complete/estimate_pi_test.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi_test.py
@@ -38,7 +38,7 @@ def in_between(lower, upper):
 class EstimatePiTest(unittest.TestCase):
 
   def test_basics(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     result = p | 'Estimate' >> estimate_pi.EstimatePiTransform()
 
     # Note: Probabilistically speaking this test can fail with a probability

--- a/sdks/python/apache_beam/examples/complete/juliaset/juliaset_main.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/juliaset_main.py
@@ -38,7 +38,7 @@ an example:
 python juliaset_main.py \
   --job_name juliaset-$USER \
   --project YOUR-PROJECT \
-  --runner BlockingDataflowPipelineRunner \
+  --runner BlockingDataflowRunner \
   --setup_file ./setup.py \
   --staging_location gs://YOUR-BUCKET/juliaset/staging \
   --temp_location gs://YOUR-BUCKET/juliaset/temp \

--- a/sdks/python/apache_beam/examples/complete/tfidf_test.py
+++ b/sdks/python/apache_beam/examples/complete/tfidf_test.py
@@ -47,7 +47,7 @@ class TfIdfTest(unittest.TestCase):
       f.write(contents)
 
   def test_tfidf_transform(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     uri_to_line = p | beam.Create(
         'create sample',
         [('1.txt', 'abc def ghi'),

--- a/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
+++ b/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
@@ -21,7 +21,7 @@ An example that reads Wikipedia edit data from Cloud Storage and computes the
 user with the longest string of edits separated by no more than an hour within
 each 30 day period.
 
-To execute this pipeline locally using the DirectPipelineRunner, specify an
+To execute this pipeline locally using the DirectRunner, specify an
 output prefix on GCS:
   --output gs://YOUR_OUTPUT_PREFIX
 
@@ -31,7 +31,7 @@ pipeline configuration in addition to the above:
   --project YOUR_PROJECT_ID
   --staging_location gs://YOUR_STAGING_DIRECTORY
   --temp_location gs://YOUR_TEMPORARY_DIRECTORY
-  --runner BlockingDataflowPipelineRunner
+  --runner BlockingDataflowRunner
 
 The default input is gs://dataflow-samples/wikipedia_edits/*.json and can be
 overridden with --input.

--- a/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions_test.py
+++ b/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions_test.py
@@ -49,7 +49,7 @@ class ComputeTopSessionsTest(unittest.TestCase):
   ]
 
   def test_compute_top_sessions(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     edits = p | beam.Create(self.EDITS)
     result = edits | top_wikipedia_sessions.ComputeTopSessions(1.0)
 

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_side_input_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_side_input_test.py
@@ -27,7 +27,7 @@ from apache_beam.examples.cookbook import bigquery_side_input
 class BigQuerySideInputTest(unittest.TestCase):
 
   def test_create_groups(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
 
     group_ids_pcoll = p | 'create_group_ids' >> beam.Create(['A', 'B', 'C'])
     corpus_pcoll = p | beam.Create('create_corpus',

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_test.py
@@ -27,7 +27,7 @@ from apache_beam.examples.cookbook import bigquery_tornadoes
 class BigQueryTornadoesTest(unittest.TestCase):
 
   def test_basics(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     rows = (p | 'create' >> beam.Create([
         {'month': 1, 'day': 1, 'tornado': False},
         {'month': 1, 'day': 2, 'tornado': True},

--- a/sdks/python/apache_beam/examples/cookbook/coders_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/coders_test.py
@@ -34,7 +34,7 @@ class CodersTest(unittest.TestCase):
       {'host': ['Brasil', 1], 'guest': ['Italy', 0]}]
 
   def test_compute_points(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     records = p | 'create' >> beam.Create(self.SAMPLE_RECORDS)
     result = (records
               | 'points' >> beam.FlatMap(coders.compute_points)

--- a/sdks/python/apache_beam/examples/cookbook/combiners_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/combiners_test.py
@@ -44,7 +44,7 @@ class CombinersTest(unittest.TestCase):
     can be used.
     """
     result = (
-        beam.Pipeline(runner=beam.runners.DirectPipelineRunner())
+        beam.Pipeline(runner=beam.runners.DirectRunner())
         | beam.Create(CombinersTest.SAMPLE_DATA)
         | beam.CombinePerKey(sum))
 
@@ -60,7 +60,7 @@ class CombinersTest(unittest.TestCase):
       return result
 
     result = (
-        beam.Pipeline(runner=beam.runners.DirectPipelineRunner())
+        beam.Pipeline(runner=beam.runners.DirectRunner())
         | beam.Create(CombinersTest.SAMPLE_DATA)
         | beam.CombinePerKey(multiply))
 

--- a/sdks/python/apache_beam/examples/cookbook/custom_ptransform_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/custom_ptransform_test.py
@@ -39,7 +39,7 @@ class CustomCountTest(unittest.TestCase):
     self.run_pipeline(custom_ptransform.Count3(factor), factor=factor)
 
   def run_pipeline(self, count_implementation, factor=1):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     words = p | beam.Create(['CAT', 'DOG', 'CAT', 'CAT', 'DOG'])
     result = words | count_implementation
     assert_that(

--- a/sdks/python/apache_beam/examples/cookbook/filters_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/filters_test.py
@@ -35,7 +35,7 @@ class FiltersTest(unittest.TestCase):
       ]
 
   def _get_result_for_month(self, month):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     rows = (p | 'create' >> beam.Create(self.input_data))
 
     results = filters.filter_cold_days(rows, month)

--- a/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
+++ b/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
@@ -40,7 +40,7 @@ pipeline configuration:
   --staging_location gs://YOUR_STAGING_DIRECTORY
   --temp_location gs://YOUR_TEMP_DIRECTORY
   --job_name YOUR_JOB_NAME
-  --runner BlockingDataflowPipelineRunner
+  --runner BlockingDataflowRunner
 
 and an output prefix on GCS:
   --output gs://YOUR_OUTPUT_PREFIX

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -220,14 +220,14 @@ def pipeline_options_remote(argv):
   options = PipelineOptions(flags=argv)
 
   # For Cloud execution, set the Cloud Platform project, job_name,
-  # staging location, temp_location and specify DataflowPipelineRunner or
-  # BlockingDataflowPipelineRunner.
+  # staging location, temp_location and specify DataflowRunner or
+  # BlockingDataflowRunner.
   google_cloud_options = options.view_as(GoogleCloudOptions)
   google_cloud_options.project = 'my-project-id'
   google_cloud_options.job_name = 'myjob'
   google_cloud_options.staging_location = 'gs://my-bucket/binaries'
   google_cloud_options.temp_location = 'gs://my-bucket/temp'
-  options.view_as(StandardOptions).runner = 'DataflowPipelineRunner'
+  options.view_as(StandardOptions).runner = 'DataflowRunner'
 
   # Create the Pipeline with the specified options.
   p = Pipeline(options=options)
@@ -238,7 +238,7 @@ def pipeline_options_remote(argv):
   my_output = my_options.output
 
   # Overriding the runner for tests.
-  options.view_as(StandardOptions).runner = 'DirectPipelineRunner'
+  options.view_as(StandardOptions).runner = 'DirectRunner'
   p = Pipeline(options=options)
 
   lines = p | beam.io.Read(beam.io.TextFileSource(my_input))
@@ -436,7 +436,7 @@ def examples_wordcount_minimal(renames):
   google_cloud_options.job_name = 'myjob'
   google_cloud_options.staging_location = 'gs://your-bucket-name-here/staging'
   google_cloud_options.temp_location = 'gs://your-bucket-name-here/temp'
-  options.view_as(StandardOptions).runner = 'BlockingDataflowPipelineRunner'
+  options.view_as(StandardOptions).runner = 'BlockingDataflowRunner'
   # [END examples_wordcount_minimal_options]
 
   # Run it locally for testing.

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -112,7 +112,7 @@ class ParDoTest(unittest.TestCase):
     self.assertEqual({1, 2, 4}, set(result))
 
   def test_pardo_side_input(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     words = p | 'start' >> beam.Create(['a', 'bb', 'ccc', 'dddd'])
 
     # [START model_pardo_side_input]
@@ -230,7 +230,7 @@ class ParDoTest(unittest.TestCase):
 class TypeHintsTest(unittest.TestCase):
 
   def test_bad_types(self):
-    p = beam.Pipeline('DirectPipelineRunner', argv=sys.argv)
+    p = beam.Pipeline('DirectRunner', argv=sys.argv)
     evens = None  # pylint: disable=unused-variable
 
     # [START type_hints_missing_define_numbers]
@@ -292,7 +292,7 @@ class TypeHintsTest(unittest.TestCase):
 
   def test_runtime_checks_off(self):
     # pylint: disable=expression-not-assigned
-    p = beam.Pipeline('DirectPipelineRunner', argv=sys.argv)
+    p = beam.Pipeline('DirectRunner', argv=sys.argv)
     # [START type_hints_runtime_off]
     p | beam.Create(['a']) | beam.Map(lambda x: 3).with_output_types(str)
     p.run()
@@ -300,7 +300,7 @@ class TypeHintsTest(unittest.TestCase):
 
   def test_runtime_checks_on(self):
     # pylint: disable=expression-not-assigned
-    p = beam.Pipeline('DirectPipelineRunner', argv=sys.argv)
+    p = beam.Pipeline('DirectRunner', argv=sys.argv)
     with self.assertRaises(typehints.TypeCheckError):
       # [START type_hints_runtime_on]
       p.options.view_as(TypeOptions).runtime_type_check = True
@@ -309,7 +309,7 @@ class TypeHintsTest(unittest.TestCase):
       # [END type_hints_runtime_on]
 
   def test_deterministic_key(self):
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     lines = (p | beam.Create(
         ['banana,fruit,3', 'kiwi,fruit,2', 'kiwi,fruit,2', 'zucchini,veg,3']))
 

--- a/sdks/python/apache_beam/examples/wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging.py
@@ -32,7 +32,7 @@ pipeline configuration::
   --staging_location gs://YOUR_STAGING_DIRECTORY
   --temp_location gs://YOUR_TEMP_DIRECTORY
   --job_name YOUR_JOB_NAME
-  --runner BlockingDataflowPipelineRunner
+  --runner BlockingDataflowRunner
 
 and an output prefix on GCS::
 

--- a/sdks/python/apache_beam/examples/wordcount_minimal.py
+++ b/sdks/python/apache_beam/examples/wordcount_minimal.py
@@ -71,9 +71,9 @@ def run(argv=None):
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
   pipeline_args.extend([
-      # CHANGE 2/5: (OPTIONAL) Change this to BlockingDataflowPipelineRunner to
+      # CHANGE 2/5: (OPTIONAL) Change this to BlockingDataflowRunner to
       # run your pipeline on the Google Cloud Dataflow Service.
-      '--runner=DirectPipelineRunner',
+      '--runner=DirectRunner',
       # CHANGE 3/5: Your project ID is required in order to run your pipeline on
       # the Google Cloud Dataflow Service.
       '--project=SET_YOUR_PROJECT_ID_HERE',

--- a/sdks/python/apache_beam/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/internal/apiclient_test.py
@@ -20,7 +20,7 @@ import re
 import unittest
 
 from apache_beam.utils.options import PipelineOptions
-from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
+from apache_beam.runners.dataflow_runner import DataflowRunner
 from apache_beam.internal import apiclient
 
 
@@ -31,7 +31,7 @@ class UtilTest(unittest.TestCase):
     pipeline_options = PipelineOptions()
     apiclient.DataflowApplicationClient(
         pipeline_options,
-        DataflowPipelineRunner.BATCH_ENVIRONMENT_MAJOR_VERSION)
+        DataflowRunner.BATCH_ENVIRONMENT_MAJOR_VERSION)
 
   def test_default_job_name(self):
     job_name = apiclient.Job.default_job_name(None)

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -325,16 +325,16 @@ class TestAvro(unittest.TestCase):
 
   def test_source_transform(self):
     path = self._write_data()
-    with beam.Pipeline('DirectPipelineRunner') as p:
+    with beam.Pipeline('DirectRunner') as p:
       assert_that(p | avroio.ReadFromAvro(path), equal_to(self.RECORDS))
 
   def test_sink_transform(self):
     with tempfile.NamedTemporaryFile() as dst:
       path = dst.name
-      with beam.Pipeline('DirectPipelineRunner') as p:
+      with beam.Pipeline('DirectRunner') as p:
         # pylint: disable=expression-not-assigned
         p | beam.Create(self.RECORDS) | avroio.WriteToAvro(path, self.SCHEMA)
-      with beam.Pipeline('DirectPipelineRunner') as p:
+      with beam.Pipeline('DirectRunner') as p:
         # json used for stable sortability
         readback = p | avroio.ReadFromAvro(path + '*') | beam.Map(json.dumps)
         assert_that(readback, equal_to([json.dumps(r) for r in self.RECORDS]))
@@ -344,13 +344,13 @@ class TestAvro(unittest.TestCase):
       import snappy  # pylint: disable=unused-variable
       with tempfile.NamedTemporaryFile() as dst:
         path = dst.name
-        with beam.Pipeline('DirectPipelineRunner') as p:
+        with beam.Pipeline('DirectRunner') as p:
           # pylint: disable=expression-not-assigned
           p | beam.Create(self.RECORDS) | avroio.WriteToAvro(
               path,
               self.SCHEMA,
               codec='snappy')
-        with beam.Pipeline('DirectPipelineRunner') as p:
+        with beam.Pipeline('DirectRunner') as p:
           # json used for stable sortability
           readback = p | avroio.ReadFromAvro(path + '*') | beam.Map(json.dumps)
           assert_that(readback, equal_to([json.dumps(r) for r in self.RECORDS]))

--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -212,7 +212,7 @@ class ConcatSourceTest(unittest.TestCase):
                            RangeSource(10, 100),
                            RangeSource(100, 1000),
                           ])
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.Read(source)
     assert_that(pcoll, equal_to(range(1000)))
 

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -364,7 +364,7 @@ class TestFileBasedSource(unittest.TestCase):
     self.assertItemsEqual(expected_data, read_data)
 
   def _run_dataflow_test(self, pattern, expected_data, splittable=True):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         pattern, splittable=splittable))
     assert_that(pcoll, equal_to(expected_data))
@@ -404,7 +404,7 @@ class TestFileBasedSource(unittest.TestCase):
     with bz2.BZ2File(filename, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         filename,
         splittable=False,
@@ -419,7 +419,7 @@ class TestFileBasedSource(unittest.TestCase):
     with gzip.GzipFile(filename, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         filename,
         splittable=False,
@@ -437,7 +437,7 @@ class TestFileBasedSource(unittest.TestCase):
       compressed_chunks.append(
           compressobj.compress('\n'.join(c)) + compressobj.flush())
     file_pattern = write_prepared_pattern(compressed_chunks)
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         file_pattern,
         splittable=False,
@@ -456,7 +456,7 @@ class TestFileBasedSource(unittest.TestCase):
         f.write('\n'.join(c))
       compressed_chunks.append(out.getvalue())
     file_pattern = write_prepared_pattern(compressed_chunks)
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         file_pattern,
         splittable=False,
@@ -471,7 +471,7 @@ class TestFileBasedSource(unittest.TestCase):
     with bz2.BZ2File(filename, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         filename,
         compression_type=fileio.CompressionTypes.AUTO))
@@ -485,7 +485,7 @@ class TestFileBasedSource(unittest.TestCase):
     with gzip.GzipFile(filename, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         filename,
         compression_type=fileio.CompressionTypes.AUTO))
@@ -504,7 +504,7 @@ class TestFileBasedSource(unittest.TestCase):
       compressed_chunks.append(out.getvalue())
     file_pattern = write_prepared_pattern(
         compressed_chunks, suffixes=['.gz']*len(chunks))
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         file_pattern,
         compression_type=fileio.CompressionTypes.AUTO))
@@ -526,7 +526,7 @@ class TestFileBasedSource(unittest.TestCase):
         chunks_to_write.append('\n'.join(c))
     file_pattern = write_prepared_pattern(chunks_to_write,
                                           suffixes=(['.gz', '']*3))
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> beam.Read(LineSource(
         file_pattern,
         compression_type=fileio.CompressionTypes.AUTO))

--- a/sdks/python/apache_beam/io/fileio_test.py
+++ b/sdks/python/apache_beam/io/fileio_test.py
@@ -760,7 +760,7 @@ class TestNativeTextFileSink(unittest.TestCase):
       self.assertEqual(f.read().splitlines(), [])
 
   def test_write_dataflow(self):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.core.Create('Create', self.lines)
     pcoll | 'Write' >> beam.Write(fileio.NativeTextFileSink(self.path))  # pylint: disable=expression-not-assigned
     pipeline.run()
@@ -773,7 +773,7 @@ class TestNativeTextFileSink(unittest.TestCase):
     self.assertEqual(read_result, self.lines)
 
   def test_write_dataflow_auto_compression(self):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.core.Create('Create', self.lines)
     pcoll | 'Write' >> beam.Write(  # pylint: disable=expression-not-assigned
         fileio.NativeTextFileSink(
@@ -788,7 +788,7 @@ class TestNativeTextFileSink(unittest.TestCase):
     self.assertEqual(read_result, self.lines)
 
   def test_write_dataflow_auto_compression_unsharded(self):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.core.Create('Create', self.lines)
     pcoll | 'Write' >> beam.Write(  # pylint: disable=expression-not-assigned
         fileio.NativeTextFileSink(
@@ -880,7 +880,7 @@ class TestFileSink(unittest.TestCase):
     temp_path = tempfile.NamedTemporaryFile().name
     sink = MyFileSink(
         temp_path, file_name_suffix='.foo', coder=coders.ToStringCoder())
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     p | beam.Create([]) | beam.io.Write(sink)  # pylint: disable=expression-not-assigned
     p.run()
     self.assertEqual(
@@ -894,7 +894,7 @@ class TestFileSink(unittest.TestCase):
         num_shards=3,
         shard_name_template='_NN_SSS_',
         coder=coders.ToStringCoder())
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     p | beam.Create(['a', 'b']) | beam.io.Write(sink)  # pylint: disable=expression-not-assigned
 
     p.run()

--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -98,7 +98,7 @@ class SourcesTest(unittest.TestCase):
 
   def test_run_direct(self):
     file_name = self._create_temp_file('aaaa\nbbbb\ncccc\ndddd')
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.Read(LineSource(file_name))
     assert_that(pcoll, equal_to(['aaaa', 'bbbb', 'cccc', 'dddd']))
 

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -264,7 +264,7 @@ class TextSourceTest(unittest.TestCase):
   def test_dataflow_single_file(self):
     file_name, expected_data = write_data(5)
     assert len(expected_data) == 5
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(file_name)
     assert_that(pcoll, equal_to(expected_data))
     pipeline.run()
@@ -279,7 +279,7 @@ class TextSourceTest(unittest.TestCase):
 
     file_name, expected_data = write_data(5)
     assert len(expected_data) == 5
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(file_name, coder=DummyCoder())
     assert_that(pcoll, equal_to([record * 2 for record in expected_data]))
     pipeline.run()
@@ -287,7 +287,7 @@ class TextSourceTest(unittest.TestCase):
   def test_dataflow_file_pattern(self):
     pattern, expected_data = write_pattern([5, 3, 12, 8, 8, 4])
     assert len(expected_data) == 40
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(pattern)
     assert_that(pcoll, equal_to(expected_data))
     pipeline.run()
@@ -299,7 +299,7 @@ class TextSourceTest(unittest.TestCase):
     with bz2.BZ2File(file_name, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(file_name)
     assert_that(pcoll, equal_to(lines))
     pipeline.run()
@@ -311,7 +311,7 @@ class TextSourceTest(unittest.TestCase):
     with gzip.GzipFile(file_name, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(file_name)
     assert_that(pcoll, equal_to(lines))
     pipeline.run()
@@ -323,7 +323,7 @@ class TextSourceTest(unittest.TestCase):
     with bz2.BZ2File(file_name, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(
         file_name,
         compression_type=CompressionTypes.BZIP2)
@@ -337,7 +337,7 @@ class TextSourceTest(unittest.TestCase):
     with gzip.GzipFile(file_name, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(
         file_name,
         0, CompressionTypes.GZIP,
@@ -352,7 +352,7 @@ class TextSourceTest(unittest.TestCase):
     with gzip.GzipFile(file_name, 'wb') as f:
       f.write('\n'.join(lines))
 
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(
         file_name,
         0, CompressionTypes.GZIP,
@@ -385,7 +385,7 @@ class TextSourceTest(unittest.TestCase):
   def test_read_gzip_empty_file(self):
     filename = tempfile.NamedTemporaryFile(
         delete=False, prefix=tempfile.template).name
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | 'Read' >> ReadFromText(
         filename,
         0, CompressionTypes.GZIP,
@@ -481,7 +481,7 @@ class TextSinkTest(unittest.TestCase):
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_write_dataflow(self):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.core.Create('Create', self.lines)
     pcoll | 'Write' >> WriteToText(self.path)  # pylint: disable=expression-not-assigned
     pipeline.run()
@@ -494,7 +494,7 @@ class TextSinkTest(unittest.TestCase):
     self.assertEqual(read_result, self.lines)
 
   def test_write_dataflow_auto_compression(self):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.core.Create('Create', self.lines)
     pcoll | 'Write' >> WriteToText(self.path, file_name_suffix='.gz')  # pylint: disable=expression-not-assigned
     pipeline.run()
@@ -507,7 +507,7 @@ class TextSinkTest(unittest.TestCase):
     self.assertEqual(read_result, self.lines)
 
   def test_write_dataflow_auto_compression_unsharded(self):
-    pipeline = beam.Pipeline('DirectPipelineRunner')
+    pipeline = beam.Pipeline('DirectRunner')
     pcoll = pipeline | beam.core.Create('Create', self.lines)
     pcoll | 'Write' >> WriteToText(self.path + '.gz', shard_name_template='')  # pylint: disable=expression-not-assigned
     pipeline.run()

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -28,7 +28,7 @@ to be executed for each node visited is specified through a runner object.
 Typical usage:
 
   # Create a pipeline object using a local runner for execution.
-  pipeline = Pipeline(runner=DirectPipelineRunner())
+  pipeline = Pipeline(runner=DirectRunner())
 
   # Add to the pipeline a "Create" transform. When executed this
   # transform will produce a PCollection object with the specified values.

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -61,7 +61,7 @@ class FakeSource(NativeSource):
 class PipelineTest(unittest.TestCase):
 
   def setUp(self):
-    self.runner_name = 'DirectPipelineRunner'
+    self.runner_name = 'DirectRunner'
 
   @staticmethod
   def custom_callable(pcoll):
@@ -202,7 +202,7 @@ class PipelineTest(unittest.TestCase):
     num_elements = 10
     num_maps = 100
 
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
 
     # Consumed memory should not be proportional to the number of maps.
     memory_threshold = (
@@ -231,7 +231,7 @@ class PipelineTest(unittest.TestCase):
         p | Create([ValueError]) | Map(raise_exception)
 
   def test_eager_pipeline(self):
-    p = Pipeline('EagerPipelineRunner')
+    p = Pipeline('EagerRunner')
     self.assertEqual([1, 4, 9], p | Create([1, 2, 3]) | Map(lambda x: x*x))
 
 

--- a/sdks/python/apache_beam/pvalue_test.py
+++ b/sdks/python/apache_beam/pvalue_test.py
@@ -39,12 +39,12 @@ class FakePipeline(Pipeline):
 class PValueTest(unittest.TestCase):
 
   def test_pvalue_expected_arguments(self):
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
     value = PValue(pipeline)
     self.assertEqual(pipeline, value.pipeline)
 
   def test_pcollectionview_not_recreated(self):
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
     value = pipeline | 'create1' >> Create([1, 2, 3])
     value2 = pipeline | 'create2' >> Create([(1, 1), (2, 2), (3, 3)])
     value3 = pipeline | 'create3' >> Create([(1, 1), (2, 2), (3, 3)])

--- a/sdks/python/apache_beam/runners/__init__.py
+++ b/sdks/python/apache_beam/runners/__init__.py
@@ -20,9 +20,9 @@
 This package defines runners, which are used to execute a pipeline.
 """
 
-from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
-from apache_beam.runners.direct.direct_runner import DirectPipelineRunner
-from apache_beam.runners.direct.direct_runner import EagerPipelineRunner
+from apache_beam.runners.dataflow_runner import DataflowRunner
+from apache_beam.runners.direct.direct_runner import DirectRunner
+from apache_beam.runners.direct.direct_runner import EagerRunner
 from apache_beam.runners.runner import create_runner
 from apache_beam.runners.runner import PipelineRunner
 from apache_beam.runners.runner import PipelineState

--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -45,11 +45,11 @@ from apache_beam.utils.options import StandardOptions
 from apache_beam.internal.clients import dataflow as dataflow_api
 
 
-def BlockingDataflowPipelineRunner(*args, **kwargs):
-  return DataflowPipelineRunner(*args, blocking=True, **kwargs)
+def BlockingDataflowRunner(*args, **kwargs):
+  return DataflowRunner(*args, blocking=True, **kwargs)
 
 
-class DataflowPipelineRunner(PipelineRunner):
+class DataflowRunner(PipelineRunner):
   """A runner that creates job graphs and submits them for remote execution.
 
   Every execution of the run() method will submit an independent job for
@@ -162,13 +162,13 @@ class DataflowPipelineRunner(PipelineRunner):
     self.job = apiclient.Job(pipeline.options)
 
     # The superclass's run will trigger a traversal of all reachable nodes.
-    super(DataflowPipelineRunner, self).run(pipeline)
+    super(DataflowRunner, self).run(pipeline)
 
     standard_options = pipeline.options.view_as(StandardOptions)
     if standard_options.streaming:
-      job_version = DataflowPipelineRunner.STREAMING_ENVIRONMENT_MAJOR_VERSION
+      job_version = DataflowRunner.STREAMING_ENVIRONMENT_MAJOR_VERSION
     else:
-      job_version = DataflowPipelineRunner.BATCH_ENVIRONMENT_MAJOR_VERSION
+      job_version = DataflowRunner.BATCH_ENVIRONMENT_MAJOR_VERSION
 
     # Get a Dataflow API client and set its options
     self.dataflow_client = apiclient.DataflowApplicationClient(
@@ -180,7 +180,7 @@ class DataflowPipelineRunner(PipelineRunner):
 
     if self.result.has_job and self.blocking:
       thread = threading.Thread(
-          target=DataflowPipelineRunner.poll_for_job_completion,
+          target=DataflowRunner.poll_for_job_completion,
           args=(self, self.result.job_id()))
       # Mark the thread as a daemon thread so a keyboard interrupt on the main
       # thread will terminate everything. This is also the reason we will not

--- a/sdks/python/apache_beam/runners/direct/__init__.py
+++ b/sdks/python/apache_beam/runners/direct/__init__.py
@@ -16,4 +16,4 @@
 #
 
 """Inprocess runner executes pipelines locally in a single process."""
-from apache_beam.runners.direct.direct_runner import DirectPipelineRunner
+from apache_beam.runners.direct.direct_runner import DirectRunner

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -25,7 +25,7 @@ from apache_beam.io import Read
 from apache_beam.io import TextFileSource
 from apache_beam.pipeline import Pipeline
 from apache_beam.pvalue import AsList
-from apache_beam.runners.direct import DirectPipelineRunner
+from apache_beam.runners.direct import DirectRunner
 from apache_beam.runners.direct.consumer_tracking_pipeline_visitor import ConsumerTrackingPipelineVisitor
 from apache_beam.transforms import CoGroupByKey
 from apache_beam.transforms import Create
@@ -42,7 +42,7 @@ from apache_beam.transforms import ParDo
 class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
 
   def setUp(self):
-    self.pipeline = Pipeline(DirectPipelineRunner())
+    self.pipeline = Pipeline(DirectRunner())
     self.visitor = ConsumerTrackingPipelineVisitor()
 
   def test_root_transforms(self):

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-"""DirectPipelineRunner, executing on the local machine.
+"""DirectRunner, executing on the local machine.
 
-The DirectPipelineRunner is a runner implementation that executes the entire
+The DirectRunner is a runner implementation that executes the entire
 graph of transformations belonging to a pipeline on the local machine.
 """
 
@@ -33,7 +33,7 @@ from apache_beam.runners.runner import PipelineState
 from apache_beam.runners.runner import PValueCache
 
 
-class DirectPipelineRunner(PipelineRunner):
+class DirectRunner(PipelineRunner):
   """Executes a single pipeline on the local machine."""
 
   def __init__(self):
@@ -52,7 +52,7 @@ class DirectPipelineRunner(PipelineRunner):
     from apache_beam.runners.direct.transform_evaluator import \
       TransformEvaluatorRegistry
 
-    logging.info('Running pipeline with DirectPipelineRunner.')
+    logging.info('Running pipeline with DirectRunner.')
     self.visitor = ConsumerTrackingPipelineVisitor()
     pipeline.visit(self.visitor)
 
@@ -153,6 +153,6 @@ class DirectPipelineResult(PipelineResult):
     return self._evaluation_context.get_aggregator_values(aggregator_or_name)
 
 
-class EagerPipelineRunner(DirectPipelineRunner):
+class EagerRunner(DirectRunner):
 
   is_eager = True

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -108,11 +108,11 @@ class EvaluationContext(object):
   """Evaluation context with the global state information of the pipeline.
 
   The evaluation context for a specific pipeline being executed by the
-  DirectPipelineRunner. Contains state shared within the execution across all
+  DirectRunner. Contains state shared within the execution across all
   transforms.
 
   EvaluationContext contains shared state for an execution of the
-  DirectPipelineRunner that can be used while evaluating a PTransform. This
+  DirectRunner that can be used while evaluating a PTransform. This
   consists of views into underlying state and watermark implementations, access
   to read and write PCollectionViews, and constructing counter sets and
   execution contexts. This includes executing callbacks asynchronously when

--- a/sdks/python/apache_beam/runners/runner.py
+++ b/sdks/python/apache_beam/runners/runner.py
@@ -30,7 +30,7 @@ _KNOWN_DIRECT_RUNNERS = ('DirectRunner', 'EagerRunner')
 _KNOWN_DATAFLOW_RUNNERS = ('DataflowRunner', 'BlockingDataflowRunner')
 _KNOWN_TEST_RUNNERS = ('TestDataflowRunner',)
 _ALL_KNOWN_RUNNERS = (
-  _KNOWN_DIRECT_RUNNERS + _KNOWN_DATAFLOW_RUNNERS + _KNOWN_TEST_RUNNERS)
+    _KNOWN_DIRECT_RUNNERS + _KNOWN_DATAFLOW_RUNNERS + _KNOWN_TEST_RUNNERS)
 
 
 def create_runner(runner_name):
@@ -54,6 +54,11 @@ def create_runner(runner_name):
       logging.warning(
           '%s is deprecated, use %s instead.', runner_name, new_runner_name)
       runner_name = new_runner_name
+
+  # TODO(BEAM-759): Remove when all BlockingDataflowRunner references are gone.
+  if runner_name == 'BlockingDataflowRunner':
+    logging.warning(
+        'BlockingDataflowRunner is deprecated, use DataflowRunner instead.')
 
   if runner_name in _KNOWN_DIRECT_RUNNERS:
     runner_name = 'apache_beam.runners.direct.direct_runner.' + runner_name

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-"""Unit tests for the PipelineRunner and DirectPipelineRunner classes.
+"""Unit tests for the PipelineRunner and DirectRunner classes.
 
-Note that PipelineRunner and DirectPipelineRunner functionality is tested in all
+Note that PipelineRunner and DirectRunner functionality is tested in all
 the other unit tests. In this file we choose to test only aspects related to
 caching and clearing values that are not tested elsewhere.
 """
@@ -31,8 +31,8 @@ import apache_beam as beam
 from apache_beam.internal import apiclient
 from apache_beam.pipeline import Pipeline
 from apache_beam.runners import create_runner
-from apache_beam.runners import DataflowPipelineRunner
-from apache_beam.runners import DirectPipelineRunner
+from apache_beam.runners import DataflowRunner
+from apache_beam.runners import DirectRunner
 from apache_beam.runners import TestDataflowRunner
 import apache_beam.transforms as ptransform
 from apache_beam.transforms.display import DisplayDataItem
@@ -50,20 +50,29 @@ class RunnerTest(unittest.TestCase):
 
   def test_create_runner(self):
     self.assertTrue(
-        isinstance(create_runner('DirectPipelineRunner'), DirectPipelineRunner))
+        isinstance(create_runner('DirectRunner'), DirectRunner))
     self.assertTrue(
-        isinstance(create_runner('DataflowPipelineRunner'),
-                   DataflowPipelineRunner))
+        isinstance(create_runner('DataflowRunner'),
+                   DataflowRunner))
     self.assertTrue(
-        isinstance(create_runner('BlockingDataflowPipelineRunner'),
-                   DataflowPipelineRunner))
+        isinstance(create_runner('BlockingDataflowRunner'),
+                   DataflowRunner))
     self.assertTrue(
         isinstance(create_runner('TestDataflowRunner'),
                    TestDataflowRunner))
     self.assertRaises(ValueError, create_runner, 'xyz')
+    # TODO(BEAM-1185): Remove when all references to PipelineRunners are gone.
+    self.assertTrue(
+        isinstance(create_runner('DirectPipelineRunner'), DirectRunner))
+    self.assertTrue(
+        isinstance(create_runner('DataflowPipelineRunner'),
+                   DataflowRunner))
+    self.assertTrue(
+        isinstance(create_runner('BlockingDataflowPipelineRunner'),
+                   DataflowRunner))
 
   def test_remote_runner_translation(self):
-    remote_runner = DataflowPipelineRunner()
+    remote_runner = DataflowRunner()
     p = Pipeline(remote_runner,
                  options=PipelineOptions(self.default_properties))
 
@@ -71,10 +80,10 @@ class RunnerTest(unittest.TestCase):
      | 'do' >> ptransform.FlatMap(lambda x: [(x, x)])
      | 'gbk' >> ptransform.GroupByKey())
     remote_runner.job = apiclient.Job(p.options)
-    super(DataflowPipelineRunner, remote_runner).run(p)
+    super(DataflowRunner, remote_runner).run(p)
 
   def test_remote_runner_display_data(self):
-    remote_runner = DataflowPipelineRunner()
+    remote_runner = DataflowRunner()
     p = Pipeline(remote_runner,
                  options=PipelineOptions(self.default_properties))
 
@@ -105,7 +114,7 @@ class RunnerTest(unittest.TestCase):
      | 'do' >> SpecialParDo(SpecialDoFn(), now))
 
     remote_runner.job = apiclient.Job(p.options)
-    super(DataflowPipelineRunner, remote_runner).run(p)
+    super(DataflowRunner, remote_runner).run(p)
     job_dict = json.loads(str(remote_runner.job))
     steps = [step
              for step in job_dict['steps']
@@ -127,7 +136,7 @@ class RunnerTest(unittest.TestCase):
     self.assertEqual(disp_data, expected_data)
 
   def test_no_group_by_key_directly_after_bigquery(self):
-    remote_runner = DataflowPipelineRunner()
+    remote_runner = DataflowRunner()
     p = Pipeline(remote_runner,
                  options=PipelineOptions([
                      '--dataflow_endpoint=ignored',

--- a/sdks/python/apache_beam/runners/template_runner_test.py
+++ b/sdks/python/apache_beam/runners/template_runner_test.py
@@ -25,12 +25,12 @@ import tempfile
 
 import apache_beam as beam
 from apache_beam.pipeline import Pipeline
-from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
+from apache_beam.runners.dataflow_runner import DataflowRunner
 from apache_beam.utils.options import PipelineOptions
 from apache_beam.internal import apiclient
 
 
-class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
+class TemplatingDataflowRunnerTest(unittest.TestCase):
   """TemplatingDataflow tests."""
   def test_full_completion(self):
     # Create dummy file and close it.  Note that we need to do this because
@@ -42,7 +42,7 @@ class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
 
     dummy_dir = tempfile.mkdtemp()
 
-    remote_runner = DataflowPipelineRunner()
+    remote_runner = DataflowRunner()
     pipeline = Pipeline(remote_runner,
                         options=PipelineOptions([
                             '--dataflow_endpoint=ignored',
@@ -67,7 +67,7 @@ class TemplatingDataflowPipelineRunnerTest(unittest.TestCase):
 
   def test_bad_path(self):
     dummy_sdk_file = tempfile.NamedTemporaryFile()
-    remote_runner = DataflowPipelineRunner()
+    remote_runner = DataflowRunner()
     pipeline = Pipeline(remote_runner,
                         options=PipelineOptions([
                             '--dataflow_endpoint=ignored',

--- a/sdks/python/apache_beam/runners/test/test_dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/test/test_dataflow_runner.py
@@ -18,11 +18,11 @@
 """Wrapper of Beam runners that's built for running and verifying e2e tests."""
 
 from apache_beam.internal import pickler
-from apache_beam.runners.dataflow_runner import DataflowPipelineRunner
+from apache_beam.runners.dataflow_runner import DataflowRunner
 from apache_beam.utils.options import TestOptions
 
 
-class TestDataflowRunner(DataflowPipelineRunner):
+class TestDataflowRunner(DataflowRunner):
 
   def __init__(self):
     super(TestDataflowRunner, self).__init__(blocking=True)

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -41,7 +41,7 @@ class TestPipeline(Pipeline):
   For example, use following command line to execute all ValidatesRunner tests::
 
     python setup.py nosetests -a ValidatesRunner \
-        --test-pipeline-options="--runner=DirectPipelineRunner \
+        --test-pipeline-options="--runner=DirectRunner \
                                  --job_name=myJobName \
                                  --num_workers=1"
 

--- a/sdks/python/apache_beam/transforms/aggregator_test.py
+++ b/sdks/python/apache_beam/transforms/aggregator_test.py
@@ -63,7 +63,7 @@ class AggregatorTest(unittest.TestCase):
         for a in aggregators:
           context.aggregate_to(a, context.element)
 
-    p = beam.Pipeline('DirectPipelineRunner')
+    p = beam.Pipeline('DirectRunner')
     p | beam.Create([0, 1, 2, 3]) | beam.ParDo(UpdateAggregators())  # pylint: disable=expression-not-assigned
     res = p.run()
     for (_, _, expected), a in zip(counter_types, aggregators):

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -40,7 +40,7 @@ class CombineTest(unittest.TestCase):
     combine.TopCombineFn._MIN_BUFFER_OVERSIZE = 1
 
   def test_builtin_combines(self):
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
 
     vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
     mean = sum(vals) / float(len(vals))
@@ -62,7 +62,7 @@ class CombineTest(unittest.TestCase):
     pipeline.run()
 
   def test_top(self):
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
 
     # A parameter we'll be sharing with a custom comparator.
     names = {0: 'zo',
@@ -201,7 +201,7 @@ class CombineTest(unittest.TestCase):
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_top_shorthands(self):
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
 
     pcoll = pipeline | 'start' >> Create([6, 3, 1, 1, 9, 1, 5, 2, 0, 6])
     result_top = pcoll | 'top' >> beam.CombineGlobally(combine.Largest(5))
@@ -222,7 +222,7 @@ class CombineTest(unittest.TestCase):
 
     # First test global samples (lots of them).
     for ix in xrange(300):
-      pipeline = Pipeline('DirectPipelineRunner')
+      pipeline = Pipeline('DirectRunner')
       pcoll = pipeline | 'start' >> Create([1, 1, 2, 2])
       result = pcoll | combine.Sample.FixedSizeGlobally('sample-%d' % ix, 3)
 
@@ -241,7 +241,7 @@ class CombineTest(unittest.TestCase):
       pipeline.run()
 
     # Now test per-key samples.
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
     pcoll = pipeline | 'start-perkey' >> Create(
         sum(([(i, 1), (i, 1), (i, 2), (i, 2)] for i in xrange(300)), []))
     result = pcoll | 'sample' >> combine.Sample.FixedSizePerKey(3)
@@ -258,7 +258,7 @@ class CombineTest(unittest.TestCase):
     pipeline.run()
 
   def test_tuple_combine_fn(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result = (
         p
         | Create([('a', 100, 0.0), ('b', 10, -1), ('c', 1, 100)])
@@ -269,7 +269,7 @@ class CombineTest(unittest.TestCase):
     p.run()
 
   def test_tuple_combine_fn_without_defaults(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result = (
         p
         | Create([1, 1, 2, 3])
@@ -280,7 +280,7 @@ class CombineTest(unittest.TestCase):
     p.run()
 
   def test_to_list_and_to_dict(self):
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
     the_list = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
     pcoll = pipeline | 'start' >> Create(the_list)
     result = pcoll | 'to list' >> combine.ToList()
@@ -292,7 +292,7 @@ class CombineTest(unittest.TestCase):
     assert_that(result, matcher([the_list]))
     pipeline.run()
 
-    pipeline = Pipeline('DirectPipelineRunner')
+    pipeline = Pipeline('DirectRunner')
     pairs = [(1, 2), (3, 4), (5, 6)]
     pcoll = pipeline | 'start-pairs' >> Create(pairs)
     result = pcoll | 'to dict' >> combine.ToDict()
@@ -306,12 +306,12 @@ class CombineTest(unittest.TestCase):
     pipeline.run()
 
   def test_combine_globally_with_default(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     assert_that(p | Create([]) | CombineGlobally(sum), equal_to([0]))
     p.run()
 
   def test_combine_globally_without_default(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result = p | Create([]) | CombineGlobally(sum).without_defaults()
     assert_that(result, equal_to([]))
     p.run()
@@ -323,7 +323,7 @@ class CombineTest(unittest.TestCase):
         main = pcoll.pipeline | Create([None])
         return main | Map(lambda _, s: s, side)
 
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result1 = p | 'i1' >> Create([]) | 'c1' >> CombineWithSideInput()
     result2 = p | 'i2' >> Create([1, 2, 3, 4]) | 'c2' >> CombineWithSideInput()
     assert_that(result1, equal_to([0]), label='r1')

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -413,7 +413,7 @@ class PTransform(WithTypeHints, HasDisplayData):
       from apache_beam.utils.options import PipelineOptions
       # pylint: enable=wrong-import-order, wrong-import-position
       p = pipeline.Pipeline(
-          'DirectPipelineRunner', PipelineOptions(sys.argv))
+          'DirectRunner', PipelineOptions(sys.argv))
     else:
       if not pipelines:
         if self.pipeline is not None:

--- a/sdks/python/apache_beam/transforms/sideinputs_test.py
+++ b/sdks/python/apache_beam/transforms/sideinputs_test.py
@@ -28,7 +28,7 @@ from apache_beam.transforms.util import assert_that, equal_to
 class SideInputsTest(unittest.TestCase):
 
   def create_pipeline(self):
-    return beam.Pipeline('DirectPipelineRunner')
+    return beam.Pipeline('DirectRunner')
 
   def run_windowed_side_inputs(self, elements, main_window_fn,
                                side_window_fn=None,

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -379,10 +379,11 @@ class TriggerTest(unittest.TestCase):
       self.assertEqual(pickle.loads(pickle.dumps(unwindowed)).value,
                        range(10))
 
+
 class TriggerPipelineTest(unittest.TestCase):
 
   def test_after_count(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result = (p
               | beam.Create([1, 2, 3, 4, 5, 10, 11])
               | beam.FlatMap(lambda t: [('A', t), ('B', t + 5)])
@@ -492,13 +493,12 @@ class TranscriptTest(unittest.TestCase):
 
     # pylint: disable=wrong-import-order, wrong-import-position
     from apache_beam.transforms import window as window_module
-    from apache_beam.transforms import trigger as trigger_module
     # pylint: enable=wrong-import-order, wrong-import-position
     window_fn_names = dict(window_module.__dict__)
     window_fn_names.update({'CustomTimestampingFixedWindowsWindowFn':
                             CustomTimestampingFixedWindowsWindowFn})
     trigger_names = {'Default': DefaultTrigger}
-    trigger_names.update(trigger_module.__dict__)
+    trigger_names.update(trigger.__dict__)
 
     window_fn = parse_fn(spec.get('window_fn', 'GlobalWindows'),
                          window_fn_names)

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -131,7 +131,7 @@ class WindowTest(unittest.TestCase):
             | Map(lambda x: WindowedValue((key, x), x, [])))
 
   def test_sliding_windows(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     pcoll = self.timestamped_key_values(p, 'key', 1, 2, 3)
     result = (pcoll
               | 'w' >> WindowInto(SlidingWindows(period=2, size=4))
@@ -144,7 +144,7 @@ class WindowTest(unittest.TestCase):
     p.run()
 
   def test_sessions(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     pcoll = self.timestamped_key_values(p, 'key', 1, 2, 3, 20, 35, 27)
     result = (pcoll
               | 'w' >> WindowInto(Sessions(10))
@@ -157,7 +157,7 @@ class WindowTest(unittest.TestCase):
     p.run()
 
   def test_timestamped_value(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result = (p
               | 'start' >> Create([(k, k) for k in range(10)])
               | Map(lambda (x, t): TimestampedValue(x, t))
@@ -169,7 +169,7 @@ class WindowTest(unittest.TestCase):
     p.run()
 
   def test_timestamped_with_combiners(self):
-    p = Pipeline('DirectPipelineRunner')
+    p = Pipeline('DirectRunner')
     result = (p
               # Create some initial test values.
               | 'start' >> Create([(k, k) for k in range(10)])

--- a/sdks/python/apache_beam/utils/options.py
+++ b/sdks/python/apache_beam/utils/options.py
@@ -178,15 +178,15 @@ class PipelineOptions(HasDisplayData):
 
 class StandardOptions(PipelineOptions):
 
-  DEFAULT_RUNNER = 'DirectPipelineRunner'
+  DEFAULT_RUNNER = 'DirectRunner'
 
   @classmethod
   def _add_argparse_args(cls, parser):
     parser.add_argument(
         '--runner',
         help=('Pipeline runner used to execute the workflow. Valid values are '
-              'DirectPipelineRunner, DataflowPipelineRunner, '
-              'and BlockingDataflowPipelineRunner.'))
+              'DirectRunner, DataflowRunner, '
+              'and BlockingDataflowRunner.'))
     # Whether to enable streaming mode.
     parser.add_argument('--streaming',
                         default=False,
@@ -218,7 +218,7 @@ class TypeOptions(PipelineOptions):
                         action='store_true',
                         help='Enable type checking at pipeline execution '
                         'time. NOTE: only supported with the '
-                        'DirectPipelineRunner')
+                        'DirectRunner')
 
 
 class GoogleCloudOptions(PipelineOptions):

--- a/sdks/python/apache_beam/utils/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator.py
@@ -105,8 +105,8 @@ class PipelineOptionsValidator(object):
     """True if pipeline will execute on the Google Cloud Dataflow service."""
     is_service_runner = (self.runner is not None and
                          type(self.runner).__name__ in [
-                             'DataflowPipelineRunner',
-                             'BlockingDataflowPipelineRunner',
+                             'DataflowRunner',
+                             'BlockingDataflowRunner',
                              'TestDataflowRunner'])
 
     dataflow_endpoint = (

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -29,7 +29,7 @@ from hamcrest.core.base_matcher import BaseMatcher
 # Mock runners to use for validations.
 class MockRunners(object):
 
-  class DataflowPipelineRunner(object):
+  class DataflowRunner(object):
     pass
 
   class TestDataflowRunner(object):
@@ -75,7 +75,7 @@ class SetupTest(unittest.TestCase):
 
   def test_missing_required_options(self):
     options = PipelineOptions([''])
-    runner = MockRunners.DataflowPipelineRunner()
+    runner = MockRunners.DataflowRunner()
     validator = PipelineOptionsValidator(options, runner)
     errors = validator.validate()
 
@@ -96,7 +96,7 @@ class SetupTest(unittest.TestCase):
         options.append('--staging_location=' + staging_location)
 
       pipeline_options = PipelineOptions(options)
-      runner = MockRunners.DataflowPipelineRunner()
+      runner = MockRunners.DataflowRunner()
       validator = PipelineOptionsValidator(pipeline_options, runner)
       return validator
 
@@ -151,7 +151,7 @@ class SetupTest(unittest.TestCase):
         options.append('--project=' + project)
 
       pipeline_options = PipelineOptions(options)
-      runner = MockRunners.DataflowPipelineRunner()
+      runner = MockRunners.DataflowRunner()
       validator = PipelineOptionsValidator(pipeline_options, runner)
       return validator
 
@@ -179,7 +179,7 @@ class SetupTest(unittest.TestCase):
         options.append('--job_name=' + job_name)
 
       pipeline_options = PipelineOptions(options)
-      runner = MockRunners.DataflowPipelineRunner()
+      runner = MockRunners.DataflowRunner()
       validator = PipelineOptionsValidator(pipeline_options, runner)
       return validator
 
@@ -207,7 +207,7 @@ class SetupTest(unittest.TestCase):
         options.append('--num_workers=' + num_workers)
 
       pipeline_options = PipelineOptions(options)
-      runner = MockRunners.DataflowPipelineRunner()
+      runner = MockRunners.DataflowRunner()
       validator = PipelineOptionsValidator(pipeline_options, runner)
       return validator
 
@@ -241,27 +241,27 @@ class SetupTest(unittest.TestCase):
             'expected': False,
         },
         {
-            'runner': MockRunners.DataflowPipelineRunner(),
+            'runner': MockRunners.DataflowRunner(),
             'options': ['--dataflow_endpoint=https://another.service.com'],
             'expected': False,
         },
         {
-            'runner': MockRunners.DataflowPipelineRunner(),
+            'runner': MockRunners.DataflowRunner(),
             'options': ['--dataflow_endpoint=https://another.service.com/'],
             'expected': False,
         },
         {
-            'runner': MockRunners.DataflowPipelineRunner(),
+            'runner': MockRunners.DataflowRunner(),
             'options': ['--dataflow_endpoint=https://dataflow.googleapis.com'],
             'expected': True,
         },
         {
-            'runner': MockRunners.DataflowPipelineRunner(),
+            'runner': MockRunners.DataflowRunner(),
             'options': ['--dataflow_endpoint=https://dataflow.googleapis.com/'],
             'expected': True,
         },
         {
-            'runner': MockRunners.DataflowPipelineRunner(),
+            'runner': MockRunners.DataflowRunner(),
             'options': [],
             'expected': True,
         },

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -73,7 +73,7 @@ SDK_LOCATION=$(find dist/apache-beam-sdk-*.tar.gz)
 # Run ValidatesRunner tests on Google Cloud Dataflow service
 python setup.py nosetests \
   -a ValidatesRunner --test-pipeline-options=" \
-    --runner=BlockingDataflowPipelineRunner \
+    --runner=BlockingDataflowRunner \
     --project=$PROJECT \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
     --temp_location=$GCS_LOCATION/temp-validatesrunner-test \
@@ -86,7 +86,7 @@ python -m apache_beam.examples.wordcount \
   --output $GCS_LOCATION/py-wordcount-cloud \
   --staging_location $GCS_LOCATION/staging-wordcount \
   --temp_location $GCS_LOCATION/temp-wordcount \
-  --runner BlockingDataflowPipelineRunner \
+  --runner BlockingDataflowRunner \
   --job_name $JOBNAME_E2E \
   --project $PROJECT \
   --sdk_location $SDK_LOCATION \


### PR DESCRIPTION
The change is mostly mechanical, except for the runner.py (and its
test). Temporarily added a way for not breaking existing users of this
runners. After a grace period after the new year, I will remove that
piece of code.
