### PR TITLE
[BEAM-1090] Skip the test_memory_usage test on macos. 

### DIFF
--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -18,6 +18,7 @@
 """Unit tests for the Pipeline class."""
 
 import logging
+import platform
 import unittest
 
 from apache_beam.pipeline import Pipeline
@@ -187,6 +188,10 @@ class PipelineTest(unittest.TestCase):
     except ImportError:
       # Skip the test if resource module is not available (e.g. non-Unix os).
       self.skipTest('resource module not available.')
+    if platform.mac_ver()[0]:
+      # Skip the test on macos, depending on version it returns ru_maxrss in
+      # different units.
+      self.skipTest('ru_maxrss is not in standard units.')
 
     def get_memory_usage_in_bytes():
       return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * (2 ** 10)


### PR DESCRIPTION
The underlying implementation for getting the used memory does
not use standard units and varies across macos versions (bytes vs kbytes),
causing Travis errors. Linux version is stable and use the documented 
units (kbytes).

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
